### PR TITLE
feat(backend): context condensation for long-running agent loops (#72)

### DIFF
--- a/conductor/backends/agent_loop.py
+++ b/conductor/backends/agent_loop.py
@@ -41,6 +41,7 @@ from conductor.backends.base import (
     MessageRole,
     TokenUsage,
 )
+from conductor.backends.condensation import Condenser
 from conductor.backends.registry import registry
 from conductor.gh.ci_patterns import detect_ci_profile
 from conductor.tools import ToolRegistry, build_default_registry
@@ -142,6 +143,7 @@ class AgentLoopBackend(ILLMBackend):
         wall_clock_timeout_seconds: float | None = None,
         enable_prompt_caching: bool = True,
         registry_factory: Callable[[Path], ToolRegistry] | None = None,
+        condenser: Condenser | None = None,
     ) -> None:
         key = api_key or os.environ.get("ANTHROPIC_API_KEY")
         if not key:
@@ -158,6 +160,7 @@ class AgentLoopBackend(ILLMBackend):
         self._wall_clock_timeout = wall_clock_timeout_seconds
         self._enable_cache = enable_prompt_caching
         self._registry_factory = registry_factory or build_default_registry
+        self._condenser = condenser
 
     # ── System prompt assembly ───────────────────────────────────────────────
 
@@ -327,6 +330,13 @@ class AgentLoopBackend(ILLMBackend):
                     f"agent loop exceeded wall-clock timeout of "
                     f"{self._wall_clock_timeout}s at turn {turn + 1}"
                 )
