### PR TITLE
feat(config): fleet.yaml + staging branch workflow (#65, #67)

### DIFF
--- a/conductor/config/fleet.py
+++ b/conductor/config/fleet.py
@@ -1,0 +1,193 @@
+"""Declarative multi-repo fleet configuration.
+
+``fleet.yaml`` is a separate file from ``conductor.yaml``: it lists the repos
+the fleet manages plus shared defaults. The priority order is explicit path →
+``CONDUCTOR_FLEET_CONFIG`` env var → ``./fleet.yaml`` → ``~/.conductor/fleet.yaml``.
+The CLI and the remote-dispatch workflow both read from the same manifest so
+"which repos are we managing" has exactly one source of truth.
+
+See GitHub issue #67 for the full schema spec.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+__all__ = [
+    "FleetDefaults",
+    "FleetManifest",
+    "FleetManifestError",
+    "FleetRepoEntry",
+    "load_fleet_manifest",
+]
+
+
+class FleetManifestError(RuntimeError):
+    """Raised when a fleet manifest can't be located or parsed."""
+
+
+class FleetDefaults(BaseModel):
+    """Fleet-wide defaults applied to every repo unless overridden."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    auto_promote_staging: bool = False
+    discovery_interval_seconds: int = Field(300, ge=10)
+    default_slots: int = Field(2, ge=1, le=32)
+    default_budget_per_story: float = Field(0.50, ge=0)
+    default_pr_target_branch: str = "staging"
+    default_pr_fallback_to_default: bool = True
+    default_watch_labels: list[str] = Field(default_factory=list)
+
+
+class FleetRepoEntry(BaseModel):
+    """One repo managed by the fleet. Any field left unset inherits from FleetDefaults."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    org: str
+    slots: int | None = Field(None, ge=1, le=32)
+    budget_per_story: float | None = Field(None, ge=0)
+    pr_target_branch: str | None = None
+    pr_fallback_to_default: bool | None = None
+    watch_labels: list[str] | None = None
+    enabled: bool = True
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.org}/{self.name}"
+
+
+class _ResolvedRepo(BaseModel):
+    """A FleetRepoEntry with all defaults folded in — guaranteed non-None fields.
+
+    Returned from ``FleetManifest.resolve()`` so callers never have to check for
+    ``None`` on inheritable fields.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    org: str
+    slots: int
+    budget_per_story: float
+    pr_target_branch: str
+    pr_fallback_to_default: bool
+    watch_labels: list[str]
+    enabled: bool
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.org}/{self.name}"
+
+
+class FleetManifest(BaseModel):
+    """Top-level ``fleet.yaml`` schema."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1] = 1
+    fleet: FleetDefaults
+    repos: list[FleetRepoEntry] = Field(default_factory=list)
+
+    @field_validator("repos")
+    @classmethod
+    def _reject_duplicate_names(cls, repos: list[FleetRepoEntry]) -> list[FleetRepoEntry]:
+        seen: set[str] = set()
+        for r in repos:
+            if r.name in seen:
+                raise ValueError(f"duplicate repo entry: {r.name!r}")
+            seen.add(r.name)
+        return repos
+
+    def active_repos(self) -> list[FleetRepoEntry]:
+        return [r for r in self.repos if r.enabled]
+
+    def resolve(self, name: str) -> _ResolvedRepo:
+        """Return the repo with all defaults folded in.
+
+        Raises ``KeyError`` when ``name`` isn't in the manifest.
+        """
+        entry = next((r for r in self.repos if r.name == name), None)
+        if entry is None:
+            raise KeyError(name)
+        d = self.fleet
+        return _ResolvedRepo(
+            name=entry.name,
+            org=entry.org,
+            slots=entry.slots if entry.slots is not None else d.default_slots,
+            budget_per_story=(
+                entry.budget_per_story
+                if entry.budget_per_story is not None
+                else d.default_budget_per_story
+            ),
+            pr_target_branch=entry.pr_target_branch or d.default_pr_target_branch,
+            pr_fallback_to_default=(
+                entry.pr_fallback_to_default
+                if entry.pr_fallback_to_default is not None
+                else d.default_pr_fallback_to_default
+            ),
+            watch_labels=(
+                list(entry.watch_labels)
+                if entry.watch_labels is not None
+                else list(d.default_watch_labels)
+            ),
+            enabled=entry.enabled,
+        )
+
+
+_DEFAULT_HOME_SUBPATH = Path(".conductor") / "fleet.yaml"
+_CWD_FILENAME = "fleet.yaml"
+_ENV_VAR = "CONDUCTOR_FLEET_CONFIG"
+
+
+def _candidate_paths() -> list[Path]:
+    """Resolution order: env var → ./fleet.yaml → ~/.conductor/fleet.yaml."""
+    paths: list[Path] = []
+    env = os.environ.get(_ENV_VAR)
+    if env:
+        paths.append(Path(env))
+    paths.append(Path.cwd() / _CWD_FILENAME)
+    home = os.environ.get("HOME")
+    if home:
+        paths.append(Path(home) / _DEFAULT_HOME_SUBPATH)
+    return paths
+
+
+def load_fleet_manifest(*, path: Path | None = None) -> FleetManifest:
+    """Load and validate a fleet manifest.
+
+    When ``path`` is given, load it directly (raises ``FleetManifestError`` if
+    missing). Otherwise walk the candidate paths and use the first one that
+    exists.
+    """
+    if path is not None:
+        if not path.is_file():
+            raise FleetManifestError(f"fleet manifest not found: {path}")
+        return _load_from_file(path)
+
+    for candidate in _candidate_paths():
+        if candidate.is_file():
+            return _load_from_file(candidate)
+
+    raise FleetManifestError("no fleet.yaml found in CONDUCTOR_FLEET_CONFIG, cwd, or ~/.conductor")
+
+
+def _load_from_file(path: Path) -> FleetManifest:
+    try:
+        raw: Any = yaml.safe_load(path.read_text())
+    except yaml.YAMLError as e:
+        raise FleetManifestError(f"{path} is not valid YAML: {e}") from e
+    if not isinstance(raw, dict):
+        raise FleetManifestError(f"{path} must contain a mapping at top level")
+    try:
+        return FleetManifest.model_validate(raw)
+    except Exception as e:  # pydantic ValidationError or unexpected
+        raise FleetManifestError(f"{path} is not a valid fleet manifest: {e}") from e

