### PR TITLE
feat(cli): multi-repo batch dispatch with --all, --max-stories, --dry-run (#62)

### DIFF
--- a/conductor/cli/batch_dispatch.py
+++ b/conductor/cli/batch_dispatch.py
@@ -1,0 +1,151 @@
+"""Pure-logic planner for ``conductor issue dispatch-batch``.
+
+The CLI wraps this with console rendering and the HTTP call to the daemon;
+**this module has no HTTP or I/O side effects** so it can be unit-tested
+without a daemon or a network. That's the TDD + LOD split: the CLI uses
+the planner; the planner uses an injected issue-lister; the lister uses
+``gh``. One concern per layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+
+from conductor.config.fleet import FleetManifest
+from conductor.contracts import require
+from conductor.gh.client import Issue
+
+__all__ = [
+    "BatchDispatchPlan",
+    "BatchDispatchPlanner",
+    "BatchItem",
+    "RepoBatchSummary",
+    "resolve_repos_from_manifest",
+]
+
+
+#: The issue-lister injected into the planner. Same shape as
+#: ``GitHubClient.list_issues``.
+ListIssuesFn = Callable[..., Awaitable[list[Issue]]]
+
+_VALID_MODES = frozenset({"plan", "implement"})
+
+
+@dataclass(slots=True, frozen=True)
+class BatchItem:
+    """One issue dispatch request that the daemon will consume."""
+
+    repo: str
+    number: int
+    mode: str
+
+
+@dataclass(slots=True, frozen=True)
+class RepoBatchSummary:
+    """Per-repo rollup of the plan — used for human-readable CLI output."""
+
+    repo: str
+    eligible: int
+    submitted: int
+    skipped: int
+
+
+@dataclass(slots=True, frozen=True)
+class BatchDispatchPlan:
+    """What ``BatchDispatchPlanner.plan`` produces — ready to print or submit."""
+
+    items: tuple[BatchItem, ...]
+    summaries: tuple[RepoBatchSummary, ...]
+
+    def total_submitted(self) -> int:
+        return sum(s.submitted for s in self.summaries)
+
+    def total_skipped(self) -> int:
+        return sum(s.skipped for s in self.summaries)
+
+
+class BatchDispatchPlanner:
+    """Compute a :class:`BatchDispatchPlan` for a set of repos.
+
+    The planner enforces two policies:
+      * **Label filter** — keep only issues whose labels include ``label``.
+      * **Per-repo cap** — ``max_stories`` issues per repo, preserving the
+        order returned by the lister (latest-created first by default).
+
+    Fan-out uses ``asyncio.gather`` so N repos are scanned concurrently.
+    Per-repo lister failures surface as an empty summary rather than
+    killing the batch — one broken repo shouldn't strand the rest.
+    """
+
+    def __init__(
+        self,
+        *,
+        list_issues: ListIssuesFn,
+        max_stories: int | None = None,
+    ) -> None:
+        if max_stories is not None:
+            require(max_stories >= 1, f"max_stories must be >= 1 (got {max_stories})")
+        self._list_issues = list_issues
+        self._max_stories = max_stories
+
+    async def plan(
+        self,
+        *,
+        repos: Sequence[str],
+        label: str | None = None,
+        mode: str = "plan",
+        state: str = "open",
+        limit: int = 100,
+    ) -> BatchDispatchPlan:
+        if mode not in _VALID_MODES:
+            raise ValueError(f"mode must be one of {_VALID_MODES} (got {mode!r})")
+        if not repos:
+            return BatchDispatchPlan(items=(), summaries=())
+
+        per_repo_results = await asyncio.gather(
+            *[
+                self._plan_one_repo(r, label=label, mode=mode, state=state, limit=limit)
+                for r in repos
+            ]
+        )
+
+        items: list[BatchItem] = []
+        summaries: list[RepoBatchSummary] = []
+        for repo_items, summary in per_repo_results:
+            items.extend(repo_items)
+            summaries.append(summary)
+        return BatchDispatchPlan(items=tuple(items), summaries=tuple(summaries))
+
+    async def _plan_one_repo(
+        self,
+        repo: str,
+        *,
+        label: str | None,
+        mode: str,
+        state: str,
+        limit: int,
+    ) -> tuple[list[BatchItem], RepoBatchSummary]:
+        try:
+            issues = await self._list_issues(repo, state=state, limit=limit)
+        except Exception:
+            return [], RepoBatchSummary(repo=repo, eligible=0, submitted=0, skipped=0)
+
+        filtered = [i for i in issues if label is None or label in i.labels]
+        eligible = len(filtered)
+
+        cap = self._max_stories
+        capped = filtered if cap is None else filtered[:cap]
+        submitted = len(capped)
+        skipped = eligible - submitted
+
+        items = [BatchItem(repo=repo, number=i.number, mode=mode) for i in capped]
+        return items, RepoBatchSummary(
+            repo=repo, eligible=eligible, submitted=submitted, skipped=skipped
+        )
+
+
+def resolve_repos_from_manifest(manifest: FleetManifest) -> list[str]:
+    """Expand ``--all`` into the list of enabled repos as ``owner/name`` strings."""
+    return [entry.full_name for entry in manifest.active_repos()]

--- a/conductor/cli/issues.py
+++ b/conductor/cli/issues.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from rich.console import Console
@@ -90,13 +90,35 @@ def dispatch_batch(
         Path | None,
         typer.Option("--from-file", "-f", help="Text file: lines of owner/repo#N[:mode]"),
     ] = None,
-    repo: Annotated[
-        str | None,
-        typer.Option("--repo", help="owner/repo to pull open issues from"),
+    repos: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--repo",
+            help="owner/repo — repeat for multiple repos",
+        ),
+    ] = None,
+    all_fleet: Annotated[
+        bool,
+        typer.Option("--all", help="Expand to every enabled repo from fleet.yaml"),
+    ] = False,
+    fleet_manifest: Annotated[
+        Path | None,
+        typer.Option("--fleet-manifest", help="Path to fleet.yaml (default: cwd/~/.conductor)"),
     ] = None,
     label: Annotated[str | None, typer.Option("--label", help="Filter by label")] = None,
     mode: Annotated[str, typer.Option("--mode")] = "plan",
     limit: Annotated[int, typer.Option("--limit")] = 100,
+    max_stories: Annotated[
+        int | None,
+        typer.Option(
+            "--max-stories",
+            help="Per-repo cap on how many issues to submit this run",
+        ),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Print what would be dispatched without submitting"),
+    ] = False,
     daemon_url: Annotated[
         str, typer.Option("--daemon-url", envvar="CONDUCTOR_DAEMON_URL")
     ] = "http://127.0.0.1:8080",
@@ -104,26 +126,58 @@ def dispatch_batch(
         str | None, typer.Option("--auth-token", envvar="CONDUCTOR_API_TOKEN")
     ] = None,
 ) -> None:
-    """Dispatch many issues in one call.
+    """Dispatch many issues across one or more repos.
 
-    Two input modes:
-      * ``--from-file`` — one ``owner/repo#NUM[:mode]`` per line (``#`` comments allowed)
-      * ``--repo o/r [--label X]`` — pull open issues matching the label filter
+    Input modes (combinable):
+      * ``--from-file`` — one ``owner/repo#NUM[:mode]`` per line
+      * ``--repo o/r`` (repeatable) — pull open issues matching the label filter
+      * ``--all`` — expand to every enabled repo in ``fleet.yaml``
+
+    Flags:
+      * ``--max-stories N`` — cap submissions per repo
+      * ``--dry-run`` — print the plan, submit nothing
     """
-    if from_file is None and repo is None:
-        console.print("[red]✗[/red] Pass either --from-file or --repo.")
+    from conductor.cli.batch_dispatch import (
+        BatchDispatchPlanner,
+        resolve_repos_from_manifest,
+    )
+    from conductor.config.fleet import FleetManifestError, load_fleet_manifest
+
+    if not from_file and not repos and not all_fleet:
+        console.print("[red]✗[/red] Pass --from-file, --repo, or --all.")
         raise typer.Exit(1)
 
+    # File input short-circuits the planner: the file itself is the plan.
     items: list[dict[str, object]] = []
     if from_file is not None:
         items.extend(_parse_batch_file(from_file, default_mode=mode))
-    if repo is not None:
+
+    # Collect target repos (explicit + fleet-expanded).
+    target_repos: list[str] = list(repos or [])
+    if all_fleet:
+        try:
+            manifest = load_fleet_manifest(path=fleet_manifest)
+        except FleetManifestError as e:
+            console.print(f"[red]✗[/red] {e}")
+            raise typer.Exit(1) from None
+        target_repos.extend(resolve_repos_from_manifest(manifest))
+
+    # De-dupe while preserving caller order — multiple --repo + --all may overlap.
+    target_repos = list(dict.fromkeys(target_repos))
+
+    if target_repos:
         client = GitHubClient()
-        issues = asyncio.run(client.list_issues(repo, state="open", limit=limit))
-        for issue in issues:
-            if label is not None and label not in issue.labels:
-                continue
-            items.append({"repo": repo, "number": issue.number, "mode": mode})
+        planner = BatchDispatchPlanner(list_issues=client.list_issues, max_stories=max_stories)
+        plan = asyncio.run(
+            planner.plan(repos=target_repos, label=label, mode=mode, state="open", limit=limit)
+        )
+
+        _render_plan_summary(plan, dry_run=dry_run, label=label, mode=mode, max_stories=max_stories)
+        items.extend({"repo": it.repo, "number": it.number, "mode": it.mode} for it in plan.items)
+
+    if dry_run:
+        console.print("[yellow]Dry run — nothing submitted.[/yellow]")
+        return
 
     if not items:
         console.print("[yellow]No issues matched.[/yellow]")
@@ -151,6 +205,37 @@ def dispatch_batch(
     )
     for failure in body.get("failures", []):
         console.print(f"  [red]✗[/red] {failure['repo']}#{failure['number']} — {failure['error']}")
+
+
+def _render_plan_summary(
+    plan: Any,
+    *,
+    dry_run: bool,
+    label: str | None,
+    mode: str,
+    max_stories: int | None,
+) -> None:
+    """Print a per-repo rollup table. Purely cosmetic — no dispatch side effects."""
+    filter_bits = [f"mode={mode}"]
+    if label:
+        filter_bits.append(f"label={label}")
+    if max_stories is not None:
+        filter_bits.append(f"max-stories={max_stories}")
+    header = f"{'Dry run: ' if dry_run else ''}Dispatching {len(plan.summaries)} repo(s)"
+    console.print(f"\n[bold]{header}[/bold]  ([dim]{', '.join(filter_bits)}[/dim])\n")
+
+    t = Table(header_style="bold cyan")
+    t.add_column("Repo")
+    t.add_column("Eligible", justify="right")
+    t.add_column("Submitted", justify="right")
+    t.add_column("Skipped", justify="right")
+    for s in plan.summaries:
+        t.add_row(s.repo, str(s.eligible), str(s.submitted), str(s.skipped))
+    console.print(t)
+    console.print(
+        f"\n[bold]Total[/bold]: {plan.total_submitted()} submitted, "
+        f"{plan.total_skipped()} skipped.\n"
+    )
 
 
 def _parse_batch_file(path: Path, *, default_mode: str) -> list[dict[str, object]]:

--- a/tests/unit/test_batch_dispatch_planner.py
+++ b/tests/unit/test_batch_dispatch_planner.py
@@ -1,0 +1,214 @@
+"""Tests for BatchDispatchPlanner — pure logic for multi-repo issue dispatch.
+
+Planner is pure: given a list of repos, an issue-lister, and filter knobs,
+it computes what would be submitted without touching the daemon. The CLI
+wraps it with HTTP/console rendering.
+
+All tests work with an in-memory `list_issues` callable — no network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from conductor.cli.batch_dispatch import (
+    BatchDispatchPlan,
+    BatchDispatchPlanner,
+    BatchItem,
+    RepoBatchSummary,
+)
+from conductor.gh.client import Issue
+
+
+def _issue(number: int, *, labels: Sequence[str] = (), title: str = "t", body: str = "") -> Issue:
+    return Issue(
+        number=number,
+        title=title,
+        body=body,
+        state="OPEN",
+        labels=list(labels),
+        url=f"https://example/issues/{number}",
+    )
+
+
+class _FakeLister:
+    """Test double — returns canned issues per repo."""
+
+    def __init__(self, per_repo: dict[str, list[Issue]]) -> None:
+        self._per_repo = per_repo
+        self.calls: list[str] = []
+
+    async def list_issues(self, repo: str, *, state: str = "open", limit: int = 50) -> list[Issue]:
+        self.calls.append(repo)
+        return list(self._per_repo.get(repo, []))
+
+
+# ── Basic shape ──────────────────────────────────────────────────────────────
+
+
+class TestBatchItemShape:
+    def test_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        item = BatchItem(repo="a/b", number=1, mode="plan")
+        with pytest.raises(FrozenInstanceError):
+            item.number = 2  # type: ignore[misc]
+
+    def test_frozen_summary(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        s = RepoBatchSummary(repo="a/b", eligible=5, submitted=3, skipped=2)
+        with pytest.raises(FrozenInstanceError):
+            s.submitted = 4  # type: ignore[misc]
+
+
+# ── Single-repo plan ────────────────────────────────────────────────────────
+
+
+class TestSingleRepoPlan:
+    async def test_all_issues_submitted_when_no_cap(self) -> None:
+        lister = _FakeLister({"a/b": [_issue(1), _issue(2), _issue(3)]})
+        planner = BatchDispatchPlanner(list_issues=lister.list_issues)
+        plan = await planner.plan(repos=["a/b"], mode="plan")
+        assert [it.number for it in plan.items] == [1, 2, 3]
+        assert plan.summaries == (RepoBatchSummary(repo="a/b", eligible=3, submitted=3, skipped=0),)
+
+    async def test_max_stories_caps_submission(self) -> None:
+        lister = _FakeLister({"a/b": [_issue(i) for i in range(5)]})
+        planner = BatchDispatchPlanner(list_issues=lister.list_issues, max_stories=2)
+        plan = await planner.plan(repos=["a/b"])
+        assert len(plan.items) == 2
+        s = plan.summaries[0]
+        assert s.eligible == 5
+        assert s.submitted == 2
+        assert s.skipped == 3
+
+    async def test_label_filter_reduces_eligible(self) -> None:
+        lister = _FakeLister(
+            {
+                "a/b": [
+                    _issue(1, labels=["bug"]),
+                    _issue(2, labels=["feature"]),
+                    _issue(3, labels=["bug", "priority"]),
+                ]
+            }
+        )
+        planner = BatchDispatchPlanner(list_issues=lister.list_issues)
+        plan = await planner.plan(repos=["a/b"], label="bug")
+        assert sorted(it.number for it in plan.items) == [1, 3]
+        assert plan.summaries[0].eligible == 2
+
+    async def test_mode_is_threaded_into_items(self) -> None:
+        lister = _FakeLister({"a/b": [_issue(1)]})
+        planner = BatchDispatchPlanner(list_issues=lister.list_issues)
+        plan = await planner.plan(repos=["a/b"], mode="implement")
+        assert plan.items[0].mode == "implement"
+
+
+# ── Multi-repo fan-out ───────────────────────────────────────────────────────
+
+
+class TestMultiRepoFanOut:
+    async def test_fans_out_across_repos(self) -> None:
+        lister = _FakeLister(
+            {
+                "a/b": [_issue(1), _issue(2)],
+                "c/d": [_issue(10)],
+            }
+        )
+        planner = BatchDispatchPlanner(list_issues=lister.list_issues)
+        plan = await planner.plan(repos=["a/b", "c/d"])
+        assert len(plan.items) == 3
+        names = {it.repo for it in plan.items}
+        assert names == {"a/b", "c/d"}
+        assert len(plan.summaries) == 2
+        # Planner calls list_issues once per repo.
+        assert sorted(lister.calls) == ["a/b", "c/d"]
+
+    async def test_per_repo_cap_independent(self) -> None:
+        """A cap of 2 applies per repo, not across the fleet."""
+        lister = _FakeLister(
+            {
+                "a/b": [_issue(1), _issue(2), _issue(3)],
+                "c/d": [_issue(10), _issue(20), _issue(30)],
+            }
+        )
+        planner = BatchDispatchPlanner(list_issues=lister.list_issues, max_stories=2)
+        plan = await planner.plan(repos=["a/b", "c/d"])
+        # 2 per repo = 4 total, not 2 total.
+        assert len(plan.items) == 4
+        by_repo = {s.repo: s for s in plan.summaries}
+        assert by_repo["a/b"].submitted == 2
+        assert by_repo["c/d"].submitted == 2
+
+    async def test_empty_repo_yields_empty_summary(self) -> None:
+        lister = _FakeLister({"a/b": [_issue(1)], "empty/repo": []})
+        planner = BatchDispatchPlanner(list_issues=lister.list_issues)
+        plan = await planner.plan(repos=["a/b", "empty/repo"])
+        by_repo = {s.repo: s for s in plan.summaries}
+        assert by_repo["empty/repo"].eligible == 0
+        assert by_repo["empty/repo"].submitted == 0
+
+    async def test_no_repos_yields_empty_plan(self) -> None:
+        lister = _FakeLister({})
+        planner = BatchDispatchPlanner(list_issues=lister.list_issues)
+        plan = await planner.plan(repos=[])
+        assert plan == BatchDispatchPlan(items=(), summaries=())
+
+    async def test_lister_failure_surfaces_as_empty_summary(self) -> None:
+        async def bad_lister(repo: str, *, state: str = "open", limit: int = 50) -> list[Issue]:
+            if repo == "broken/repo":
+                raise RuntimeError("boom")
+            return [_issue(1)]
+
+        planner = BatchDispatchPlanner(list_issues=bad_lister)
+        plan = await planner.plan(repos=["ok/repo", "broken/repo"])
+        by_repo = {s.repo: s for s in plan.summaries}
+        # Broken repo surfaces as an empty summary rather than killing the whole batch.
+        assert by_repo["broken/repo"].eligible == 0
+        assert by_repo["broken/repo"].submitted == 0
+        assert by_repo["ok/repo"].submitted == 1
+
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+
+
+class TestPreconditions:
+    async def test_invalid_mode_rejected(self) -> None:
+        lister = _FakeLister({})
+        planner = BatchDispatchPlanner(list_issues=lister.list_issues)
+        with pytest.raises(ValueError, match="mode"):
+            await planner.plan(repos=["a/b"], mode="destroy")
+
+    def test_invalid_max_stories_rejected(self) -> None:
+        from conductor.contracts import PreconditionError
+
+        lister = _FakeLister({})
+        with pytest.raises(PreconditionError, match="max_stories"):
+            BatchDispatchPlanner(list_issues=lister.list_issues, max_stories=0)
+
+
+# ── Fleet manifest resolution ───────────────────────────────────────────────
+
+
+class TestResolveReposFromManifest:
+    def test_all_active_repos_included(self) -> None:
+        from conductor.cli.batch_dispatch import resolve_repos_from_manifest
+        from conductor.config.fleet import FleetManifest
+
+        manifest = FleetManifest.model_validate(
+            {
+                "version": 1,
+                "fleet": {"name": "f"},
+                "repos": [
+                    {"name": "A", "org": "acme"},
+                    {"name": "B", "org": "acme", "enabled": False},
+                    {"name": "C", "org": "acme"},
+                ],
+            }
+        )
+        resolved = resolve_repos_from_manifest(manifest)
+        # Disabled repos excluded.
+        assert sorted(resolved) == ["acme/A", "acme/C"]


### PR DESCRIPTION
## Summary

Closes **#62**. Fan-out parity with `gaai-fleet.sh` — one command dispatches work across every repo in `fleet.yaml`, respects per-repo caps, and shows the plan before any HTTP call hits the daemon.

## UX

```bash
# Explicit multi-repo
conductor issue dispatch-batch \
  --repo AffineDrift --repo UpstreamDrift --repo Gasification_Model \
  --label "conductor:ready" --max-stories 3

# Fleet-wide (reads fleet.yaml from PR #79)
conductor issue dispatch-batch --all --label "conductor:ready"

# Dry run — see what would be dispatched
conductor issue dispatch-batch --all --max-stories 2 --dry-run
```

Output:
```
Dispatching 3 repo(s)  (mode=plan, label=conductor:ready, max-stories=2)

┃ Repo                    ┃ Eligible ┃ Submitted ┃ Skipped ┃
┃ D-sorg/AffineDrift      ┃        5 ┃         2 ┃       3 ┃
┃ D-sorg/UpstreamDrift    ┃        2 ┃         2 ┃       0 ┃
┃ D-sorg/Gasification     ┃        0 ┃         0 ┃       0 ┃

Total: 4 submitted, 3 skipped.
```

## New

### `conductor/cli/batch_dispatch.py` (pure logic, no I/O)
- `BatchItem`, `RepoBatchSummary`, `BatchDispatchPlan` — all frozen.
- `BatchDispatchPlanner` — `asyncio.gather` fan-out across N repos; applies label filter; enforces per-repo `max_stories` cap. **Per-repo lister failures surface as empty summaries** so one broken repo doesn't kill the batch.
- `resolve_repos_from_manifest(manifest)` — expand `--all` into `owner/name` strings.

### `conductor/cli/issues.py` — `dispatch-batch` command
- `--repo` accepts multiple values.
- `--all` reads `fleet.yaml` via `load_fleet_manifest()` (PR #79).
- `--max-stories N` caps submissions per repo.
- `--dry-run` prints the plan and stops before any HTTP call.
- `--fleet-manifest` overrides the default resolution path.

## Tests (14 new)

`tests/unit/test_batch_dispatch_planner.py`:
- Frozen-dataclass contracts
- Single-repo: no-cap, cap, label filter, mode threading
- Multi-repo: fan-out, per-repo independent cap, empty repo, empty repos, broken-lister graceful degradation
- Preconditions: invalid mode → `ValueError`; `max_stories < 1` → `PreconditionError` (via `contracts.require`)
- Fleet manifest resolution excludes disabled repos

## Design notes (per the user's principles)

- **LOD:** CLI depends on planner's public API only; planner depends on an injected `list_issues` callable only. No method chains deeper than one level.
- **DRY:** fleet expansion goes through the same `FleetManifest.resolve` path that #79 shipped — no duplicated "which repos" logic.
- **Reversibility:** `--dry-run` lets operators see the exact plan before committing. The planner has no HTTP side effects so dry-run is always safe.
- **TDD:** 14 red-green tests cover every branch of the planner; the CLI layer composes tested primitives.

## Test plan

- [x] 14 new planner tests pass locally
- [x] All 9 pre-existing CLI-issues tests still pass
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy --strict` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)