+
+            # Condense message history if context is getting long. The
+            # condenser no-ops when the list is already short enough.
+            if self._condenser is not None and self._condenser.should_condense(
+                total_usage.prompt_tokens
+            ):
+                sdk_messages = await self._condenser.condense(sdk_messages)
 
             response = await self._client.messages.create(
                 model=effective_model,

--- a/conductor/backends/condensation.py
+++ b/conductor/backends/condensation.py
@@ -1,0 +1,94 @@
+"""Conversation-history condensation for long-running agent loops.
+
+A 150-turn agent loop balloons the message list past the model's context
+window. Rather than hit a hard error, we summarize a middle slice into a
+single synthetic "user" message. Preserved:
+
+  * the first user message (the original task) — the anchor
+  * the last ``keep_recent`` messages — fresh context for the next turn
+
+Everything between is replaced by one bracketed summary so the agent still
+has *some* signal about what happened earlier.
+
+DbC:
+  * ``threshold_tokens`` and ``keep_recent`` must be positive.
+  * ``condense()`` is idempotent on short lists — returns the input
+    unchanged when there's nothing meaningful to summarize.
+
+LOD:
+  * The summarizer is an injected callable; we don't know it's an LLM.
+  * ``Condenser`` doesn't touch the Anthropic client or the cost ledger —
+    that's the agent loop's job when it invokes condense().
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from conductor.contracts import require
+
+__all__ = ["Condenser", "SummarizerFn"]
+
+
+#: Summarizer signature — takes the middle-slice of messages and returns a
+#: one-paragraph summary string. Wired to the LLM at the call site.
+SummarizerFn = Callable[[list[dict[str, object]]], Awaitable[str]]
+
+
+class Condenser:
+    """Shrinks a long agent message list by summarizing middle turns.
+
+    Invariants across ``condense()``:
+      1. The first message (the task statement) is always retained.
+      2. The last ``keep_recent`` messages are always retained verbatim.
+      3. If the compressed result wouldn't be shorter than the input, we
+         return the input — no point paying for a summary that adds bytes.
+    """
+
+    def __init__(
+        self,
+        *,
+        threshold_tokens: int,
+        keep_recent: int,
+        summarizer: SummarizerFn,
+    ) -> None:
+        require(threshold_tokens >= 1, f"threshold_tokens must be >= 1 (got {threshold_tokens})")
+        require(keep_recent >= 1, f"keep_recent must be >= 1 (got {keep_recent})")
+        self._threshold = threshold_tokens
+        self._keep_recent = keep_recent
+        self._summarize = summarizer
+
+    def should_condense(self, total_tokens: int) -> bool:
+        """True when accumulated prompt tokens have reached the threshold."""
+        return total_tokens >= self._threshold
+
+    async def condense(self, messages: list[dict[str, object]]) -> list[dict[str, object]]:
+        """Return a shorter message list, or the input if compression isn't useful.
+
+        The output shape is ``[anchor, summary, *tail]`` with the summary as
+        a synthetic ``role: user`` message so it doesn't break the
+        user/assistant alternation downstream models expect.
+        """
+        # Anchor (1) + summary (1) + tail (keep_recent) = keep_recent + 2
+        # messages after compression. Only worth it if we can drop at least
+        # one real middle message.
+        minimum_length = self._keep_recent + 2
+        if len(messages) <= minimum_length:
+            return messages
+
+        anchor = messages[:1]
+        tail = messages[-self._keep_recent :]
+        middle = messages[1 : -self._keep_recent]
+        if not middle:
+            return messages
+
+        try:
+            summary_text = await self._summarize(list(middle))
+        except Exception:
+            return messages
+
+        summary_msg: dict[str, object] = {
+            "role": "user",
+            "content": f"[Prior turns summarized: {summary_text}]",
+        }
+        return [*anchor, summary_msg, *tail]

--- a/tests/unit/test_agent_loop_condensation.py
+++ b/tests/unit/test_agent_loop_condensation.py
@@ -1,0 +1,132 @@
+"""Tests for AgentLoopBackend's integration with Condenser.
+
+Condenser itself is tested in ``test_condensation.py``. Here we verify the
+loop calls it at the right moment and threads the result back in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from conductor.backends.agent_loop import AgentLoopBackend
+from conductor.backends.base import Message, MessageRole
+from conductor.backends.condensation import Condenser
+
+
+@pytest.fixture(autouse=True)
+def _api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+
+def _response(
+    *,
+    stop_reason: str = "end_turn",
+    text: str | None = "done",
+    input_tokens: int = 10_000,
+    output_tokens: int = 100,
+) -> MagicMock:
+    resp = MagicMock()
+    resp.stop_reason = stop_reason
+    resp.model = "claude-sonnet-4-6"
+    resp.usage = MagicMock()
+    resp.usage.input_tokens = input_tokens
+    resp.usage.output_tokens = output_tokens
+    resp.usage.cache_read_input_tokens = 0
+    if text is None:
+        resp.content = []
+    else:
+        block = MagicMock()
+        block.type = "text"
+        block.text = text
+        resp.content = [block]
+    return resp
+
+
+def _install_mock_client(backend: AgentLoopBackend, responses: list[MagicMock]) -> AsyncMock:
+    client = MagicMock()
+    client.messages = MagicMock()
+    client.messages.create = AsyncMock(side_effect=list(responses))
+    backend._client = client  # type: ignore[assignment]
+    return client.messages.create
+
+
+class _FakeCondenser:
+    """Test double — records ``should_condense`` calls and ``condense`` invocations."""
+
+    def __init__(self, *, trigger_at_tokens: int) -> None:
+        self._trigger = trigger_at_tokens
+        self.should_condense_calls: list[int] = []
+        self.condense_calls: int = 0
+        self.last_output: list[dict[str, Any]] | None = None
+
+    def should_condense(self, total_tokens: int) -> bool:
+        self.should_condense_calls.append(total_tokens)
+        return total_tokens >= self._trigger
+
+    async def condense(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        self.condense_calls += 1
+        shrunk: list[dict[str, Any]] = [{"role": "user", "content": "[condensed]"}]
+        self.last_output = shrunk
+        return shrunk
+
+
+class TestCondenserIntegration:
+    async def test_not_called_when_no_condenser_configured(self, tmp_path: Path) -> None:
+        backend = AgentLoopBackend(workspace_dir=str(tmp_path))  # no condenser
+        _install_mock_client(backend, [_response()])
+        await backend.complete(
+            [Message(role=MessageRole.USER, content="hi")], model="claude-sonnet-4-6"
+        )
+
+    async def test_called_when_token_threshold_hit(self, tmp_path: Path) -> None:
+        cond = _FakeCondenser(trigger_at_tokens=5_000)
+        backend = AgentLoopBackend(
+            workspace_dir=str(tmp_path),
+            condenser=cond,  # type: ignore[arg-type]
+        )
+        # Two turns: tool_use → end_turn. First turn reports 10k input_tokens
+        # (> 5k trigger), so condense runs before turn 2.
+        turn_a = _response(stop_reason="tool_use", text=None, input_tokens=10_000)
+        turn_b = _response(stop_reason="end_turn", text="done", input_tokens=100)
+        create = _install_mock_client(backend, [turn_a, turn_b])
+        await backend.complete(
+            [Message(role=MessageRole.USER, content="do it")],
+            model="claude-sonnet-4-6",
+        )
+        assert cond.should_condense_calls, "condenser should have been consulted"
+        # Trigger fires on turn 2 after turn 1's usage accumulated.
+        assert cond.condense_calls >= 1
+        # Turn 2's messages must include the condensed list.
+        turn_2_msgs = create.call_args_list[1].kwargs["messages"]
+        assert any(m.get("content") == "[condensed]" for m in turn_2_msgs)
+
+    async def test_not_called_below_threshold(self, tmp_path: Path) -> None:
+        cond = _FakeCondenser(trigger_at_tokens=100_000)
+        backend = AgentLoopBackend(
+            workspace_dir=str(tmp_path),
+            condenser=cond,  # type: ignore[arg-type]
+        )
+        turn_a = _response(stop_reason="tool_use", text=None, input_tokens=1_000)
+        turn_b = _response(stop_reason="end_turn", text="done", input_tokens=100)
+        _install_mock_client(backend, [turn_a, turn_b])
+        await backend.complete(
+            [Message(role=MessageRole.USER, content="do it")],
+            model="claude-sonnet-4-6",
+        )
+        # Consulted but never triggered.
+        assert cond.should_condense_calls
+        assert cond.condense_calls == 0
+
+
+class TestCondenserWiring:
+    def test_accepts_real_condenser(self, tmp_path: Path) -> None:
+        async def summarizer(_: list[dict[str, object]]) -> str:
+            return "summary"
+
+        cond = Condenser(threshold_tokens=100_000, keep_recent=5, summarizer=summarizer)
+        backend = AgentLoopBackend(workspace_dir=str(tmp_path), condenser=cond)
+        assert backend._condenser is cond

--- a/tests/unit/test_condensation.py
+++ b/tests/unit/test_condensation.py
@@ -1,0 +1,158 @@
+"""Tests for Condenser — shrinks long agent message histories via LLM summary.
+
+For long-running stories (100+ turns), the message list grows until it hits
+the context window. Condenser splits the history into [anchor][mid][tail]
+segments, replaces the middle with a one-line "[prior turns summarized]"
+synthetic assistant message, and preserves the original task plus the most
+recent turns.
+
+Tests exercise the orchestration (what's kept, what's dropped, where the
+summary lands); the summarizer itself is injected so tests never hit an LLM.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from conductor.backends.condensation import Condenser
+
+
+async def _stub_summarizer(messages: list[dict[str, object]]) -> str:
+    return f"<summary of {len(messages)} turns>"
+
+
+# ── Threshold policy ─────────────────────────────────────────────────────────
+
+
+class TestShouldCondense:
+    def test_below_threshold_returns_false(self) -> None:
+        c = Condenser(threshold_tokens=1000, keep_recent=2, summarizer=_stub_summarizer)
+        assert c.should_condense(999) is False
+
+    def test_at_threshold_returns_true(self) -> None:
+        c = Condenser(threshold_tokens=1000, keep_recent=2, summarizer=_stub_summarizer)
+        assert c.should_condense(1000) is True
+
+    def test_above_threshold_returns_true(self) -> None:
+        c = Condenser(threshold_tokens=1000, keep_recent=2, summarizer=_stub_summarizer)
+        assert c.should_condense(5_000) is True
+
+
+# ── Structural invariants ────────────────────────────────────────────────────
+
+
+class TestCondense:
+    async def test_no_op_when_too_short_to_compress(self) -> None:
+        c = Condenser(threshold_tokens=1, keep_recent=10, summarizer=_stub_summarizer)
+        messages = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        out = await c.condense(messages)
+        # 2 messages < anchor(1) + keep_recent(10) + summary(1) → leave untouched.
+        assert out == messages
+
+    async def test_preserves_first_user_message(self) -> None:
+        c = Condenser(threshold_tokens=1, keep_recent=2, summarizer=_stub_summarizer)
+        messages = [
+            {"role": "user", "content": "the original task"},
+            {"role": "assistant", "content": "m1"},
+            {"role": "user", "content": "m2"},
+            {"role": "assistant", "content": "m3"},
+            {"role": "user", "content": "m4"},
+            {"role": "assistant", "content": "m5"},
+        ]
+        out = await c.condense(messages)
+        # First message always retained so the task statement stays visible.
+        assert out[0] == {"role": "user", "content": "the original task"}
+
+    async def test_preserves_last_keep_recent_messages(self) -> None:
+        c = Condenser(threshold_tokens=1, keep_recent=2, summarizer=_stub_summarizer)
+        messages = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "m1"},
+            {"role": "user", "content": "m2"},
+            {"role": "assistant", "content": "m3"},
+            {"role": "user", "content": "latest-1"},
+            {"role": "assistant", "content": "latest"},
+        ]
+        out = await c.condense(messages)
+        assert out[-2:] == [
+            {"role": "user", "content": "latest-1"},
+            {"role": "assistant", "content": "latest"},
+        ]
+
+    async def test_injects_summary_between_anchor_and_tail(self) -> None:
+        c = Condenser(threshold_tokens=1, keep_recent=2, summarizer=_stub_summarizer)
+        messages = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "m1"},
+            {"role": "user", "content": "m2"},
+            {"role": "assistant", "content": "m3"},
+            {"role": "user", "content": "latest-1"},
+            {"role": "assistant", "content": "latest"},
+        ]
+        out = await c.condense(messages)
+        # Shape: [task, summary, latest-1, latest]
+        assert len(out) == 4
+        summary_msg = out[1]
+        assert summary_msg["role"] == "user"
+        body = summary_msg["content"]
+        assert isinstance(body, str)
+        assert "summary" in body.lower()
+
+    async def test_summarizer_receives_middle_slice(self) -> None:
+        seen: list[list[dict[str, object]]] = []
+
+        async def recording(messages: list[dict[str, object]]) -> str:
+            seen.append(messages)
+            return "summary"
+
+        c = Condenser(threshold_tokens=1, keep_recent=2, summarizer=recording)
+        messages = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "middle-1"},
+            {"role": "user", "content": "middle-2"},
+            {"role": "assistant", "content": "middle-3"},
+            {"role": "user", "content": "last-user"},
+            {"role": "assistant", "content": "last-assist"},
+        ]
+        await c.condense(messages)
+        assert seen
+        mid = seen[0]
+        # Summarizer sees the middle 3 — not the anchor, not the tail.
+        assert [m["content"] for m in mid] == ["middle-1", "middle-2", "middle-3"]
+
+    async def test_summarizer_failure_returns_original(self) -> None:
+        async def exploding(_: list[dict[str, object]]) -> str:
+            raise RuntimeError("summarizer crashed")
+
+        c = Condenser(threshold_tokens=1, keep_recent=2, summarizer=exploding)
+        messages = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": "m1"},
+            {"role": "user", "content": "m2"},
+            {"role": "assistant", "content": "m3"},
+            {"role": "user", "content": "latest-1"},
+            {"role": "assistant", "content": "latest"},
+        ]
+        out = await c.condense(messages)
+        # On summarizer failure we keep the original rather than drop context.
+        assert out == messages
+
+
+# ── DbC ──────────────────────────────────────────────────────────────────────
+
+
+class TestPreconditions:
+    def test_threshold_must_be_positive(self) -> None:
+        from conductor.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError, match="threshold"):
+            Condenser(threshold_tokens=0, keep_recent=2, summarizer=_stub_summarizer)
+
+    def test_keep_recent_must_be_positive(self) -> None:
+        from conductor.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError, match="keep_recent"):
+            Condenser(threshold_tokens=1000, keep_recent=0, summarizer=_stub_summarizer)


### PR DESCRIPTION
## Summary

Closes **#72**. A 150-turn agent loop can balloon its message list past the model's context window. Instead of hitting a hard error, we summarize the middle turns into a single synthetic `[Prior turns summarized: ...]` message, preserving the original task (anchor) and the most recent turns (tail) verbatim.

## New

### `conductor/backends/condensation.py`
- `Condenser` — `should_condense(total_tokens)` + async `condense(messages)`.
- Invariants across `condense()`:
  1. First message (task statement) always retained.
  2. Last `keep_recent` messages always retained verbatim.
  3. Output shorter than input, or input returned unchanged.
  4. Summary message is `role=user` with `[Prior turns summarized: ...]` wrapper so user/assistant alternation stays well-formed for downstream models.
- Summarizer is injected (`SummarizerFn`) — zero coupling to the Anthropic client.
- **DbC:** `threshold_tokens` and `keep_recent` both must be ≥ 1.
- On summarizer failure: returns the original messages (context preserved rather than lost).

### `conductor/backends/agent_loop.py`
- `AgentLoopBackend` accepts `condenser: Condenser | None = None`.
- Between turns, when `should_condense(cumulative_prompt_tokens)` is `True`, `condense()` replaces `sdk_messages` in place before the next API call.
- No-op when `condenser is None` — preserves prior behaviour byte-for-byte.

## Tests (15 new)

`test_condensation.py` (11):
- Threshold policy: below / at / above.
- Structural: no-op when list too short; anchor preserved; tail preserved; summary inserted between; summarizer receives *only* the middle slice.
- Resilience: summarizer failure returns original list — never drops context.
- DbC preconditions: positive threshold + keep_recent enforced.

`test_agent_loop_condensation.py` (4):
- Not called when no condenser configured.
- Called when token threshold is hit; condensed list reaches the next API call verbatim.
- Not called when below threshold.
- Real `Condenser` instance wires up cleanly.

## Design notes

- **LOD:** `Condenser` is standalone — no knowledge of LLM SDK, cost ledger, or workspace. Agent loop composes via two calls.
- **DRY:** single source of truth for condensation policy. Reusable from any backend that accumulates messages.
- **Reversibility:** `condenser=None` preserves current behaviour. Opting in is passing an argument; opting out is removing it.
- **TDD:** 11 red-green tests on `Condenser` alone before any integration.

## Test plan
- [x] 15 new tests pass locally
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy --strict` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)