### PR TITLE
feat: AgentLoopBackend — multi-turn agent loop with file/bash tools (#61)

### DIFF
--- a/conductor/backends/__init__.py
+++ b/conductor/backends/__init__.py
@@ -1,5 +1,8 @@
 """LLM backend abstraction layer and adapter implementations."""
 
+from contextlib import suppress
+from importlib import import_module
+
 from conductor.backends.base import (
     BackendCapabilities,
     BackendError,
@@ -26,7 +29,5 @@ __all__ = [
 ]
 
 # Ensure agent-loop backend is registered when this package is imported.
-try:
-    import conductor.backends.agent_loop as _agent_loop_mod  # noqa: F401
-except ImportError:
-    pass
+with suppress(ImportError):
+    import_module("conductor.backends.agent_loop")

--- a/conductor/backends/__init__.py
+++ b/conductor/backends/__init__.py
@@ -24,3 +24,9 @@ __all__ = [
     "TokenUsage",
     "registry",
 ]
+
+# Ensure agent-loop backend is registered when this package is imported.
+try:
+    import conductor.backends.agent_loop as _agent_loop_mod  # noqa: F401
+except ImportError:
+    pass

--- a/conductor/backends/agent_loop.py
+++ b/conductor/backends/agent_loop.py
@@ -16,6 +16,7 @@ import glob as _glob
 import os
 import subprocess
 from collections.abc import AsyncIterator
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -230,9 +231,7 @@ class AgentLoopBackend(ILLMBackend):
     # Tool execution
     # ------------------------------------------------------------------
 
-    def _execute_tool(
-        self, name: str, inputs: dict[str, Any], workspace_dir: str
-    ) -> str:
+    def _execute_tool(self, name: str, inputs: dict[str, Any], workspace_dir: str) -> str:
         """Dispatch a single tool call and return the string result.
 
         All exceptions are caught and returned as error strings so the loop
@@ -243,9 +242,7 @@ class AgentLoopBackend(ILLMBackend):
         except Exception as exc:
             return f"ERROR: {exc}"
 
-    def _dispatch_tool(
-        self, name: str, inputs: dict[str, Any], workspace_dir: str
-    ) -> str:
+    def _dispatch_tool(self, name: str, inputs: dict[str, Any], workspace_dir: str) -> str:
         if name == "read_file":
             path = self._safe_path(workspace_dir, inputs["path"])
             return path.read_text(errors="replace")
@@ -276,7 +273,7 @@ class AgentLoopBackend(ILLMBackend):
             timeout: int = int(inputs.get("timeout") or 30)
             result = subprocess.run(
                 command,
-                shell=True,
+                shell=True,  # nosec B602
                 cwd=workspace_dir,
                 capture_output=True,
                 text=True,
@@ -341,7 +338,7 @@ class AgentLoopBackend(ILLMBackend):
     ) -> None:
         if self._ledger is None:
             return
-        try:
+        with suppress(Exception):
             from conductor.core.ledger import CostRecord
 
             price_in, price_out = _MODEL_PRICING.get(model, (3.0, 15.0))
@@ -365,8 +362,6 @@ class AgentLoopBackend(ILLMBackend):
                 agent_id=agent_id,
             )
             self._ledger.record(rec)
-        except Exception:
-            pass  # Cost recording must never crash the agent loop
 
     # ------------------------------------------------------------------
     # ILLMBackend interface
@@ -464,9 +459,7 @@ class AgentLoopBackend(ILLMBackend):
             # If tool_use, execute tools and continue loop.
             if response.stop_reason == "tool_use":
                 # Append the assistant turn with all content blocks.
-                sdk_messages.append(
-                    {"role": "assistant", "content": response.content}
-                )
+                sdk_messages.append({"role": "assistant", "content": response.content})
 
                 # Build tool results.
                 tool_results: list[dict[str, Any]] = []
@@ -497,9 +490,7 @@ class AgentLoopBackend(ILLMBackend):
                 raw={"turns": turn + 1},
             )
 
-        raise RuntimeError(
-            f"Agent loop exceeded max_turns={effective_max_turns} without end_turn"
-        )
+        raise RuntimeError(f"Agent loop exceeded max_turns={effective_max_turns} without end_turn")
 
     async def stream(
         self,

--- a/conductor/backends/agent_loop.py
+++ b/conductor/backends/agent_loop.py
@@ -240,7 +240,7 @@ class AgentLoopBackend(ILLMBackend):
         """
         try:
             return self._dispatch_tool(name, inputs, workspace_dir)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return f"ERROR: {exc}"
 
     def _dispatch_tool(
@@ -296,17 +296,22 @@ class AgentLoopBackend(ILLMBackend):
         if name == "grep_files":
             pattern = inputs["pattern"]
             search_path = inputs.get("path") or "."
-            try:
-                safe_search = self._safe_path(workspace_dir, search_path)
-            except ValueError:
-                raise
-            result = subprocess.run(
-                ["grep", "-r", "-n", pattern, str(safe_search)],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            return result.stdout or "(no matches)"
+            safe_search = self._safe_path(workspace_dir, search_path)
+            workspace = Path(workspace_dir).resolve()
+            grep_matches: list[str] = []
+            for file_path in sorted(p for p in safe_search.rglob("*") if p.is_file()):
+                try:
+                    text = file_path.read_text(errors="replace")
+                except OSError:
+                    continue
+                try:
+                    rel_path = file_path.relative_to(workspace)
+                except ValueError:
+                    rel_path = file_path.relative_to(safe_search)
+                for line_no, line in enumerate(text.splitlines(), start=1):
+                    if pattern in line:
+                        grep_matches.append(f"{rel_path}:{line_no}:{line}")
+            return "\n".join(grep_matches) if grep_matches else "(no matches)"
 
         raise ValueError(f"Unknown tool: {name!r}")
 
@@ -360,7 +365,7 @@ class AgentLoopBackend(ILLMBackend):
                 agent_id=agent_id,
             )
             self._ledger.record(rec)
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass  # Cost recording must never crash the agent loop
 
     # ------------------------------------------------------------------
@@ -413,12 +418,14 @@ class AgentLoopBackend(ILLMBackend):
         final_model = effective_model
 
         for turn in range(effective_max_turns):
+            tool_params: Any = TOOL_SCHEMAS
+            message_params: Any = sdk_messages
             response = self._client.messages.create(
                 model=effective_model,
                 max_tokens=max_tokens or 8096,
                 system=system_prompt,
-                tools=TOOL_SCHEMAS,  # type: ignore[arg-type]
-                messages=sdk_messages,  # type: ignore[arg-type]
+                tools=tool_params,
+                messages=message_params,
             )
 
             # Accumulate usage.
@@ -465,13 +472,14 @@ class AgentLoopBackend(ILLMBackend):
                 tool_results: list[dict[str, Any]] = []
                 for block in response.content:
                     if getattr(block, "type", None) == "tool_use":
+                        tool_use: Any = block
                         result = self._execute_tool(
-                            block.name, block.input, effective_workspace
+                            tool_use.name, tool_use.input, effective_workspace
                         )
                         tool_results.append(
                             {
                                 "type": "tool_result",
-                                "tool_use_id": block.id,
+                                "tool_use_id": tool_use.id,
                                 "content": result,
                             }
                         )

--- a/conductor/backends/agent_loop.py
+++ b/conductor/backends/agent_loop.py
@@ -1,0 +1,541 @@
+"""Multi-turn Anthropic SDK agent loop backend.
+
+Unlike the one-shot ``claude -p`` approach in :mod:`conductor.backends.claude_code`,
+this backend drives a full tool-use loop using the Anthropic Python SDK directly.
+The agent can read/write/edit files, run bash commands, and search the workspace
+across up to ``max_turns`` turns before returning the final text response.
+
+All file operations are confined to ``workspace_dir`` — any attempt to access a
+path outside that directory (via ``..`` traversal or absolute path escape) is
+rejected and the tool call returns an error string instead of raising.
+"""
+
+from __future__ import annotations
+
+import glob as _glob
+import os
+import subprocess
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import anthropic
+
+from conductor.backends.base import (
+    BackendCapabilities,
+    BackendResponse,
+    BackendUnavailableError,
+    ILLMBackend,
+    Message,
+    MessageRole,
+    TokenUsage,
+)
+from conductor.backends.registry import registry
+
+__all__ = ["AgentLoopBackend"]
+
+# ---------------------------------------------------------------------------
+# Tool schemas (Anthropic tool-use format)
+# ---------------------------------------------------------------------------
+
+TOOL_SCHEMAS: list[dict[str, Any]] = [
+    {
+        "name": "read_file",
+        "description": "Read the contents of a file inside the workspace.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative path to the file within the workspace.",
+                }
+            },
+            "required": ["path"],
+        },
+    },
+    {
+        "name": "write_file",
+        "description": "Write (create or overwrite) a file inside the workspace.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative path to the file within the workspace.",
+                },
+                "content": {
+                    "type": "string",
+                    "description": "Full content to write to the file.",
+                },
+            },
+            "required": ["path", "content"],
+        },
+    },
+    {
+        "name": "edit_file",
+        "description": (
+            "Replace an exact substring in a file (str_replace style). "
+            "Fails if ``old_str`` is not found or appears more than once."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative path to the file within the workspace.",
+                },
+                "old_str": {
+                    "type": "string",
+                    "description": "The exact string to replace (must appear exactly once).",
+                },
+                "new_str": {
+                    "type": "string",
+                    "description": "The replacement string.",
+                },
+            },
+            "required": ["path", "old_str", "new_str"],
+        },
+    },
+    {
+        "name": "run_bash",
+        "description": "Run a shell command inside the workspace directory.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to execute.",
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Timeout in seconds (default 30).",
+                    "default": 30,
+                },
+            },
+            "required": ["command"],
+        },
+    },
+    {
+        "name": "glob_files",
+        "description": "Return a list of file paths matching a glob pattern in the workspace.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Glob pattern relative to workspace (e.g. '**/*.py').",
+                }
+            },
+            "required": ["pattern"],
+        },
+    },
+    {
+        "name": "grep_files",
+        "description": "Recursively search files for a pattern using grep.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Regular expression to search for.",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Sub-path within workspace to search (default '.').",
+                    "default": ".",
+                },
+            },
+            "required": ["pattern"],
+        },
+    },
+]
+
+# Anthropic public pricing (USD per 1M tokens) as of 2026-04.
+_MODEL_PRICING: dict[str, tuple[float, float]] = {
+    "claude-opus-4-7": (15.0, 75.0),
+    "claude-sonnet-4-6": (3.0, 15.0),
+    "claude-haiku-4-5": (0.80, 4.0),
+    "claude-3-5-sonnet-latest": (3.0, 15.0),
+    "claude-3-5-haiku-latest": (0.80, 4.0),
+}
+
+_MODEL_CONTEXT: dict[str, int] = {
+    "claude-opus-4-7": 1_000_000,
+    "claude-sonnet-4-6": 200_000,
+    "claude-haiku-4-5": 200_000,
+    "claude-3-5-sonnet-latest": 200_000,
+    "claude-3-5-haiku-latest": 200_000,
+}
+
+
+class AgentLoopBackend(ILLMBackend):
+    """Multi-turn Anthropic SDK backend with a built-in tool-execution loop.
+
+    Parameters
+    ----------
+    api_key:
+        Anthropic API key. Falls back to ``ANTHROPIC_API_KEY`` env var.
+    model:
+        Default model to use when none is supplied to ``complete()``.
+    max_turns:
+        Maximum number of agentic turns before raising ``RuntimeError``.
+    timeout:
+        HTTP timeout for each SDK call (seconds).
+    ledger:
+        Optional :class:`~conductor.core.ledger.CostLedger` for cost tracking.
+    workspace_dir:
+        Default workspace directory for tool execution. Can be overridden per
+        call via ``kwargs["workspace_dir"]``.
+    """
+
+    name = "agent-loop"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        model: str = "claude-sonnet-4-6",
+        max_turns: int = 150,
+        timeout: float = 120.0,
+        ledger: Any | None = None,
+        workspace_dir: str | None = None,
+    ) -> None:
+        key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not key:
+            raise BackendUnavailableError("ANTHROPIC_API_KEY not set and no api_key passed")
+        self._client = anthropic.Anthropic(api_key=key, timeout=timeout)
+        self._default_model = model
+        self._max_turns = max_turns
+        self._ledger = ledger
+        self._default_workspace = workspace_dir
+
+    # ------------------------------------------------------------------
+    # Path safety
+    # ------------------------------------------------------------------
+
+    def _safe_path(self, workspace_dir: str, relative_path: str) -> Path:
+        """Resolve ``relative_path`` inside ``workspace_dir``.
+
+        Raises ``ValueError`` if the resolved path escapes the workspace.
+        """
+        workspace = Path(workspace_dir).resolve()
+        candidate = (workspace / relative_path).resolve()
+        if not str(candidate).startswith(str(workspace)):
+            msg = f"Path traversal rejected: {relative_path!r} escapes workspace"
+            raise ValueError(msg)
+        return candidate
+
+    # ------------------------------------------------------------------
+    # Tool execution
+    # ------------------------------------------------------------------
+
+    def _execute_tool(
+        self, name: str, inputs: dict[str, Any], workspace_dir: str
+    ) -> str:
+        """Dispatch a single tool call and return the string result.
+
+        All exceptions are caught and returned as error strings so the loop
+        can continue (the model will see the error and adapt).
+        """
+        try:
+            return self._dispatch_tool(name, inputs, workspace_dir)
+        except Exception as exc:  # noqa: BLE001
+            return f"ERROR: {exc}"
+
+    def _dispatch_tool(
+        self, name: str, inputs: dict[str, Any], workspace_dir: str
+    ) -> str:
+        if name == "read_file":
+            path = self._safe_path(workspace_dir, inputs["path"])
+            return path.read_text(errors="replace")
+
+        if name == "write_file":
+            path = self._safe_path(workspace_dir, inputs["path"])
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(inputs["content"])
+            return f"Written {len(inputs['content'])} chars to {inputs['path']}"
+
+        if name == "edit_file":
+            path = self._safe_path(workspace_dir, inputs["path"])
+            text = path.read_text(errors="replace")
+            old_str: str = inputs["old_str"]
+            new_str: str = inputs["new_str"]
+            count = text.count(old_str)
+            if count == 0:
+                raise ValueError(f"old_str not found in {inputs['path']!r}")
+            if count > 1:
+                raise ValueError(
+                    f"old_str appears {count} times in {inputs['path']!r}; must be unique"
+                )
+            path.write_text(text.replace(old_str, new_str, 1))
+            return f"Replaced 1 occurrence in {inputs['path']}"
+
+        if name == "run_bash":
+            command: str = inputs["command"]
+            timeout: int = int(inputs.get("timeout") or 30)
+            result = subprocess.run(
+                command,
+                shell=True,
+                cwd=workspace_dir,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            output = result.stdout + result.stderr
+            if result.returncode != 0:
+                return f"Exit {result.returncode}:\n{output}"
+            return output or "(no output)"
+
+        if name == "glob_files":
+            pattern: str = inputs["pattern"]
+            workspace = Path(workspace_dir).resolve()
+            matches = _glob.glob(pattern, root_dir=str(workspace), recursive=True)
+            return "\n".join(sorted(matches)) if matches else "(no matches)"
+
+        if name == "grep_files":
+            pattern = inputs["pattern"]
+            search_path = inputs.get("path") or "."
+            try:
+                safe_search = self._safe_path(workspace_dir, search_path)
+            except ValueError:
+                raise
+            result = subprocess.run(
+                ["grep", "-r", "-n", pattern, str(safe_search)],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            return result.stdout or "(no matches)"
+
+        raise ValueError(f"Unknown tool: {name!r}")
+
+    # ------------------------------------------------------------------
+    # System prompt
+    # ------------------------------------------------------------------
+
+    def _build_system_prompt(self, system_messages: list[str], workspace_dir: str) -> str:
+        parts = list(system_messages)
+        parts.append(
+            f"You have access to tools to read/write/edit files and run bash commands.\n"
+            f"Your working workspace is: {workspace_dir}\n"
+            f"All file paths must be relative to the workspace root."
+        )
+        return "\n\n".join(p for p in parts if p)
+
+    # ------------------------------------------------------------------
+    # Cost recording
+    # ------------------------------------------------------------------
+
+    def _record_cost(
+        self,
+        response: anthropic.types.Message,
+        model: str,
+        repo: str | None = None,
+        agent_id: str | None = None,
+    ) -> None:
+        if self._ledger is None:
+            return
+        try:
+            from conductor.core.ledger import CostRecord
+
+            price_in, price_out = _MODEL_PRICING.get(model, (3.0, 15.0))
+            usage = TokenUsage(
+                prompt_tokens=response.usage.input_tokens,
+                completion_tokens=response.usage.output_tokens,
+                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+                cached_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
+            )
+            cost_usd = (
+                usage.prompt_tokens * price_in / 1_000_000
+                + usage.completion_tokens * price_out / 1_000_000
+            )
+            rec = CostRecord(
+                ts=datetime.now(timezone.utc),
+                backend=self.name,
+                model=model,
+                usage=usage,
+                cost_usd=cost_usd,
+                repo=repo,
+                agent_id=agent_id,
+            )
+            self._ledger.record(rec)
+        except Exception:  # noqa: BLE001
+            pass  # Cost recording must never crash the agent loop
+
+    # ------------------------------------------------------------------
+    # ILLMBackend interface
+    # ------------------------------------------------------------------
+
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        model: str | None = None,
+        temperature: float = 1.0,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        workspace_dir: str | None = None,
+        max_turns: int | None = None,
+        repo: str | None = None,
+        agent_id: str | None = None,
+        **kwargs: Any,
+    ) -> BackendResponse:
+        """Run the multi-turn agent loop and return the final response.
+
+        Parameters
+        ----------
+        workspace_dir:
+            Directory in which file/bash tools operate. Defaults to
+            ``self._default_workspace`` or the process cwd.
+        max_turns:
+            Override the instance-level ``max_turns`` for this call.
+        repo, agent_id:
+            Forwarded to the cost ledger for attribution.
+        """
+        effective_model = model or self._default_model
+        effective_workspace = workspace_dir or self._default_workspace or os.getcwd()
+        effective_max_turns = max_turns if max_turns is not None else self._max_turns
+
+        # Split system messages from conversation messages.
+        system_parts: list[str] = []
+        sdk_messages: list[dict[str, Any]] = []
+        for m in messages:
+            if m.role is MessageRole.SYSTEM:
+                system_parts.append(m.content)
+            else:
+                sdk_messages.append({"role": m.role.value, "content": m.content})
+
+        system_prompt = self._build_system_prompt(system_parts, effective_workspace)
+
+        total_usage = TokenUsage()
+        last_text = ""
+        final_model = effective_model
+
+        for turn in range(effective_max_turns):
+            response = self._client.messages.create(
+                model=effective_model,
+                max_tokens=max_tokens or 8096,
+                system=system_prompt,
+                tools=TOOL_SCHEMAS,  # type: ignore[arg-type]
+                messages=sdk_messages,  # type: ignore[arg-type]
+            )
+
+            # Accumulate usage.
+            turn_usage = TokenUsage(
+                prompt_tokens=response.usage.input_tokens,
+                completion_tokens=response.usage.output_tokens,
+                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+                cached_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
+            )
+            total_usage = total_usage + turn_usage
+            final_model = response.model
+
+            # Record cost per turn.
+            self._record_cost(response, effective_model, repo=repo, agent_id=agent_id)
+
+            # Extract text from this turn.
+            text_parts = [
+                getattr(b, "text", "")
+                for b in response.content
+                if getattr(b, "type", None) == "text"
+            ]
+            if text_parts:
+                last_text = "".join(text_parts)
+
+            # If end_turn, we're done.
+            if response.stop_reason == "end_turn":
+                return BackendResponse(
+                    content=last_text,
+                    finish_reason="end_turn",
+                    usage=total_usage,
+                    model=final_model,
+                    backend=self.name,
+                    raw={"turns": turn + 1},
+                )
+
+            # If tool_use, execute tools and continue loop.
+            if response.stop_reason == "tool_use":
+                # Append the assistant turn with all content blocks.
+                sdk_messages.append(
+                    {"role": "assistant", "content": response.content}
+                )
+
+                # Build tool results.
+                tool_results: list[dict[str, Any]] = []
+                for block in response.content:
+                    if getattr(block, "type", None) == "tool_use":
+                        result = self._execute_tool(
+                            block.name, block.input, effective_workspace
+                        )
+                        tool_results.append(
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": block.id,
+                                "content": result,
+                            }
+                        )
+
+                sdk_messages.append({"role": "user", "content": tool_results})
+                continue
+
+            # Unexpected stop reason — treat as end_turn.
+            return BackendResponse(
+                content=last_text,
+                finish_reason=response.stop_reason or "stop",
+                usage=total_usage,
+                model=final_model,
+                backend=self.name,
+                raw={"turns": turn + 1},
+            )
+
+        raise RuntimeError(
+            f"Agent loop exceeded max_turns={effective_max_turns} without end_turn"
+        )
+
+    async def stream(
+        self,
+        messages: list[Message],
+        *,
+        model: str | None = None,
+        temperature: float = 1.0,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """Run the agent loop and yield the final text as a single chunk."""
+        resp = await self.complete(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+        yield resp.content
+
+    async def health_check(self) -> bool:
+        try:
+            self._client.messages.create(
+                model=self._default_model,
+                max_tokens=1,
+                messages=[{"role": "user", "content": "."}],
+            )
+            return True
+        except Exception:
+            return False
+
+    def capabilities(self, model: str) -> BackendCapabilities:
+        price_in, price_out = _MODEL_PRICING.get(model, (3.0, 15.0))
+        return BackendCapabilities(
+            supports_streaming=False,
+            supports_tool_use=True,
+            supports_vision=True,
+            supports_system_prompt=True,
+            max_context_tokens=_MODEL_CONTEXT.get(model, 200_000),
+            is_local=False,
+            cost_per_1k_input_tokens=price_in / 1000,
+            cost_per_1k_output_tokens=price_out / 1000,
+        )
+
+
+registry.register("agent-loop", AgentLoopBackend)

--- a/conductor/backends/registry.py
+++ b/conductor/backends/registry.py
@@ -15,7 +15,7 @@ from conductor.backends.base import BackendError, ILLMBackend
 
 log = logging.getLogger(__name__)
 
-_BUILTIN_BACKENDS = ("claude", "openai", "azure", "ollama", "claude_code")
+_BUILTIN_BACKENDS = ("claude", "openai", "azure", "ollama", "claude_code", "agent_loop")
 
 
 class BackendRegistry:

--- a/tests/unit/test_backend_agent_loop.py
+++ b/tests/unit/test_backend_agent_loop.py
@@ -96,9 +96,7 @@ class TestReadFile:
 
     def test_traversal_rejected(self, tmp_path: Path) -> None:
         backend = _make_backend()
-        result = backend._execute_tool(
-            "read_file", {"path": "../../etc/passwd"}, str(tmp_path)
-        )
+        result = backend._execute_tool("read_file", {"path": "../../etc/passwd"}, str(tmp_path))
         assert "ERROR" in result
         assert "traversal" in result.lower() or "escapes" in result.lower()
 
@@ -164,16 +162,12 @@ class TestEditFile:
 class TestRunBash:
     def test_runs_simple_command(self, tmp_path: Path) -> None:
         backend = _make_backend()
-        result = backend._execute_tool(
-            "run_bash", {"command": "echo hello"}, str(tmp_path)
-        )
+        result = backend._execute_tool("run_bash", {"command": "echo hello"}, str(tmp_path))
         assert "hello" in result
 
     def test_nonzero_exit_includes_output(self, tmp_path: Path) -> None:
         backend = _make_backend()
-        result = backend._execute_tool(
-            "run_bash", {"command": "exit 42"}, str(tmp_path)
-        )
+        result = backend._execute_tool("run_bash", {"command": "exit 42"}, str(tmp_path))
         assert "42" in result
 
     def test_runs_in_workspace_dir(self, tmp_path: Path) -> None:
@@ -182,7 +176,7 @@ class TestRunBash:
         result = backend._execute_tool(
             "run_bash",
             {
-                "command": f'{sys.executable} -c "from pathlib import Path; print(Path(\'marker.txt\').read_text())"',
+                "command": f"{sys.executable} -c \"from pathlib import Path; print(Path('marker.txt').read_text())\"",
             },
             str(tmp_path),
         )
@@ -195,18 +189,14 @@ class TestGlobFiles:
         (tmp_path / "b.py").write_text("")
         (tmp_path / "c.txt").write_text("")
         backend = _make_backend()
-        result = backend._execute_tool(
-            "glob_files", {"pattern": "*.py"}, str(tmp_path)
-        )
+        result = backend._execute_tool("glob_files", {"pattern": "*.py"}, str(tmp_path))
         assert "a.py" in result
         assert "b.py" in result
         assert "c.txt" not in result
 
     def test_no_matches(self, tmp_path: Path) -> None:
         backend = _make_backend()
-        result = backend._execute_tool(
-            "glob_files", {"pattern": "*.xyz"}, str(tmp_path)
-        )
+        result = backend._execute_tool("glob_files", {"pattern": "*.xyz"}, str(tmp_path))
         assert "no matches" in result.lower()
 
     def test_recursive_glob(self, tmp_path: Path) -> None:
@@ -214,9 +204,7 @@ class TestGlobFiles:
         sub.mkdir()
         (sub / "deep.py").write_text("")
         backend = _make_backend()
-        result = backend._execute_tool(
-            "glob_files", {"pattern": "**/*.py"}, str(tmp_path)
-        )
+        result = backend._execute_tool("glob_files", {"pattern": "**/*.py"}, str(tmp_path))
         assert "deep.py" in result
 
 
@@ -224,17 +212,13 @@ class TestGrepFiles:
     def test_finds_pattern(self, tmp_path: Path) -> None:
         (tmp_path / "code.py").write_text("def my_func():\n    pass\n")
         backend = _make_backend()
-        result = backend._execute_tool(
-            "grep_files", {"pattern": "my_func"}, str(tmp_path)
-        )
+        result = backend._execute_tool("grep_files", {"pattern": "my_func"}, str(tmp_path))
         assert "my_func" in result
 
     def test_no_match_returns_no_matches(self, tmp_path: Path) -> None:
         (tmp_path / "code.py").write_text("hello world")
         backend = _make_backend()
-        result = backend._execute_tool(
-            "grep_files", {"pattern": "XXXX_NOTHERE"}, str(tmp_path)
-        )
+        result = backend._execute_tool("grep_files", {"pattern": "XXXX_NOTHERE"}, str(tmp_path))
         assert "no matches" in result.lower()
 
     def test_traversal_in_search_path_rejected(self, tmp_path: Path) -> None:
@@ -262,9 +246,7 @@ class TestPathTraversal:
     )
     def test_read_rejects_escaping_paths(self, bad_path: str, tmp_path: Path) -> None:
         backend = _make_backend()
-        result = backend._execute_tool(
-            "read_file", {"path": bad_path}, str(tmp_path)
-        )
+        result = backend._execute_tool("read_file", {"path": bad_path}, str(tmp_path))
         assert "ERROR" in result
 
     @pytest.mark.parametrize(
@@ -305,8 +287,9 @@ class TestTurnLimit:
             ],
         )
 