--- a/conductor/gh/client.py
+++ b/conductor/gh/client.py
@@ -159,6 +159,27 @@ class GitHubClient:
         out = await self._gh(*argv)
         return out.decode().strip()
 
+    async def list_branches(self, repo: str) -> list[str]:
+        """Return every branch name on the remote, paginated across all pages.
+
+        Used by the executor to decide whether a configured ``pr_target_branch``
+        (e.g. ``staging``) actually exists before we base a PR on it.
+        """
+        self._validate_repo(repo)
+        out = await self._gh("api", f"repos/{repo}/branches", "--paginate")
+        payload = json.loads(out) if out else []
+        return [str(b.get("name", "")) for b in payload if b.get("name")]
+
+    async def get_default_branch(self, repo: str) -> str:
+        """Return the repo's default branch (e.g. ``main`` or ``master``)."""
+        self._validate_repo(repo)
+        out = await self._gh("api", f"repos/{repo}")
+        payload = json.loads(out) if out else {}
+        branch = payload.get("default_branch")
+        if not branch:
+            raise GhCliError(f"repos/{repo} response missing default_branch field")
+        return str(branch)
+
     async def create_pull_request(
         self,
         repo: str,

--- a/conductor/gh/executor.py
+++ b/conductor/gh/executor.py
@@ -64,6 +64,13 @@ class _GitHubProto(Protocol):
     ) -> Any: ...
 
 
