### PR TITLE
feat(tools): agent-agnostic MCP tool layer + 6 sandboxed built-ins (#74)

### DIFF
--- a/conductor/tools/__init__.py
+++ b/conductor/tools/__init__.py
@@ -1,0 +1,25 @@
+"""Agent-agnostic tool definitions.
+
+Tools are declared once as ``ToolSpec`` (or via the ``@mcp_tool`` decorator) and
+compiled to provider-specific schemas on demand. The same handler serves every
+backend — Anthropic, OpenAI, Ollama, or any model we add later — which keeps the
+tool layer DRY and makes swapping backends a config change, not a code change.
+"""
+
+from conductor.tools.mcp import (
+    ToolParam,
+    ToolRegistry,
+    ToolRegistryError,
+    ToolResult,
+    ToolSpec,
+    mcp_tool,
+)
+
+__all__ = [
+    "ToolParam",
+    "ToolRegistry",
+    "ToolRegistryError",
+    "ToolResult",
+    "ToolSpec",
+    "mcp_tool",
+]

--- a/conductor/tools/builtins.py
+++ b/conductor/tools/builtins.py
@@ -1,0 +1,294 @@
+"""Built-in agent tools — sandboxed to a workspace root.
+
+The goal is every tool uses the *same* handler regardless of which backend
+dispatched it. Factories (``make_read_file``, …) bind a workspace ``root`` so
+each invocation is limited to that directory. Resolution goes through
+``_resolve`` which refuses:
+
+  * absolute paths outside the root
+  * ``..`` traversal
+  * symlinks whose target escapes the root
+
+These rules apply to every path argument across every tool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import subprocess
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+from conductor.tools.mcp import (
+    ToolParam,
+    ToolRegistry,
+    mcp_tool,
+)
+
+__all__ = [
+    "BashRunner",
+    "SandboxViolationError",
+    "build_default_registry",
+    "make_edit_file",
+    "make_glob_files",
+    "make_grep_files",
+    "make_read_file",
+    "make_run_bash",
+    "make_write_file",
+]
+
+#: Default timeout on ``run_bash`` when the model doesn't specify one.
+DEFAULT_BASH_TIMEOUT_SECONDS = 30.0
+#: Max bytes of combined stdout+stderr returned to the model; beyond this we
+#: truncate so one runaway command can't poison the context window.
+DEFAULT_MAX_OUTPUT_BYTES = 64_000
+
+#: Runner signature — takes argv, cwd, and timeout; returns (rc, stdout, stderr).
+#: Injected so tests don't spawn real subprocesses.
+BashRunner = Callable[[list[str], str, float], Awaitable[tuple[int, bytes, bytes]]]
+
+
+class SandboxViolationError(ValueError):
+    """Raised when a tool would access a path outside its workspace."""
+
+
+def _resolve(root: Path, rel: str) -> Path:
+    """Resolve ``rel`` under ``root`` and refuse anything that escapes.
+
+    We deliberately resolve with ``strict=False`` so write/create paths that
+    don't exist yet still pass — the constraint is the *resolved* path must
+    live under ``root``. When a symlink is in play we also check the real
+    target via ``Path.resolve(strict=False)``.
+    """
+    root_resolved = root.resolve()
+    candidate = (root_resolved / rel).resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as exc:
+        raise SandboxViolationError(
+            f"path {rel!r} resolves outside the workspace root {root_resolved}"
+        ) from exc
+    return candidate
+
+
+# ── read_file ────────────────────────────────────────────────────────────────
+def make_read_file(root: Path) -> Callable[..., str]:
+    @mcp_tool(
+        name="read_file",
+        description="Read a UTF-8 text file from the workspace. Returns the file contents.",
+        params=[
+            ToolParam(name="path", type="string", description="Path relative to the workspace root")
+        ],
+    )
+    def read_file(path: str) -> str:
+        resolved = _resolve(root, path)
+        if not resolved.is_file():
+            raise FileNotFoundError(f"{path!r} not found or is not a regular file")
+        return resolved.read_text(encoding="utf-8", errors="replace")
+
+    return read_file
+
+
+# ── write_file ───────────────────────────────────────────────────────────────
+def make_write_file(root: Path) -> Callable[..., str]:
+    @mcp_tool(
+        name="write_file",
+        description=(
+            "Write or overwrite a UTF-8 text file in the workspace. Creates parent "
+            "directories as needed. Returns a short confirmation."
+        ),
+        params=[
+            ToolParam(
+                name="path", type="string", description="Path relative to the workspace root"
+            ),
+            ToolParam(name="content", type="string", description="Full file content to write"),
+        ],
+    )
+    def write_file(path: str, content: str) -> str:
+        resolved = _resolve(root, path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text(content, encoding="utf-8")
+        return f"wrote {len(content)} bytes to {path}"
+
+    return write_file
+
+
+# ── edit_file ────────────────────────────────────────────────────────────────
+def make_edit_file(root: Path) -> Callable[..., str]:
+    @mcp_tool(
+        name="edit_file",
+        description=(
+            "Replace a single, unambiguous occurrence of ``old_string`` with "
+            "``new_string`` in the named file. Refuses if ``old_string`` is "
+            "missing or appears more than once."
+        ),
+        params=[
+            ToolParam(
+                name="path", type="string", description="Path relative to the workspace root"
+            ),
+            ToolParam(name="old_string", type="string", description="Exact text to replace"),
+            ToolParam(name="new_string", type="string", description="Replacement text"),
+        ],
+    )
+    def edit_file(path: str, old_string: str, new_string: str) -> str:
+        resolved = _resolve(root, path)
+        if not resolved.is_file():
+            raise FileNotFoundError(f"{path!r} not found")
+        content = resolved.read_text(encoding="utf-8")
+        occurrences = content.count(old_string)
+        if occurrences == 0:
+            raise ValueError(f"old_string not found in {path!r}")
+        if occurrences > 1:
+            raise ValueError(
+                f"old_string appears {occurrences} times in {path!r} — "
+                "refuse ambiguous edits; include more surrounding context"
+            )
+        resolved.write_text(content.replace(old_string, new_string), encoding="utf-8")
+        return f"edited {path}"
+
+    return edit_file
+
+
+# ── run_bash ─────────────────────────────────────────────────────────────────
+async def _default_runner(cmd: list[str], cwd: str, timeout: float) -> tuple[int, bytes, bytes]:
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return 124, b"", f"timeout after {timeout}s".encode()
+    return proc.returncode or 0, stdout, stderr
+
+
+def make_run_bash(
+    root: Path,
+    *,
+    runner: BashRunner | None = None,
+    default_timeout: float = DEFAULT_BASH_TIMEOUT_SECONDS,
+    max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+) -> Callable[..., Awaitable[str]]:
+    run = runner or _default_runner
+
+    @mcp_tool(
+        name="run_bash",
+        description=(
+            "Run a bash command inside the workspace root. The command runs via "
+            "``bash -lc`` with ``cwd`` pinned to the workspace. Output is combined "
+            "stdout+stderr, truncated to a bounded length."
+        ),
+        params=[
+            ToolParam(name="command", type="string", description="Bash command line"),
+            ToolParam(
+                name="timeout_seconds",
+                type="integer",
+                description="Wall-clock limit",
+                required=False,
+            ),
+        ],
+    )
+    async def run_bash(command: str, timeout_seconds: int | float | None = None) -> str:
+        timeout = float(timeout_seconds) if timeout_seconds is not None else default_timeout
+        cwd = str(root.resolve())
+        rc, stdout, stderr = await run(["bash", "-lc", command], cwd, timeout)
+        body = stdout + (b"\n" + stderr if stderr else b"")
+        truncated = False
+        if len(body) > max_output_bytes:
+            body = body[:max_output_bytes]
+            truncated = True
+        text = body.decode(errors="replace")
+        if rc != 0:
+            text = f"(exit {rc})\n{text}"
+        if truncated:
+            text += f"\n[output truncated to {max_output_bytes} bytes]"
+        return text
+
+    return run_bash
+
+
+# ── glob_files ───────────────────────────────────────────────────────────────
+def make_glob_files(root: Path) -> Callable[..., str]:
+    @mcp_tool(
+        name="glob_files",
+        description=(
+            "List files matching a glob pattern, one per line, paths relative to "
+            "the workspace root. Use ``**/`` for recursive matching."
+        ),
+        params=[
+            ToolParam(name="pattern", type="string", description="Glob pattern (e.g. '**/*.py')"),
+        ],
+    )
+    def glob_files(pattern: str) -> str:
+        root_resolved = root.resolve()
+        matches = sorted(
+            str(p.relative_to(root_resolved)) for p in root_resolved.glob(pattern) if p.is_file()
+        )
+        if not matches:
+            return f"no matches for pattern {pattern!r}"
+        return "\n".join(matches)
+
+    return glob_files
+
+
+# ── grep_files ───────────────────────────────────────────────────────────────
+def make_grep_files(root: Path) -> Callable[..., str]:
+    @mcp_tool(
+        name="grep_files",
+        description=(
+            "Search files under the workspace for a Python-regex pattern. Returns "
+            "matching lines as ``path:lineno:line``. Optionally scoped to a glob."
+        ),
+        params=[
+            ToolParam(name="pattern", type="string", description="Python regex pattern"),
+            ToolParam(
+                name="glob",
+                type="string",
+                description="Glob filter (e.g. '*.py'); default scans all files",
+                required=False,
+            ),
+        ],
+    )
+    def grep_files(pattern: str, glob: str | None = None) -> str:
+        regex = re.compile(pattern)
+        root_resolved = root.resolve()
+        scan = root_resolved.rglob(glob) if glob else root_resolved.rglob("*")
+        hits: list[str] = []
+        for path in scan:
+            if not path.is_file():
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if regex.search(line):
+                    rel = path.relative_to(root_resolved)
+                    hits.append(f"{rel}:{lineno}:{line}")
+        if not hits:
+            return f"no match for {pattern!r}"
+        return "\n".join(hits)
+
+    return grep_files
+
+
+# ── default registry ────────────────────────────────────────────────────────
+def build_default_registry(root: Path, *, bash_runner: BashRunner | None = None) -> ToolRegistry:
+    """Return a ``ToolRegistry`` with all six built-in tools bound to ``root``.
+
+    Callers who want a different tool set can build their own registry and
+    register only what they need — this helper is the agent-loop default.
+    """
+    reg = ToolRegistry()
+    reg.register_from_function(make_read_file(root))
+    reg.register_from_function(make_write_file(root))
+    reg.register_from_function(make_edit_file(root))
+    reg.register_from_function(make_glob_files(root))
+    reg.register_from_function(make_grep_files(root))
+    reg.register_from_function(make_run_bash(root, runner=bash_runner))
+    return reg

--- a/conductor/tools/mcp.py
+++ b/conductor/tools/mcp.py
@@ -1,0 +1,191 @@
+"""Model Context Protocol — agent-agnostic tool declarations.
+
+Every tool is a ``ToolSpec`` (name + description + params + handler). A registry
+collects specs and emits provider-specific schemas (Anthropic ``tools`` dicts,
+OpenAI function-calling dicts, …) so one set of handlers serves every backend.
+
+The decorator ``@mcp_tool`` attaches a ``ToolSpec`` to a function so it can be
+registered in bulk without repeating metadata.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal, TypeVar
+
+__all__ = [
+    "ToolHandler",
+    "ToolParam",
+    "ToolRegistry",
+    "ToolRegistryError",
+    "ToolResult",
+    "ToolSpec",
+    "mcp_tool",
+]
+
+#: JSON-schema primitive types we model in tool params. Complex structures are
+#: represented as ``"object"`` or ``"array"``; a tool that needs nested validation
+#: should do it inside the handler.
+ParamType = Literal["string", "integer", "number", "boolean", "array", "object"]
+
+ToolHandler = Callable[..., Any] | Callable[..., Awaitable[Any]]
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class ToolRegistryError(Exception):
+    """Raised when the registry is asked to do something inconsistent."""
+
+
+@dataclass(slots=True, frozen=True)
+class ToolParam:
+    """A declared parameter on a tool."""
+
+    name: str
+    type: ParamType
+    description: str
+    required: bool = True
+    enum: list[Any] | None = None
+
+    def to_schema(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"type": self.type, "description": self.description}
+        if self.enum is not None:
+            out["enum"] = list(self.enum)
+        return out
+
+
+@dataclass(slots=True, frozen=True)
+class ToolResult:
+    """Outcome of a tool invocation.
+
+    ``is_error=True`` signals a handler failure in a form the model can see and
+    recover from; the exception is rendered into ``content`` so the agent can
+    decide what to do next.
+    """
+
+    content: str
+    is_error: bool = False
+
+
+def _noop_handler() -> None:
+    return None
+
+
+@dataclass(slots=True)
+class ToolSpec:
+    """Declarative tool definition used by every backend."""
+
+    name: str
+    description: str
+    params: list[ToolParam] = field(default_factory=list)
+    handler: ToolHandler = field(default=_noop_handler)
+
+    def _schema_body(self) -> dict[str, Any]:
+        properties: dict[str, Any] = {p.name: p.to_schema() for p in self.params}
+        required = [p.name for p in self.params if p.required]
+        return {"type": "object", "properties": properties, "required": required}
+
+    def to_anthropic(self) -> dict[str, Any]:
+        """Emit the dict the Anthropic SDK expects in ``messages.create(tools=[…])``."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self._schema_body(),
+        }
+
+    def to_openai(self) -> dict[str, Any]:
+        """Emit the dict the OpenAI SDK expects for function calling."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self._schema_body(),
+            },
+        }
+
+
+class ToolRegistry:
+    """Holds ``ToolSpec``s. Emits schemas. Dispatches calls."""
+
+    def __init__(self) -> None:
+        self._specs: dict[str, ToolSpec] = {}
+
+    def register(self, spec: ToolSpec) -> None:
+        if spec.name in self._specs:
+            raise ToolRegistryError(f"tool {spec.name!r} already registered")
+        self._specs[spec.name] = spec
+
+    def register_from_function(self, fn: Callable[..., Any]) -> None:
+        """Register a function previously decorated with ``@mcp_tool``."""
+        spec = getattr(fn, "__mcp_tool__", None)
+        if not isinstance(spec, ToolSpec):
+            raise ToolRegistryError(f"{fn!r} is not decorated with @mcp_tool — nothing to register")
+        self.register(spec)
+
+    def get(self, name: str) -> ToolSpec:
+        if name not in self._specs:
+            raise ToolRegistryError(f"unknown tool {name!r}")
+        return self._specs[name]
+
+    def names(self) -> list[str]:
+        return sorted(self._specs.keys())
+
+    def to_anthropic(self) -> list[dict[str, Any]]:
+        return [s.to_anthropic() for s in self._specs.values()]
+
+    def to_openai(self) -> list[dict[str, Any]]:
+        return [s.to_openai() for s in self._specs.values()]
+
+    async def invoke(self, name: str, arguments: dict[str, Any]) -> ToolResult:
+        """Call the handler for ``name`` with ``arguments``. Errors become ToolResult(is_error=True)."""
+        spec = self.get(name)  # raises ToolRegistryError on unknown — caller bug, not model bug
+        try:
+            result = spec.handler(**arguments)
+            if inspect.isawaitable(result):
+                result = await result
+            return ToolResult(content=_stringify(result), is_error=False)
+        except Exception as exc:
+            return ToolResult(content=f"{type(exc).__name__}: {exc}", is_error=True)
+
+
+def mcp_tool(
+    *,
+    description: str,
+    params: list[ToolParam] | None = None,
+    name: str | None = None,
+) -> Callable[[F], F]:
+    """Attach a ``ToolSpec`` to a function so a registry can pick it up.
+
+    The wrapped function is returned unchanged — we only stamp ``__mcp_tool__``
+    on it so the registry can inspect it later. Default ``name`` is the
+    function's own ``__name__``.
+    """
+
+    def decorator(fn: F) -> F:
+        fn_name = getattr(fn, "__name__", "tool") or "tool"
+        spec = ToolSpec(
+            name=name or fn_name,
+            description=description,
+            params=list(params or []),
+            handler=fn,
+        )
+        fn.__mcp_tool__ = spec  # type: ignore[attr-defined]
+        return fn
+
+    return decorator
+
+
+def _stringify(value: Any) -> str:
+    """Coerce a handler return to the string representation backends expect.
+
+    ``None`` becomes an empty string so empty returns don't surface as the
+    literal ``"None"`` to the model — which would be confusing context.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return repr(value)

--- a/tests/unit/test_tools_builtins.py
+++ b/tests/unit/test_tools_builtins.py
@@ -1,0 +1,241 @@
+"""Unit tests for conductor.tools.builtins — the sandboxed filesystem tools.
+
+Every tool must:
+ - refuse paths that escape the workspace (``..`` traversal, absolute paths outside root)
+ - accept paths relative to the workspace
+ - surface errors as ``ToolResult(is_error=True)`` rather than raising through the registry
+
+The bash tool uses a bounded subprocess runner injected by the test so we never
+touch the real shell here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from conductor.tools.builtins import (
+    SandboxViolationError,
+    build_default_registry,
+    make_edit_file,
+    make_glob_files,
+    make_grep_files,
+    make_read_file,
+    make_run_bash,
+    make_write_file,
+)
+
+
+# ── read_file ────────────────────────────────────────────────────────────────
+class TestReadFile:
+    def test_reads_file(self, tmp_path: Path) -> None:
+        (tmp_path / "hello.txt").write_text("hi there")
+        read = make_read_file(tmp_path)
+        assert read(path="hello.txt") == "hi there"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        read = make_read_file(tmp_path)
+        with pytest.raises(FileNotFoundError):
+            read(path="missing.txt")
+
+    def test_absolute_path_outside_root_rejected(self, tmp_path: Path) -> None:
+        read = make_read_file(tmp_path)
+        with pytest.raises(SandboxViolationError):
+            read(path="/etc/passwd")
+
+    def test_traversal_rejected(self, tmp_path: Path) -> None:
+        (tmp_path.parent / "secret.txt").write_text("nope")
+        read = make_read_file(tmp_path)
+        with pytest.raises(SandboxViolationError):
+            read(path="../secret.txt")
+
+    def test_symlink_escape_rejected(self, tmp_path: Path) -> None:
+        target = tmp_path.parent / "outside.txt"
+        target.write_text("nope")
+        (tmp_path / "link.txt").symlink_to(target)
+        read = make_read_file(tmp_path)
+        with pytest.raises(SandboxViolationError):
+            read(path="link.txt")
+
+
+# ── write_file ───────────────────────────────────────────────────────────────
+class TestWriteFile:
+    def test_writes_new_file(self, tmp_path: Path) -> None:
+        write = make_write_file(tmp_path)
+        write(path="a/b/c.txt", content="hello")
+        assert (tmp_path / "a/b/c.txt").read_text() == "hello"
+
+    def test_overwrites_existing(self, tmp_path: Path) -> None:
+        (tmp_path / "x").write_text("before")
+        write = make_write_file(tmp_path)
+        write(path="x", content="after")
+        assert (tmp_path / "x").read_text() == "after"
+
+    def test_traversal_rejected(self, tmp_path: Path) -> None:
+        write = make_write_file(tmp_path)
+        with pytest.raises(SandboxViolationError):
+            write(path="../escape.txt", content="x")
+
+
+# ── edit_file ────────────────────────────────────────────────────────────────
+class TestEditFile:
+    def test_single_replacement(self, tmp_path: Path) -> None:
+        (tmp_path / "f").write_text("alpha beta gamma")
+        edit = make_edit_file(tmp_path)
+        edit(path="f", old_string="beta", new_string="DELTA")
+        assert (tmp_path / "f").read_text() == "alpha DELTA gamma"
+
+    def test_ambiguous_match_rejected(self, tmp_path: Path) -> None:
+        (tmp_path / "f").write_text("x x")
+        edit = make_edit_file(tmp_path)
+        with pytest.raises(ValueError, match="appears 2 times"):
+            edit(path="f", old_string="x", new_string="y")
+
+    def test_old_string_not_found(self, tmp_path: Path) -> None:
+        (tmp_path / "f").write_text("abc")
+        edit = make_edit_file(tmp_path)
+        with pytest.raises(ValueError, match="not found"):
+            edit(path="f", old_string="zzz", new_string="y")
+
+    def test_traversal_rejected(self, tmp_path: Path) -> None:
+        edit = make_edit_file(tmp_path)
+        with pytest.raises(SandboxViolationError):
+            edit(path="../x", old_string="a", new_string="b")
+
+
+# ── run_bash ─────────────────────────────────────────────────────────────────
+class TestRunBash:
+    async def test_runs_and_returns_stdout(self, tmp_path: Path) -> None:
+        async def runner(cmd: list[str], cwd: str, timeout: float) -> tuple[int, bytes, bytes]:
+            assert cwd == str(tmp_path)
+            assert cmd[-1] == "echo hi"
+            return 0, b"hi\n", b""
+
+        bash = make_run_bash(tmp_path, runner=runner)
+        out = await bash(command="echo hi")
+        assert "hi" in out
+
+    async def test_non_zero_exit_reports_rc(self, tmp_path: Path) -> None:
+        async def runner(cmd: list[str], cwd: str, timeout: float) -> tuple[int, bytes, bytes]:
+            return 2, b"", b"oops"
+
+        bash = make_run_bash(tmp_path, runner=runner)
+        out = await bash(command="false")
+        assert "exit 2" in out
+        assert "oops" in out
+
+    async def test_timeout_honoured(self, tmp_path: Path) -> None:
+        async def runner(cmd: list[str], cwd: str, timeout: float) -> tuple[int, bytes, bytes]:
+            assert timeout == 5
+            return 0, b"", b""
+
+        bash = make_run_bash(tmp_path, runner=runner, default_timeout=10)
+        await bash(command="true", timeout_seconds=5)
+
+    async def test_default_timeout_applied(self, tmp_path: Path) -> None:
+        seen: list[float] = []
+
+        async def runner(cmd: list[str], cwd: str, timeout: float) -> tuple[int, bytes, bytes]:
+            seen.append(timeout)
+            return 0, b"", b""
+
+        bash = make_run_bash(tmp_path, runner=runner, default_timeout=42)
+        await bash(command="true")
+        assert seen == [42]
+
+    async def test_output_truncated(self, tmp_path: Path) -> None:
+        async def runner(cmd: list[str], cwd: str, timeout: float) -> tuple[int, bytes, bytes]:
+            return 0, b"x" * 10_000, b""
+
+        bash = make_run_bash(tmp_path, runner=runner, max_output_bytes=100)
+        out = await bash(command="yes")
+        assert "truncated" in out.lower()
+
+
+# ── glob_files ───────────────────────────────────────────────────────────────
+class TestGlobFiles:
+    def test_finds_matches(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").touch()
+        (tmp_path / "b.py").touch()
+        (tmp_path / "c.txt").touch()
+        glob = make_glob_files(tmp_path)
+        result = glob(pattern="*.py")
+        assert sorted(result.splitlines()) == ["a.py", "b.py"]
+
+    def test_recursive(self, tmp_path: Path) -> None:
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub/nested.py").touch()
+        glob = make_glob_files(tmp_path)
+        result = glob(pattern="**/*.py")
+        assert "sub/nested.py" in result
+
+    def test_empty_is_explicit(self, tmp_path: Path) -> None:
+        glob = make_glob_files(tmp_path)
+        result = glob(pattern="*.nonesuch")
+        assert "no matches" in result.lower()
+
+
+# ── grep_files ───────────────────────────────────────────────────────────────
+class TestGrepFiles:
+    def test_finds_line(self, tmp_path: Path) -> None:
+        (tmp_path / "f.py").write_text("def foo():\n    pass\n")
+        grep = make_grep_files(tmp_path)
+        result = grep(pattern=r"def foo")
+        assert "f.py" in result
+
+    def test_scoped_glob(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("needle")
+        (tmp_path / "a.md").write_text("needle")
+        grep = make_grep_files(tmp_path)
+        result = grep(pattern="needle", glob="*.py")
+        assert "a.py" in result
+        assert "a.md" not in result
+
+    def test_no_match_is_explicit(self, tmp_path: Path) -> None:
+        (tmp_path / "f.py").write_text("unrelated")
+        grep = make_grep_files(tmp_path)
+        result = grep(pattern="zzz")
+        assert "no match" in result.lower()
+
+
+# ── registry assembly ───────────────────────────────────────────────────────
+class TestBuildDefaultRegistry:
+    def test_registers_all_six_tools(self, tmp_path: Path) -> None:
+        reg = build_default_registry(tmp_path)
+        assert set(reg.names()) == {
+            "read_file",
+            "write_file",
+            "edit_file",
+            "run_bash",
+            "glob_files",
+            "grep_files",
+        }
+
+    def test_each_tool_has_description_and_params(self, tmp_path: Path) -> None:
+        reg = build_default_registry(tmp_path)
+        for name in reg.names():
+            spec = reg.get(name)
+            assert spec.description, f"{name} missing description"
+            # Every real tool takes at least one argument.
+            assert spec.params, f"{name} declared zero params"
+
+    def test_emits_valid_anthropic_schemas(self, tmp_path: Path) -> None:
+        reg = build_default_registry(tmp_path)
+        schemas = reg.to_anthropic()
+        for s in schemas:
+            assert set(s.keys()) == {"name", "description", "input_schema"}
+            assert s["input_schema"]["type"] == "object"
+
+    async def test_invoke_through_registry_end_to_end(self, tmp_path: Path) -> None:
+        (tmp_path / "hi.txt").write_text("payload")
+        reg = build_default_registry(tmp_path)
+        result = await reg.invoke("read_file", {"path": "hi.txt"})
+        assert result.content == "payload"
+        assert result.is_error is False
+
+    async def test_sandbox_violation_surfaces_as_tool_error(self, tmp_path: Path) -> None:
+        reg = build_default_registry(tmp_path)
+        result = await reg.invoke("read_file", {"path": "/etc/passwd"})
+        assert result.is_error is True
+        assert "Sandbox" in result.content or "sandbox" in result.content

--- a/tests/unit/test_tools_mcp.py
+++ b/tests/unit/test_tools_mcp.py
@@ -1,0 +1,208 @@
+"""Unit tests for conductor.tools.mcp — the Model Context Protocol abstraction.
+
+The abstraction exists so tool *definitions* live in one place (a ``ToolSpec``)
+and *emit* provider-specific schemas (Anthropic, OpenAI) on demand. Handlers
+run through the registry so every backend uses the same implementations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from conductor.tools.mcp import (
+    ToolParam,
+    ToolRegistry,
+    ToolRegistryError,
+    ToolResult,
+    ToolSpec,
+    mcp_tool,
+)
+
+
+def _echo_handler(message: str) -> str:
+    return f"echo: {message}"
+
+
+async def _async_echo_handler(message: str) -> str:
+    return f"async-echo: {message}"
+
+
+def _echo_spec() -> ToolSpec:
+    return ToolSpec(
+        name="echo",
+        description="Return the message prefixed with 'echo:'",
+        params=[ToolParam(name="message", type="string", description="Input text")],
+        handler=_echo_handler,
+    )
+
+
+class TestToolSpecAnthropicSchema:
+    """ToolSpec.to_anthropic must match Anthropic tool_use shape exactly."""
+
+    def test_basic_string_param(self) -> None:
+        schema = _echo_spec().to_anthropic()
+        assert schema["name"] == "echo"
+        assert schema["description"] == "Return the message prefixed with 'echo:'"
+        assert schema["input_schema"]["type"] == "object"
+        assert schema["input_schema"]["properties"] == {
+            "message": {"type": "string", "description": "Input text"},
+        }
+        assert schema["input_schema"]["required"] == ["message"]
+
+    def test_optional_param_not_in_required(self) -> None:
+        spec = ToolSpec(
+            name="t",
+            description="desc",
+            params=[
+                ToolParam(name="a", type="string", description="required"),
+                ToolParam(name="b", type="integer", description="optional", required=False),
+            ],
+            handler=lambda **_: "x",
+        )
+        schema = spec.to_anthropic()
+        assert schema["input_schema"]["required"] == ["a"]
+        assert set(schema["input_schema"]["properties"].keys()) == {"a", "b"}
+
+    def test_enum_field_is_emitted(self) -> None:
+        spec = ToolSpec(
+            name="t",
+            description="desc",
+            params=[
+                ToolParam(name="color", type="string", description="c", enum=["red", "blue"]),
+            ],
+            handler=lambda **_: "x",
+        )
+        schema = spec.to_anthropic()
+        assert schema["input_schema"]["properties"]["color"]["enum"] == ["red", "blue"]
+
+
+class TestToolSpecOpenAISchema:
+    """ToolSpec.to_openai must match OpenAI function-calling shape exactly."""
+
+    def test_basic(self) -> None:
+        schema = _echo_spec().to_openai()
+        assert schema["type"] == "function"
+        fn = schema["function"]
+        assert fn["name"] == "echo"
+        assert fn["description"] == "Return the message prefixed with 'echo:'"
+        assert fn["parameters"]["type"] == "object"
+        assert fn["parameters"]["required"] == ["message"]
+
+
+class TestToolRegistry:
+    def test_register_and_get(self) -> None:
+        reg = ToolRegistry()
+        reg.register(_echo_spec())
+        assert reg.get("echo").name == "echo"
+
+    def test_register_duplicate_rejected(self) -> None:
+        reg = ToolRegistry()
+        reg.register(_echo_spec())
+        with pytest.raises(ToolRegistryError, match="already registered"):
+            reg.register(_echo_spec())
+
+    def test_get_unknown_rejected(self) -> None:
+        reg = ToolRegistry()
+        with pytest.raises(ToolRegistryError, match="unknown tool"):
+            reg.get("nope")
+
+    def test_names_sorted(self) -> None:
+        reg = ToolRegistry()
+        reg.register(ToolSpec(name="zulu", description="z", params=[], handler=lambda: "z"))
+        reg.register(ToolSpec(name="alpha", description="a", params=[], handler=lambda: "a"))
+        assert reg.names() == ["alpha", "zulu"]
+
+    def test_to_anthropic_returns_list(self) -> None:
+        reg = ToolRegistry()
+        reg.register(_echo_spec())
+        schemas = reg.to_anthropic()
+        assert len(schemas) == 1
+        assert schemas[0]["name"] == "echo"
+
+    def test_to_openai_returns_list(self) -> None:
+        reg = ToolRegistry()
+        reg.register(_echo_spec())
+        schemas = reg.to_openai()
+        assert len(schemas) == 1
+        assert schemas[0]["function"]["name"] == "echo"
+
+
+class TestToolRegistryInvoke:
+    async def test_invokes_sync_handler(self) -> None:
+        reg = ToolRegistry()
+        reg.register(_echo_spec())
+        result = await reg.invoke("echo", {"message": "hi"})
+        assert result == ToolResult(content="echo: hi", is_error=False)
+
+    async def test_invokes_async_handler(self) -> None:
+        reg = ToolRegistry()
+        reg.register(
+            ToolSpec(
+                name="aecho",
+                description="async echo",
+                params=[ToolParam(name="message", type="string", description="m")],
+                handler=_async_echo_handler,
+            )
+        )
+        result = await reg.invoke("aecho", {"message": "hi"})
+        assert result == ToolResult(content="async-echo: hi", is_error=False)
+
+    async def test_handler_exception_returns_error_result(self) -> None:
+        def boom(**_: object) -> str:
+            raise ValueError("kaboom")
+
+        reg = ToolRegistry()
+        reg.register(
+            ToolSpec(name="boom", description="fails", params=[], handler=boom),
+        )
+        result = await reg.invoke("boom", {})
+        assert result.is_error is True
+        assert "ValueError" in result.content
+        assert "kaboom" in result.content
+
+    async def test_unknown_tool_raises(self) -> None:
+        reg = ToolRegistry()
+        with pytest.raises(ToolRegistryError, match="unknown tool"):
+            await reg.invoke("nope", {})
+
+
+class TestMcpToolDecorator:
+    def test_decorator_attaches_spec(self) -> None:
+        @mcp_tool(
+            name="greet",
+            description="say hi",
+            params=[ToolParam(name="who", type="string", description="target")],
+        )
+        def greet(who: str) -> str:
+            return f"hi {who}"
+
+        spec = getattr(greet, "__mcp_tool__", None)
+        assert isinstance(spec, ToolSpec)
+        assert spec.name == "greet"
+        assert spec.description == "say hi"
+        assert spec.handler is greet
+
+    def test_decorator_name_defaults_to_function_name(self) -> None:
+        @mcp_tool(description="no name given", params=[])
+        def auto() -> str:
+            return "x"
+
+        spec = auto.__mcp_tool__
+        assert spec.name == "auto"
+
+    def test_registry_register_from_function_accepts_decorated(self) -> None:
+        @mcp_tool(description="d", params=[])
+        def fn() -> str:
+            return "x"
+
+        reg = ToolRegistry()
+        reg.register_from_function(fn)
+        assert reg.get("fn").handler is fn
+
+    def test_register_from_function_rejects_undecorated(self) -> None:
+        def plain() -> str:
+            return "x"
+
+        reg = ToolRegistry()
+        with pytest.raises(ToolRegistryError, match="not decorated"):
+            reg.register_from_function(plain)


### PR DESCRIPTION
## Summary

Delivers the core of **#74 (MCP tool layer for agent-agnostic backends)** and provides the sandboxed built-ins every downstream backend will share.

- `conductor/tools/mcp.py` — `ToolParam` / `ToolSpec` / `ToolRegistry` / `ToolResult` plus `@mcp_tool` decorator. One `ToolSpec` emits both Anthropic `tool_use` dicts and OpenAI function-calling dicts — DRY across providers.
- `conductor/tools/builtins.py` — `read_file`, `write_file`, `edit_file`, `glob_files`, `grep_files`, `run_bash`. Every tool factory binds a workspace root; path resolution rejects `..` escapes, absolute-path escapes, and symlinks whose targets resolve outside root. `run_bash` takes an injectable `BashRunner` so tests don't spawn real subprocesses.
- 46 unit tests covering schema shapes, registry behaviour, and every sandbox edge-case (traversal, symlink escape, ambiguous edits, timeouts, output truncation).

## Why this lands first

Foundation for:
- **#61 (AgentLoopBackend)** — the in-flight branch `feat/issue-61-agent-loop-backend` hardcodes Anthropic-shaped `TOOL_SCHEMAS` and embeds tool dispatch in the backend class. A follow-up can refactor that branch to consume this registry, eliminating the Anthropic coupling and getting the same handlers for free.
- **#75 (OllamaBackend)** — gets tool use via the same registry, emitting OpenAI schemas.
- **#71 (event-driven state machine)** — the registry becomes the natural emission point for `ToolUse` / `Observation` events.

## Design notes

- **Why `ToolSpec` + registry instead of inline dicts:** #74 asks for an abstraction that yields provider-specific schemas on demand. Per the user's principles: DRY (one spec, N schemas), Agent Agnostic (tools don't know which backend invoked them), Easiness to Change (add OpenAI/Gemini by adding an emitter method, not by touching tool code).
- **Why factory functions (`make_read_file(root)`):** Reversibility — swap a tool for a test double or per-repo variant without subclassing. Orthogonality — tool logic doesn't know about the registry or loop.
- **Why errors become `ToolResult(is_error=True)`:** the agent must see and recover from handler failures. Raising would abort the loop; a structured error gives the model a chance to try a different path.
- **Sandbox strategy:** resolve the path, then `Path.relative_to(root)` — works for non-existent write targets and catches symlink escapes (`.resolve()` follows links).

## Test plan

- [x] 46 new unit tests pass locally
- [x] `ruff check` + `ruff format --check` clean on new files
- [x] `mypy --strict` clean on `conductor/tools/`
- [x] Full suite: 559 passed, 1 pre-existing flaky test unrelated to this PR
- [ ] CI green

## Coordination

Parallel work on `feat/issue-61-agent-loop-backend` adds the multi-turn loop. This PR and that one touch disjoint files (`conductor/tools/` vs `conductor/backends/agent_loop.py`) so they merge cleanly in either order. After both land, a small follow-up can replace the hardcoded `TOOL_SCHEMAS` / `_dispatch_tool` in `agent_loop.py` with `build_default_registry(workspace).to_anthropic()` and `registry.invoke(name, args)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)