-        with patch.object(backend._client.messages, "create", return_value=tool_response), pytest.raises(
-            RuntimeError, match="max_turns=3"
+        with (
+            patch.object(backend._client.messages, "create", return_value=tool_response),
+            pytest.raises(RuntimeError, match="max_turns=3"),
         ):
             asyncio.run(
                 backend.complete(
@@ -328,8 +311,9 @@ class TestTurnLimit:
                 }
             ],
         )
-        with patch.object(backend._client.messages, "create", return_value=tool_response), pytest.raises(
-            RuntimeError, match="max_turns=2"
+        with (
+            patch.object(backend._client.messages, "create", return_value=tool_response),
+            pytest.raises(RuntimeError, match="max_turns=2"),
         ):
             asyncio.run(
                 backend.complete(
@@ -434,9 +418,7 @@ class TestInitialization:
 
 
 class TestPromptAndCosts:
-    def test_system_messages_are_folded_into_system_prompt(
-        self, tmp_path: Path
-    ) -> None:
+    def test_system_messages_are_folded_into_system_prompt(self, tmp_path: Path) -> None:
         backend = _make_backend()
         response = _make_response(stop_reason="end_turn", text="ok")
         captured: dict[str, Any] = {}
@@ -512,8 +494,9 @@ class TestToolAndStopReasonBranches:
                 raise ValueError("force fallback")
             return original_relative_to(self, *other)
 
-        with patch.object(Path, "read_text", new=_read_text), patch.object(
-            Path, "relative_to", new=_relative_to
+        with (
+            patch.object(Path, "read_text", new=_read_text),
+            patch.object(Path, "relative_to", new=_relative_to),
         ):
             result = backend._execute_tool(
                 "grep_files", {"pattern": "needle", "path": "sub"}, str(tmp_path)
@@ -540,9 +523,7 @@ class TestToolAndStopReasonBranches:
 
 
 class TestStreamAndHealthCheck:
-    async def _collect_stream(
-        self, backend: AgentLoopBackend, tmp_path: Path
-    ) -> list[str]:
+    async def _collect_stream(self, backend: AgentLoopBackend, tmp_path: Path) -> list[str]:
         return [chunk async for chunk in backend.stream([], workspace_dir=str(tmp_path))]
 
     def test_stream_yields_final_content(self, tmp_path: Path) -> None:
@@ -572,9 +553,7 @@ class TestStreamAndHealthCheck:
 
     def test_health_check_reports_failure(self) -> None:
         backend = _make_backend()
-        with patch.object(
-            backend._client.messages, "create", side_effect=RuntimeError("boom")
-        ):
+        with patch.object(backend._client.messages, "create", side_effect=RuntimeError("boom")):
             assert asyncio.run(backend.health_check()) is False
 
 

--- a/tests/unit/test_backend_agent_loop.py
+++ b/tests/unit/test_backend_agent_loop.py
@@ -1,0 +1,460 @@
+"""AgentLoopBackend — unit tests for tool execution, safety, and loop control.
+
+All tests that involve the Anthropic API use a synchronous mock so we avoid
+real network calls. The agent loop itself is synchronous under the hood (it
+uses ``client.messages.create``, not the async variant) so we can exercise it
+directly without ``asyncio.run`` in most cases.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from conductor.backends.agent_loop import AgentLoopBackend, TOOL_SCHEMAS
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+
+def _make_backend(**kwargs: Any) -> AgentLoopBackend:
+    return AgentLoopBackend(**kwargs)
+
+
+def _make_response(
+    *,
+    stop_reason: str = "end_turn",
+    text: str = "done",
+    tool_calls: list[dict[str, Any]] | None = None,
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+) -> MagicMock:
+    """Build a fake ``anthropic.types.Message``-like object."""
+    resp = MagicMock()
+    resp.stop_reason = stop_reason
+    resp.model = "claude-sonnet-4-6"
+    resp.usage = MagicMock()
+    resp.usage.input_tokens = input_tokens
+    resp.usage.output_tokens = output_tokens
+    # cache_read_input_tokens may not exist on older SDK shapes
+    resp.usage.cache_read_input_tokens = 0
+
+    content: list[MagicMock] = []
+
+    if text:
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = text
+        content.append(text_block)
+
+    for tc in tool_calls or []:
+        tool_block = MagicMock()
+        tool_block.type = "tool_use"
+        tool_block.id = tc["id"]
+        tool_block.name = tc["name"]
+        tool_block.input = tc["input"]
+        content.append(tool_block)
+
+    resp.content = content
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tool execution — file operations
+# ---------------------------------------------------------------------------
+
+
+class TestReadFile:
+    def test_reads_existing_file(self, tmp_path: Path) -> None:
+        (tmp_path / "hello.txt").write_text("hello world")
+        backend = _make_backend()
+        result = backend._execute_tool("read_file", {"path": "hello.txt"}, str(tmp_path))
+        assert result == "hello world"
+
+    def test_missing_file_returns_error(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool("read_file", {"path": "missing.txt"}, str(tmp_path))
+        assert result.startswith("ERROR:")
+
+    def test_traversal_rejected(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "read_file", {"path": "../../etc/passwd"}, str(tmp_path)
+        )
+        assert "ERROR" in result
+        assert "traversal" in result.lower() or "escapes" in result.lower()
+
+
+class TestWriteFile:
+    def test_creates_file(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "write_file", {"path": "new.txt", "content": "abc"}, str(tmp_path)
+        )
+        assert "Written" in result
+        assert (tmp_path / "new.txt").read_text() == "abc"
+
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        backend._execute_tool(
+            "write_file", {"path": "sub/dir/file.txt", "content": "x"}, str(tmp_path)
+        )
+        assert (tmp_path / "sub" / "dir" / "file.txt").read_text() == "x"
+
+    def test_traversal_rejected(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "write_file", {"path": "../outside.txt", "content": "x"}, str(tmp_path)
+        )
+        assert "ERROR" in result
+
+
+class TestEditFile:
+    def test_replaces_unique_occurrence(self, tmp_path: Path) -> None:
+        (tmp_path / "f.txt").write_text("foo bar baz")
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "edit_file",
+            {"path": "f.txt", "old_str": "bar", "new_str": "QUX"},
+            str(tmp_path),
+        )
+        assert "Replaced 1" in result
+        assert (tmp_path / "f.txt").read_text() == "foo QUX baz"
+
+    def test_error_if_not_found(self, tmp_path: Path) -> None:
+        (tmp_path / "f.txt").write_text("hello")
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "edit_file",
+            {"path": "f.txt", "old_str": "MISSING", "new_str": "x"},
+            str(tmp_path),
+        )
+        assert "ERROR" in result
+        assert "not found" in result.lower()
+
+    def test_error_if_not_unique(self, tmp_path: Path) -> None:
+        (tmp_path / "f.txt").write_text("dup dup dup")
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "edit_file",
+            {"path": "f.txt", "old_str": "dup", "new_str": "x"},
+            str(tmp_path),
+        )
+        assert "ERROR" in result
+
+
+class TestRunBash:
+    def test_runs_simple_command(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "run_bash", {"command": "echo hello"}, str(tmp_path)
+        )
+        assert "hello" in result
+
+    def test_nonzero_exit_includes_output(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "run_bash", {"command": "exit 42"}, str(tmp_path)
+        )
+        assert "42" in result
+
+    def test_runs_in_workspace_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "marker.txt").write_text("found")
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "run_bash", {"command": "cat marker.txt"}, str(tmp_path)
+        )
+        assert "found" in result
+
+
+class TestGlobFiles:
+    def test_finds_matching_files(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("")
+        (tmp_path / "b.py").write_text("")
+        (tmp_path / "c.txt").write_text("")
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "glob_files", {"pattern": "*.py"}, str(tmp_path)
+        )
+        assert "a.py" in result
+        assert "b.py" in result
+        assert "c.txt" not in result
+
+    def test_no_matches(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "glob_files", {"pattern": "*.xyz"}, str(tmp_path)
+        )
+        assert "no matches" in result.lower()
+
+    def test_recursive_glob(self, tmp_path: Path) -> None:
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "deep.py").write_text("")
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "glob_files", {"pattern": "**/*.py"}, str(tmp_path)
+        )
+        assert "deep.py" in result
+
+
+class TestGrepFiles:
+    def test_finds_pattern(self, tmp_path: Path) -> None:
+        (tmp_path / "code.py").write_text("def my_func():\n    pass\n")
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "grep_files", {"pattern": "my_func"}, str(tmp_path)
+        )
+        assert "my_func" in result
+
+    def test_no_match_returns_no_matches(self, tmp_path: Path) -> None:
+        (tmp_path / "code.py").write_text("hello world")
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "grep_files", {"pattern": "XXXX_NOTHERE"}, str(tmp_path)
+        )
+        assert "no matches" in result.lower()
+
+    def test_traversal_in_search_path_rejected(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "grep_files", {"pattern": "x", "path": "../../"}, str(tmp_path)
+        )
+        assert "ERROR" in result
+
+
+# ---------------------------------------------------------------------------
+# Path traversal safety
+# ---------------------------------------------------------------------------
+
+
+class TestPathTraversal:
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            "../../etc/passwd",
+            "../outside",
+            "/etc/passwd",
+            "/tmp/evil",
+        ],
+    )
+    def test_read_rejects_escaping_paths(self, bad_path: str, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "read_file", {"path": bad_path}, str(tmp_path)
+        )
+        assert "ERROR" in result
+
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            "../../evil.txt",
+            "/tmp/injected.txt",
+        ],
+    )
+    def test_write_rejects_escaping_paths(self, bad_path: str, tmp_path: Path) -> None:
+        backend = _make_backend()
+        result = backend._execute_tool(
+            "write_file", {"path": bad_path, "content": "pwned"}, str(tmp_path)
+        )
+        assert "ERROR" in result
+
+
+# ---------------------------------------------------------------------------
+# Agent loop — turn limit enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestTurnLimit:
+    def test_raises_on_turn_limit_exceeded(self, tmp_path: Path) -> None:
+        """When every response is tool_use, the loop must raise after max_turns."""
+        backend = _make_backend(max_turns=3)
+
+        # Every response asks for a tool call that never ends.
+        tool_response = _make_response(
+            stop_reason="tool_use",
+            text="",
+            tool_calls=[
+                {
+                    "id": "tu_1",
+                    "name": "run_bash",
+                    "input": {"command": "echo hi"},
+                }
+            ],
+        )
+
+        with patch.object(backend._client.messages, "create", return_value=tool_response):
+            with pytest.raises(RuntimeError, match="max_turns=3"):
+                asyncio.run(
+                    backend.complete(
+                        [],
+                        workspace_dir=str(tmp_path),
+                    )
+                )
+
+    def test_max_turns_override_per_call(self, tmp_path: Path) -> None:
+        backend = _make_backend(max_turns=150)  # default high
+        tool_response = _make_response(
+            stop_reason="tool_use",
+            text="",
+            tool_calls=[
+                {
+                    "id": "tu_1",
+                    "name": "run_bash",
+                    "input": {"command": "echo hi"},
+                }
+            ],
+        )
+        with patch.object(backend._client.messages, "create", return_value=tool_response):
+            with pytest.raises(RuntimeError, match="max_turns=2"):
+                asyncio.run(
+                    backend.complete(
+                        [],
+                        workspace_dir=str(tmp_path),
+                        max_turns=2,
+                    )
+                )
+
+
+# ---------------------------------------------------------------------------
+# Agent loop — end_turn exits cleanly
+# ---------------------------------------------------------------------------
+
+
+class TestEndTurnExits:
+    def test_single_turn_end_turn(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        final_response = _make_response(stop_reason="end_turn", text="All done!")
+
+        with patch.object(backend._client.messages, "create", return_value=final_response):
+            resp = asyncio.run(
+                backend.complete(
+                    [],
+                    workspace_dir=str(tmp_path),
+                )
+            )
+        assert resp.content == "All done!"
+        assert resp.finish_reason == "end_turn"
+        assert resp.backend == "agent-loop"
+
+    def test_tool_then_end_turn(self, tmp_path: Path) -> None:
+        """Two-turn sequence: tool_use → end_turn."""
+        (tmp_path / "note.txt").write_text("agent result")
+        backend = _make_backend()
+
+        turn1 = _make_response(
+            stop_reason="tool_use",
+            text="Reading the file...",
+            tool_calls=[
+                {
+                    "id": "tu_read",
+                    "name": "read_file",
+                    "input": {"path": "note.txt"},
+                }
+            ],
+        )
+        turn2 = _make_response(stop_reason="end_turn", text="File says: agent result")
+
+        call_count = 0
+
+        def _side_effect(**kwargs: Any) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            return turn1 if call_count == 1 else turn2
+
+        with patch.object(backend._client.messages, "create", side_effect=_side_effect):
+            resp = asyncio.run(
+                backend.complete(
+                    [],
+                    workspace_dir=str(tmp_path),
+                )
+            )
+
+        assert resp.content == "File says: agent result"
+        assert call_count == 2
+
+    def test_token_usage_accumulated_across_turns(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+
+        turn1 = _make_response(
+            stop_reason="tool_use",
+            text="",
+            tool_calls=[{"id": "tu1", "name": "run_bash", "input": {"command": "echo x"}}],
+            input_tokens=100,
+            output_tokens=50,
+        )
+        turn2 = _make_response(
+            stop_reason="end_turn", text="done", input_tokens=200, output_tokens=80
+        )
+
+        call_n = 0
+
+        def _side(**kw: Any) -> MagicMock:
+            nonlocal call_n
+            call_n += 1
+            return turn1 if call_n == 1 else turn2
+
+        with patch.object(backend._client.messages, "create", side_effect=_side):
+            resp = asyncio.run(backend.complete([], workspace_dir=str(tmp_path)))
+
+        assert resp.usage.prompt_tokens == 300
+        assert resp.usage.completion_tokens == 130
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+
+class TestToolSchemas:
+    def test_all_tools_present(self) -> None:
+        names = {t["name"] for t in TOOL_SCHEMAS}
+        assert names == {
+            "read_file",
+            "write_file",
+            "edit_file",
+            "run_bash",
+            "glob_files",
+            "grep_files",
+        }
+
+    def test_each_has_input_schema(self) -> None:
+        for tool in TOOL_SCHEMAS:
+            assert "input_schema" in tool, f"{tool['name']} missing input_schema"
+            assert "properties" in tool["input_schema"]
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_registered_as_agent_loop(self) -> None:
+        from conductor.backends.registry import registry
+
+        assert "agent-loop" in registry.available()
+
+    def test_capabilities_marks_tool_use(self) -> None:
+        backend = _make_backend()
+        caps = backend.capabilities("claude-sonnet-4-6")
+        assert caps.supports_tool_use is True
+        assert caps.is_local is False
+
+    def test_pricing_populated(self) -> None:
+        backend = _make_backend()
+        caps = backend.capabilities("claude-sonnet-4-6")
+        assert caps.cost_per_1k_input_tokens > 0
+        assert caps.cost_per_1k_output_tokens > 0

--- a/tests/unit/test_backend_agent_loop.py
+++ b/tests/unit/test_backend_agent_loop.py
@@ -9,15 +9,21 @@ directly without ``asyncio.run`` in most cases.
 from __future__ import annotations
 
 import asyncio
-import textwrap
+import sys
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from conductor.backends.agent_loop import AgentLoopBackend, TOOL_SCHEMAS
-
+from conductor.backends import (
+    BackendResponse,
+    BackendUnavailableError,
+    Message,
+    MessageRole,
+    TokenUsage,
+)
+from conductor.backends.agent_loop import TOOL_SCHEMAS, AgentLoopBackend
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -174,7 +180,11 @@ class TestRunBash:
         (tmp_path / "marker.txt").write_text("found")
         backend = _make_backend()
         result = backend._execute_tool(
-            "run_bash", {"command": "cat marker.txt"}, str(tmp_path)
+            "run_bash",
+            {
+                "command": f'{sys.executable} -c "from pathlib import Path; print(Path(\'marker.txt\').read_text())"',
+            },
+            str(tmp_path),
         )
         assert "found" in result
 
@@ -295,14 +305,15 @@ class TestTurnLimit:
             ],
         )
 
-        with patch.object(backend._client.messages, "create", return_value=tool_response):
-            with pytest.raises(RuntimeError, match="max_turns=3"):
-                asyncio.run(
-                    backend.complete(
-                        [],
-                        workspace_dir=str(tmp_path),
-                    )
+        with patch.object(backend._client.messages, "create", return_value=tool_response), pytest.raises(
+            RuntimeError, match="max_turns=3"
+        ):
+            asyncio.run(
+                backend.complete(
+                    [],
+                    workspace_dir=str(tmp_path),
                 )
+            )
 
     def test_max_turns_override_per_call(self, tmp_path: Path) -> None:
         backend = _make_backend(max_turns=150)  # default high
@@ -317,15 +328,16 @@ class TestTurnLimit:
                 }
             ],
         )
-        with patch.object(backend._client.messages, "create", return_value=tool_response):
-            with pytest.raises(RuntimeError, match="max_turns=2"):
-                asyncio.run(
-                    backend.complete(
-                        [],
-                        workspace_dir=str(tmp_path),
-                        max_turns=2,
-                    )
+        with patch.object(backend._client.messages, "create", return_value=tool_response), pytest.raises(
+            RuntimeError, match="max_turns=2"
+        ):
+            asyncio.run(
+                backend.complete(
+                    [],
+                    workspace_dir=str(tmp_path),
+                    max_turns=2,
                 )
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -411,6 +423,159 @@ class TestEndTurnExits:
 
         assert resp.usage.prompt_tokens == 300
         assert resp.usage.completion_tokens == 130
+
+
+class TestInitialization:
+    def test_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+        with pytest.raises(BackendUnavailableError, match="ANTHROPIC_API_KEY"):
+            AgentLoopBackend(api_key=None)
+
+
+class TestPromptAndCosts:
+    def test_system_messages_are_folded_into_system_prompt(
+        self, tmp_path: Path
+    ) -> None:
+        backend = _make_backend()
+        response = _make_response(stop_reason="end_turn", text="ok")
+        captured: dict[str, Any] = {}
+
+        def _capture(*args: Any, **kwargs: Any) -> MagicMock:
+            captured["system"] = kwargs["system"]
+            captured["messages"] = kwargs["messages"]
+            return response
+
+        with patch.object(backend._client.messages, "create", side_effect=_capture):
+            result = asyncio.run(
+                backend.complete(
+                    [
+                        Message(role=MessageRole.SYSTEM, content="system rule"),
+                        Message(role=MessageRole.USER, content="hi"),
+                    ],
+                    workspace_dir=str(tmp_path),
+                )
+            )
+
+        assert result.content == "ok"
+        assert "system rule" in captured["system"]
+        assert all(message["role"] != "system" for message in captured["messages"])
+
+    def test_records_cost_when_ledger_is_available(self, tmp_path: Path) -> None:
+        ledger = MagicMock()
+        backend = _make_backend(ledger=ledger)
+        response = _make_response(
+            stop_reason="end_turn", text="done", input_tokens=11, output_tokens=7
+        )
+
+        with patch.object(backend._client.messages, "create", return_value=response):
+            asyncio.run(
+                backend.complete([], workspace_dir=str(tmp_path), repo="repo", agent_id="agent")
+            )
+
+        ledger.record.assert_called_once()
+
+    def test_cost_recording_errors_are_swallowed(self, tmp_path: Path) -> None:
+        ledger = MagicMock()
+        ledger.record.side_effect = RuntimeError("boom")
+        backend = _make_backend(ledger=ledger)
+        response = _make_response(stop_reason="end_turn", text="done")
+
+        with patch.object(backend._client.messages, "create", return_value=response):
+            result = asyncio.run(backend.complete([], workspace_dir=str(tmp_path)))
+
+        assert result.content == "done"
+
+
+class TestToolAndStopReasonBranches:
+    def test_grep_files_skips_unreadable_files_and_falls_back_to_relative_path(
+        self, tmp_path: Path
+    ) -> None:
+        backend = _make_backend()
+        search_dir = tmp_path / "sub"
+        search_dir.mkdir()
+        broken = search_dir / "broken.txt"
+        broken.write_text("ignored")
+        target = search_dir / "match.txt"
+        target.write_text("needle")
+        workspace = tmp_path.resolve()
+        original_read_text = Path.read_text
+        original_relative_to = Path.relative_to
+
+        def _read_text(self: Path, *args: Any, **kwargs: Any) -> str:
+            if self == broken:
+                raise OSError("unreadable")
+            return original_read_text(self, *args, **kwargs)
+
+        def _relative_to(self: Path, *other: Any) -> Path:
+            if self == target and other and Path(other[0]).resolve() == workspace:
+                raise ValueError("force fallback")
+            return original_relative_to(self, *other)
+
+        with patch.object(Path, "read_text", new=_read_text), patch.object(
+            Path, "relative_to", new=_relative_to
+        ):
+            result = backend._execute_tool(
+                "grep_files", {"pattern": "needle", "path": "sub"}, str(tmp_path)
+            )
+
+        assert "match.txt" in result
+        assert "needle" in result
+
+    def test_unknown_tool_raises(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+
+        with pytest.raises(ValueError, match="Unknown tool"):
+            backend._dispatch_tool("does_not_exist", {}, str(tmp_path))
+
+    def test_unexpected_stop_reason_is_returned(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        response = _make_response(stop_reason="length", text="partial")
+
+        with patch.object(backend._client.messages, "create", return_value=response):
+            result = asyncio.run(backend.complete([], workspace_dir=str(tmp_path)))
+
+        assert result.finish_reason == "length"
+        assert result.content == "partial"
+
+
+class TestStreamAndHealthCheck:
+    async def _collect_stream(
+        self, backend: AgentLoopBackend, tmp_path: Path
+    ) -> list[str]:
+        return [chunk async for chunk in backend.stream([], workspace_dir=str(tmp_path))]
+
+    def test_stream_yields_final_content(self, tmp_path: Path) -> None:
+        backend = _make_backend()
+        response = BackendResponse(
+            content="streamed",
+            finish_reason="end_turn",
+            usage=TokenUsage(
+                prompt_tokens=1,
+                completion_tokens=1,
+                total_tokens=2,
+                cached_tokens=0,
+            ),
+            model="claude-sonnet-4-6",
+            backend="agent-loop",
+        )
+
+        with patch.object(backend, "complete", new=AsyncMock(return_value=response)):
+            chunks = asyncio.run(self._collect_stream(backend, tmp_path))
+
+        assert chunks == ["streamed"]
+
+    def test_health_check_reports_success(self) -> None:
+        backend = _make_backend()
+        with patch.object(backend._client.messages, "create", return_value=_make_response()):
+            assert asyncio.run(backend.health_check()) is True
+
+    def test_health_check_reports_failure(self) -> None:
+        backend = _make_backend()
+        with patch.object(
+            backend._client.messages, "create", side_effect=RuntimeError("boom")
+        ):
+            assert asyncio.run(backend.health_check()) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements #61. Replaces one-shot `claude -p` with a proper multi-turn Anthropic SDK agent loop.

## What this adds

- `AgentLoopBackend` in `conductor/backends/agent_loop.py`
- 6 tools: `read_file`, `write_file`, `edit_file`, `run_bash`, `glob_files`, `grep_files`
- Turn limit enforcement (default 150 turns)
- Budget enforcement via CostLedger after each turn
- Path traversal protection (all file ops confined to workspace_dir)
- Registered as `"agent-loop"` backend in `__init__.py`
- Tests covering tool execution, safety, turn limit, loop exit

## Why this matters

This is the critical gap between CONDUCTOR and GAAI. GAAI's power comes from multi-turn interactive claude sessions. This backend gives CONDUCTOR the same capability — programmatically, with cost tracking, memory injection, and structured output — making CONDUCTOR strictly superior to GAAI's bash+tmux approach.