+class _GitHubBranchProto(Protocol):
+    """Minimal protocol for branch resolution — used by resolve_pr_target_branch."""
+
+    async def list_branches(self, repo: str) -> list[str]: ...
+    async def get_default_branch(self, repo: str) -> str: ...
+
+
 class _WorkspaceProto(Protocol):
     async def ensure_clone(self, repo: str, *, task_id: str) -> Any: ...
     async def create_branch(
@@ -426,6 +433,37 @@ class IssueExecutor:
             return default
         value = getattr(overrides, attr, None)
         return value if value is not None else default
+
+    @staticmethod
+    async def resolve_pr_target_branch(
+        github: _GitHubBranchProto,
+        repo: str,
+        *,
+        preferred: str,
+        fallback_to_default: bool,
+    ) -> str:
+        """Pick the branch a PR should target.
+
+        If ``preferred`` exists on the remote, use it. Otherwise:
+          * ``fallback_to_default=True``  → silently fall back to the default branch.
+          * ``fallback_to_default=False`` → raise ``IssueExecutionError`` so the
+            operator notices a misconfigured fleet manifest early.
+
+        Skips the branch listing when ``preferred`` already is the default
+        (common for CONDUCTOR itself merging directly to ``main``).
+        """
+        default = await github.get_default_branch(repo)
+        if preferred == default:
+            return preferred
+        branches = await github.list_branches(repo)
+        if preferred in branches:
+            return preferred
+        if not fallback_to_default:
+            raise IssueExecutionError(
+                f"configured pr_target_branch {preferred!r} not found on {repo!r} "
+                "and fallback is disabled"
+            )
+        return default
 
     async def _refine_diff(
         self,

--- a/fleet.yaml
+++ b/fleet.yaml
@@ -1,0 +1,56 @@
+# CONDUCTOR fleet manifest — single source of truth for which repos the fleet
+# manages, their slot limits, budget caps, PR targets, and the labels we watch.
+#
+# Resolution order when no explicit path is given:
+#   1. $CONDUCTOR_FLEET_CONFIG
+#   2. ./fleet.yaml           ← this file, when checked out at the project root
+#   3. ~/.conductor/fleet.yaml
+#
+# Inheritance: any field left unset on a repo entry inherits the matching
+# `default_*` from the `fleet:` block.
+version: 1
+
+fleet:
+  name: D-sorganization Fleet
+  auto_promote_staging: false        # flip on once the PR auto-merge daemon lands (#68)
+  discovery_interval_seconds: 300
+  default_slots: 2
+  default_budget_per_story: 0.50
+  default_pr_target_branch: staging
+  default_pr_fallback_to_default: true
+  default_watch_labels:
+    - "gaai:deliver"
+    - "conductor:ready"
+
+repos:
+  - name: AffineDrift
+    org: D-sorganization
+
+  - name: UpstreamDrift
+    org: D-sorganization
+    slots: 3
+    budget_per_story: 0.75              # larger repo, higher cap
+
+  - name: Gasification_Model
+    org: D-sorganization
+
+  - name: Tools
+    org: D-sorganization
+    slots: 3
+
+  - name: Worksheet-Workshop
+    org: D-sorganization
+
+  - name: Repository_Management
+    org: D-sorganization
+    slots: 1
+    budget_per_story: 0.30
+    pr_target_branch: main              # no staging branch here
+    watch_labels: ["conductor:ready"]
+
+  - name: CONDUCTOR
+    org: D-sorganization
+    slots: 1
+    budget_per_story: 0.75
+    pr_target_branch: main              # CONDUCTOR itself merges directly to main
+    watch_labels: ["conductor:ready"]

--- a/tests/unit/test_executor_pr_target.py
+++ b/tests/unit/test_executor_pr_target.py
@@ -1,0 +1,118 @@
+"""Tests for IssueExecutor's pr_target_branch + fallback logic (#65).
+
+The executor must base PRs on the repo's configured target branch (default
+``staging``). If the branch doesn't exist on the remote and fallback is
+enabled, it quietly switches to the default branch; if fallback is disabled,
+it raises so the operator sees the misconfiguration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from conductor.gh.client import Issue, PullRequest
+from conductor.gh.executor import IssueExecutionError, IssueExecutor
+
+
+class _GhStub:
+    def __init__(
+        self,
+        *,
+        branches: list[str] | None = None,
+        default_branch: str = "main",
+    ) -> None:
+        self._branches = branches or ["main"]
+        self._default = default_branch
+        self.create_calls: list[dict[str, Any]] = []
+        self.list_branches_calls = 0
+
+    async def get_issue(self, repo: str, number: int) -> Issue:
+        return Issue(
+            number=number,
+            title="test",
+            body="body",
+            state="OPEN",
+            labels=[],
+            url="https://example/issues/1",
+        )
+
+    async def list_branches(self, repo: str) -> list[str]:
+        self.list_branches_calls += 1
+        return list(self._branches)
+
+    async def get_default_branch(self, repo: str) -> str:
+        return self._default
+
+    async def create_pull_request(
+        self,
+        repo: str,
+        *,
+        head: str,
+        base: str,
+        title: str,
+        body: str,
+        draft: bool = True,
+    ) -> PullRequest:
+        self.create_calls.append(
+            {"repo": repo, "head": head, "base": base, "title": title, "draft": draft}
+        )
+        return PullRequest(number=1, url="https://example/pull/1", draft=draft)
+
+
+class _WorkspaceStub:
+    async def ensure_clone(self, repo: str, *, task_id: str) -> Any:
+        return "/tmp/ws"
+
+    async def create_branch(
+        self, repo: str, branch: str, *, base: str = "main", task_id: str
+    ) -> None:
+        self.last_base = base
+
+    async def apply_diff(self, repo: str, diff: str, *, task_id: str) -> None: ...
+
+    async def commit_and_push(
+        self, repo: str, *, branch: str, message: str, task_id: str
+    ) -> None: ...
+
+
+class _BackendStub:
+    async def complete(self, messages: Any, *, model: str, **_: Any) -> Any:
+        class _R:
+            content = '{"plan":"p","diff":""}'
+
+        return _R()
+
+
+class TestResolvePrTargetBranch:
+    async def test_uses_configured_branch_when_it_exists(self) -> None:
+        gh = _GhStub(branches=["main", "staging"])
+        target = await IssueExecutor.resolve_pr_target_branch(
+            gh, "acme/foo", preferred="staging", fallback_to_default=True
+        )
+        assert target == "staging"
+        assert gh.list_branches_calls == 1
+
+    async def test_falls_back_when_branch_missing(self) -> None:
+        gh = _GhStub(branches=["main"], default_branch="main")
+        target = await IssueExecutor.resolve_pr_target_branch(
+            gh, "acme/foo", preferred="staging", fallback_to_default=True
+        )
+        assert target == "main"
+
+    async def test_fallback_disabled_raises(self) -> None:
+        gh = _GhStub(branches=["main"])
+        with pytest.raises(IssueExecutionError, match="staging"):
+            await IssueExecutor.resolve_pr_target_branch(
+                gh, "acme/foo", preferred="staging", fallback_to_default=False
+            )
+
+    async def test_preferred_is_default_branch_skips_list(self) -> None:
+        """Optimisation: if preferred == default, no branch listing needed."""
+        gh = _GhStub(branches=["main"], default_branch="main")
+        target = await IssueExecutor.resolve_pr_target_branch(
+            gh, "acme/foo", preferred="main", fallback_to_default=True
+        )
+        assert target == "main"
+        assert gh.list_branches_calls == 0

--- a/tests/unit/test_fleet_config.py
+++ b/tests/unit/test_fleet_config.py
@@ -1,0 +1,275 @@
+"""Unit tests for conductor.config.fleet — declarative multi-repo fleet config.
+
+``fleet.yaml`` is a separate file from ``conductor.yaml``: it lists the repos
+managed by the fleet plus shared defaults, and is loaded via a priority order
+(explicit path → CWD → ``~/.conductor/fleet.yaml`` → env var).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from conductor.config.fleet import (
+    FleetDefaults,
+    FleetManifest,
+    FleetManifestError,
+    FleetRepoEntry,
+    load_fleet_manifest,
+)
+
+
+def _write(path: Path, body: str) -> Path:
+    path.write_text(dedent(body).lstrip())
+    return path
+
+
+class TestFleetRepoEntry:
+    def test_raw_fields_are_none_when_unset(self) -> None:
+        """Unset inheritable fields stay ``None`` until resolve() folds in defaults."""
+        entry = FleetRepoEntry.model_validate({"name": "Foo", "org": "acme"})
+        assert entry.name == "Foo"
+        assert entry.org == "acme"
+        assert entry.slots is None
+        assert entry.pr_target_branch is None
+        assert entry.pr_fallback_to_default is None
+        assert entry.watch_labels is None
+        assert entry.budget_per_story is None
+        # ``enabled`` is not inheritable — it's a per-repo decision.
+        assert entry.enabled is True
+        assert entry.full_name == "acme/Foo"
+
+    def test_full_name_joins(self) -> None:
+        entry = FleetRepoEntry.model_validate({"name": "Bar", "org": "acme"})
+        assert entry.full_name == "acme/Bar"
+
+    def test_rejects_missing_org(self) -> None:
+        with pytest.raises(ValueError):
+            FleetRepoEntry.model_validate({"name": "Foo"})
+
+    def test_rejects_slot_below_one(self) -> None:
+        with pytest.raises(ValueError):
+            FleetRepoEntry.model_validate({"name": "Foo", "org": "acme", "slots": 0})
+
+    def test_per_repo_overrides_applied(self) -> None:
+        entry = FleetRepoEntry.model_validate(
+            {
+                "name": "Foo",
+                "org": "acme",
+                "slots": 5,
+                "pr_target_branch": "main",
+                "pr_fallback_to_default": False,
+                "enabled": False,
+                "watch_labels": ["deliver"],
+                "budget_per_story": 1.50,
+            }
+        )
+        assert entry.slots == 5
+        assert entry.pr_target_branch == "main"
+        assert entry.pr_fallback_to_default is False
+        assert entry.enabled is False
+        assert entry.watch_labels == ["deliver"]
+        assert entry.budget_per_story == 1.50
+
+
+class TestFleetManifestValidation:
+    def test_happy_path_parses(self) -> None:
+        manifest = FleetManifest.model_validate(
+            {
+                "version": 1,
+                "fleet": {"name": "Test Fleet"},
+                "repos": [
+                    {"name": "R1", "org": "a"},
+                    {"name": "R2", "org": "a", "enabled": False},
+                ],
+            }
+        )
+        assert manifest.version == 1
+        assert manifest.fleet.name == "Test Fleet"
+        assert len(manifest.repos) == 2
+
+    def test_active_repos_filters_disabled(self) -> None:
+        manifest = FleetManifest.model_validate(
+            {
+                "version": 1,
+                "fleet": {"name": "f"},
+                "repos": [
+                    {"name": "R1", "org": "a", "enabled": True},
+                    {"name": "R2", "org": "a", "enabled": False},
+                    {"name": "R3", "org": "a"},
+                ],
+            }
+        )
+        active = manifest.active_repos()
+        assert [r.name for r in active] == ["R1", "R3"]
+
+    def test_duplicate_repo_names_rejected(self) -> None:
+        with pytest.raises(ValueError, match="duplicate"):
+            FleetManifest.model_validate(
+                {
+                    "version": 1,
+                    "fleet": {"name": "f"},
+                    "repos": [
+                        {"name": "R1", "org": "a"},
+                        {"name": "R1", "org": "b"},
+                    ],
+                }
+            )
+
+    def test_version_must_be_one(self) -> None:
+        with pytest.raises(ValueError):
+            FleetManifest.model_validate(
+                {
+                    "version": 99,
+                    "fleet": {"name": "f"},
+                    "repos": [],
+                }
+            )
+
+    def test_defaults_apply_to_repos_on_lookup(self) -> None:
+        manifest = FleetManifest.model_validate(
+            {
+                "version": 1,
+                "fleet": {
+                    "name": "f",
+                    "default_slots": 4,
+                    "default_pr_target_branch": "trunk",
+                    "default_budget_per_story": "0.25",
+                    "default_watch_labels": ["conductor:ready"],
+                },
+                "repos": [
+                    {"name": "R1", "org": "a"},  # inherits
+                    {"name": "R2", "org": "a", "slots": 9, "pr_target_branch": "main"},  # overrides
+                ],
+            }
+        )
+        r1 = manifest.resolve("R1")
+        assert r1.slots == 4
+        assert r1.pr_target_branch == "trunk"
+        assert r1.budget_per_story == 0.25
+        assert r1.watch_labels == ["conductor:ready"]
+
+        r2 = manifest.resolve("R2")
+        assert r2.slots == 9
+        assert r2.pr_target_branch == "main"
+        # Unset fields still inherit.
+        assert r2.budget_per_story == 0.25
+
+
+class TestLoadFleetManifest:
+    def test_loads_from_explicit_path(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path / "fleet.yaml",
+            """
+            version: 1
+            fleet:
+              name: Explicit
+            repos:
+              - {name: R, org: a}
+            """,
+        )
+        manifest = load_fleet_manifest(path=path)
+        assert manifest.fleet.name == "Explicit"
+
+    def test_priority_cwd_over_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        home_conductor = tmp_path / "home" / ".conductor"
+        home_conductor.mkdir(parents=True)
+
+        _write(
+            cwd / "fleet.yaml",
+            """
+            version: 1
+            fleet: {name: CWD}
+            repos: []
+            """,
+        )
+        _write(
+            home_conductor / "fleet.yaml",
+            """
+            version: 1
+            fleet: {name: HOME}
+            repos: []
+            """,
+        )
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        manifest = load_fleet_manifest()
+        assert manifest.fleet.name == "CWD"
+
+    def test_falls_back_to_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        empty_cwd = tmp_path / "empty"
+        empty_cwd.mkdir()
+        home_conductor = tmp_path / "home" / ".conductor"
+        home_conductor.mkdir(parents=True)
+        _write(
+            home_conductor / "fleet.yaml",
+            """
+            version: 1
+            fleet: {name: HOME}
+            repos: []
+            """,
+        )
+        monkeypatch.chdir(empty_cwd)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("CONDUCTOR_FLEET_CONFIG", raising=False)
+        manifest = load_fleet_manifest()
+        assert manifest.fleet.name == "HOME"
+
+    def test_env_override_wins_over_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        _write(
+            cwd / "fleet.yaml",
+            """
+            version: 1
+            fleet: {name: CWD}
+            repos: []
+            """,
+        )
+        env_dir = tmp_path / "env"
+        env_dir.mkdir()
+        env_file = _write(
+            env_dir / "custom.yaml",
+            """
+            version: 1
+            fleet: {name: ENV}
+            repos: []
+            """,
+        )
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv("CONDUCTOR_FLEET_CONFIG", str(env_file))
+        manifest = load_fleet_manifest()
+        assert manifest.fleet.name == "ENV"
+
+    def test_missing_everywhere_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        monkeypatch.chdir(empty)
+        monkeypatch.setenv("HOME", str(empty))
+        monkeypatch.delenv("CONDUCTOR_FLEET_CONFIG", raising=False)
+        with pytest.raises(FleetManifestError, match=r"no fleet\.yaml found"):
+            load_fleet_manifest()
+
+    def test_malformed_yaml_surfaces_error(self, tmp_path: Path) -> None:
+        bad = tmp_path / "fleet.yaml"
+        bad.write_text("not: [valid: yaml")
+        with pytest.raises(FleetManifestError):
+            load_fleet_manifest(path=bad)
+
+
+class TestFleetDefaults:
+    def test_baseline_defaults(self) -> None:
+        d = FleetDefaults.model_validate({"name": "f"})
+        assert d.default_slots == 2
+        assert d.default_pr_target_branch == "staging"
+        assert d.default_budget_per_story == 0.50
+        assert d.discovery_interval_seconds == 300
+        assert d.auto_promote_staging is False

--- a/tests/unit/test_gh_client_branches.py
+++ b/tests/unit/test_gh_client_branches.py
@@ -1,0 +1,72 @@
+"""Tests for GitHubClient.list_branches and get_default_branch.
+
+These methods support the staging-branch workflow (#65): the executor needs
+to know which branches exist on the remote so it can fall back from
+``staging`` to the default branch when ``staging`` doesn't exist yet.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from conductor.gh.client import GhCliError, GitHubClient
+
+
+class _StubRunner:
+    """Inject canned (rc, stdout, stderr) responses keyed by argv."""
+
+    def __init__(self, canned: dict[tuple[str, ...], tuple[int, bytes, bytes]]) -> None:
+        self.canned = canned
+        self.calls: list[tuple[str, ...]] = []
+
+    async def __call__(self, *argv: str, cwd: str | None = None) -> tuple[int, bytes, bytes]:
+        self.calls.append(tuple(argv))
+        for key, resp in self.canned.items():
+            if argv[: len(key)] == key:
+                return resp
+        return 1, b"", f"no canned response for {argv}".encode()
+
+
+class TestListBranches:
+    async def test_returns_branch_names(self) -> None:
+        payload = json.dumps([{"name": "main"}, {"name": "staging"}, {"name": "dev"}])
+        runner = _StubRunner({("gh", "api", "repos/acme/foo/branches"): (0, payload.encode(), b"")})
+        gh = GitHubClient(runner=runner)
+        branches = await gh.list_branches("acme/foo")
+        assert branches == ["main", "staging", "dev"]
+
+    async def test_invalid_repo_rejected(self) -> None:
+        gh = GitHubClient(runner=_StubRunner({}))
+        with pytest.raises(ValueError, match="Invalid repo"):
+            await gh.list_branches("not-valid")
+
+    async def test_gh_error_propagates(self) -> None:
+        runner = _StubRunner({("gh", "api", "repos/acme/foo/branches"): (1, b"", b"api boom")})
+        gh = GitHubClient(runner=runner)
+        with pytest.raises(GhCliError, match="api boom"):
+            await gh.list_branches("acme/foo")
+
+    async def test_paginates_or_limits(self) -> None:
+        """Sanity: we pass --paginate so gh collects all pages (large fleets)."""
+        payload = json.dumps([{"name": "main"}])
+        runner = _StubRunner({("gh", "api", "repos/acme/foo/branches"): (0, payload.encode(), b"")})
+        gh = GitHubClient(runner=runner)
+        await gh.list_branches("acme/foo")
+        argv = runner.calls[0]
+        assert "--paginate" in argv
+
+
+class TestGetDefaultBranch:
+    async def test_returns_default_branch(self) -> None:
+        payload = json.dumps({"default_branch": "trunk"})
+        runner = _StubRunner({("gh", "api", "repos/acme/foo"): (0, payload.encode(), b"")})
+        gh = GitHubClient(runner=runner)
+        assert await gh.get_default_branch("acme/foo") == "trunk"
+
+    async def test_missing_field_surfaces_as_error(self) -> None:
+        runner = _StubRunner({("gh", "api", "repos/acme/foo"): (0, b'{"id": 1}', b"")})
+        gh = GitHubClient(runner=runner)
+        with pytest.raises(GhCliError, match="default_branch"):
+            await gh.get_default_branch("acme/foo")


### PR DESCRIPTION
## Summary

GAAI-parity batch that lets CONDUCTOR declare its fleet in one place (`fleet.yaml`) and safely target `staging` branches when opening PRs with automatic fallback to the default branch. Covers **#65** and **#67**.

## What's in

### `conductor/config/fleet.py` (new)
- `FleetDefaults` — fleet-wide defaults (slots, budget, discovery interval, PR target branch, watch labels, `auto_promote_staging` flag scaffolded for #68).
- `FleetRepoEntry` — per-repo overrides. Inheritable fields stay `None` until `resolve()` folds in defaults (explicit > magic).
- `FleetManifest.resolve(name) → _ResolvedRepo` — non-None guaranteed.
- `FleetManifest.active_repos()` filters disabled entries.
- `load_fleet_manifest()` — priority: explicit path → `CONDUCTOR_FLEET_CONFIG` → `./fleet.yaml` → `~/.conductor/fleet.yaml`.
- Duplicate repo names rejected at validation time; malformed YAML surfaces as `FleetManifestError`.

### `fleet.yaml` (new, at repo root)
Initial manifest for the D-sorganization fleet: 7 repos, `staging` default, `Repository_Management` and `CONDUCTOR` pinned to `main` (no staging branch yet). `auto_promote_staging` flag scaffolded but defaults off until #68 ships.

### `conductor/gh/client.py`
- `GitHubClient.list_branches(repo)` — paginated.
- `GitHubClient.get_default_branch(repo)`.

### `conductor/gh/executor.py`
- `IssueExecutor.resolve_pr_target_branch()` — static helper. Given a preferred branch and a fallback flag, returns the branch a PR should base on. Raises `IssueExecutionError` when the configured branch is missing and fallback is off — operator sees the misconfiguration early instead of silently defaulting. Skips the branch listing when `preferred` is already the default (common for CONDUCTOR itself).

## Tests (27 new)

- `tests/unit/test_fleet_config.py` (17) — validation, duplicate names, defaults inheritance, priority-order loading, malformed YAML surfaces.
- `tests/unit/test_gh_client_branches.py` (6) — happy path, `--paginate` flag presence, error propagation, missing `default_branch` field.
- `tests/unit/test_executor_pr_target.py` (4) — branch resolution with and without fallback, skip-listing optimisation.

## Design notes (per the user's principles)

- **Agent Agnostic / Orthogonality:** `resolve_pr_target_branch` is a static method on `IssueExecutor` with no `self` — pure policy helper usable from any call site (daemon, CLI, tests). The executor itself stays focused on execute-the-issue; target-branch *policy* is at the caller.
- **DRY:** `FleetDefaults.default_*` flows into `_ResolvedRepo` via one `resolve()` path. Repo entries don't duplicate defaults.
- **Reversibility / Easiness to Change:** inheritable fields use `None` sentinels, not "magic" defaults, so an override and an explicit-equals-default are distinguishable — important when `conductor fleet add` (future) serializes entries back to YAML.
- **DbC:** `_ResolvedRepo` is frozen and has no `None` on inheritable fields; the type system enforces "defaults have been applied."

## Follow-ups (intentionally out of scope to keep this reviewable)

- Wiring `base_branch` through `Daemon._execute_issue` from the resolved fleet entry. This PR gives operators everything they need via `IssueExecutor.resolve_pr_target_branch`; the daemon call site stays `base="main"` until a small follow-up loads `fleet.yaml` at startup.
- `conductor fleet status|add` CLI commands (#67 acceptance criteria — touches typer CLI plumbing that doesn't gate this).
- `--all` flag on existing commands.
- Auto-promote staging→main implementation (flag ships here; implementation pairs with PR auto-merge daemon #68).

## Test plan

- [x] 27 new unit tests pass locally
- [x] `ruff check` + `ruff format --check` clean on new/changed files
- [x] `mypy --strict` clean on `conductor/config/fleet.py`, `conductor/gh/client.py`, `conductor/gh/executor.py`
- [x] `tests/unit/test_daemon_issues.py::test_issue_task_opens_pr` and `test_implement_mode_marked` observed flaky on `main` without this PR (same race as `test_multiple_workers_process_concurrently`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)