### PR TITLE
feat(backend): OllamaAgentLoopBackend — multi-turn loop via local Ollama (#75)

### DIFF
--- a/conductor/backends/ollama_agent_loop.py
+++ b/conductor/backends/ollama_agent_loop.py
@@ -1,0 +1,304 @@
+"""Multi-turn agent loop backend backed by Ollama (local inference).
+
+Ollama exposes an OpenAI-compatible endpoint (``/v1/chat/completions``), so
+we speak the same JSON shape as OpenAI: the MCP registry emits tool
+schemas via ``to_openai()`` and the response's ``message.tool_calls`` drive
+the next turn.
+
+Why a separate backend instead of a flag on :class:`AgentLoopBackend`?
+Keeping them split means the Anthropic loop doesn't grow a set of Ollama-
+only branches and vice versa — easier to reason about, easier to delete
+if one provider goes away. When their shapes converge we can collapse.
+
+DRY: tool handlers come from ``conductor.tools.build_default_registry``
+(shared with the Anthropic loop). One registry, many providers.
+
+LOD: the HTTP client is injected (any async-post callable with a json
+kwarg will do). Tests pass a recorder; prod passes ``httpx.AsyncClient``.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import os
+import time
+from collections.abc import AsyncIterator, Callable
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Protocol
+
+from conductor.backends.base import (
+    BackendCapabilities,
+    BackendResponse,
+    ILLMBackend,
+    Message,
+    MessageRole,
+    TokenUsage,
+)
+from conductor.backends.condensation import Condenser
+from conductor.backends.registry import registry
+from conductor.gh.ci_patterns import detect_ci_profile
+from conductor.gh.repo_map import build_repo_map
+from conductor.tools import ToolRegistry, build_default_registry
+
+__all__ = [
+    "OllamaAgentLoopBackend",
+    "WallClockTimeoutError",
+]
+
+
+# Reuse the same wall-clock exception the Anthropic loop uses. Import lazily
+# so this module stays importable even if the other backend is removed.
+from conductor.backends.agent_loop import WallClockTimeoutError
+
+
+class _PostClient(Protocol):
+    """Minimal protocol for an injected HTTP client — only .post is needed."""
+
+    async def post(
+        self,
+        url: str,
+        json: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> Any: ...
+
+    async def aclose(self) -> None: ...
+
+
+#: Default URL of Ollama's OpenAI-compatible endpoint.
+DEFAULT_BASE_URL = "http://localhost:11434/v1"
+
+#: Purpose-built for agentic code editing, 24B, runs on 24 GB VRAM.
+DEFAULT_MODEL = "devstral"
+
+
+class OllamaAgentLoopBackend(ILLMBackend):
+    """Multi-turn tool-use loop against a local Ollama server."""
+
+    name = "ollama-agent-loop"
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        model: str = DEFAULT_MODEL,
+        max_turns: int = 150,
+        timeout: float = 600.0,
+        workspace_dir: str | None = None,
+        wall_clock_timeout_seconds: float | None = None,
+        registry_factory: Callable[[Path], ToolRegistry] | None = None,
+        client: _PostClient | None = None,
+        condenser: Condenser | None = None,
+    ) -> None:
+        self.base_url = (base_url or os.environ.get("OLLAMA_BASE_URL") or DEFAULT_BASE_URL).rstrip(
+            "/"
+        )
+        self.default_model = model
+        self._max_turns = max_turns
+        self._workspace = workspace_dir
+        self._wall_clock = wall_clock_timeout_seconds
+        self._registry_factory = registry_factory or build_default_registry
+        self._client: _PostClient = client or _default_httpx_client(timeout)
+        self._condenser = condenser
+
+    # ── ILLMBackend surface ──────────────────────────────────────────────────
+
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        model: str | None = None,
+        temperature: float = 1.0,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        workspace_dir: str | None = None,
+        max_turns: int | None = None,
+        **_: Any,
+    ) -> BackendResponse:
+        effective_workspace = Path(workspace_dir or self._workspace or os.getcwd()).resolve()
+        effective_model = model or self.default_model
+        effective_max_turns = max_turns if max_turns is not None else self._max_turns
+
+        tool_registry = self._registry_factory(effective_workspace)
+        tool_defs = tool_registry.to_openai()
+
+        sdk_messages = self._build_messages(messages, workspace=effective_workspace)
+
+        deadline: float | None = None
+        if self._wall_clock is not None:
+            deadline = time.monotonic() + self._wall_clock
+
+        total_usage = TokenUsage()
+        last_text = ""
+
+        for turn in range(effective_max_turns):
+            if deadline is not None and time.monotonic() >= deadline:
+                raise WallClockTimeoutError(
+                    f"agent loop exceeded wall-clock timeout of {self._wall_clock}s"
+                )
+
+            if self._condenser is not None and self._condenser.should_condense(
+                total_usage.prompt_tokens
+            ):
+                sdk_messages = await self._condenser.condense(sdk_messages)
+
+            payload = {
+                "model": effective_model,
+                "messages": sdk_messages,
+                "tools": tool_defs,
+                "temperature": temperature,
+            }
+            if max_tokens is not None:
+                payload["max_tokens"] = max_tokens
+
+            resp = await self._client.post(f"{self.base_url}/chat/completions", json=payload)
+            resp.raise_for_status()
+            body = resp.json()
+
+            usage = body.get("usage") or {}
+            total_usage = total_usage + TokenUsage(
+                prompt_tokens=int(usage.get("prompt_tokens", 0)),
+                completion_tokens=int(usage.get("completion_tokens", 0)),
+                total_tokens=int(usage.get("total_tokens", 0)),
+            )
+
+            choice = (body.get("choices") or [{}])[0]
+            message = choice.get("message") or {}
+            finish_reason = choice.get("finish_reason") or "stop"
+
+            if message.get("content"):
+                last_text = str(message["content"])
+
+            tool_calls = message.get("tool_calls") or []
+            if finish_reason == "tool_calls" and tool_calls:
+                sdk_messages.append(message)  # assistant turn
+                for call in tool_calls:
+                    fn = call.get("function") or {}
+                    args = _parse_args(fn.get("arguments"))
+                    result = await tool_registry.invoke(str(fn.get("name", "")), args)
+                    content = f"ERROR: {result.content}" if result.is_error else result.content
+                    sdk_messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": str(call.get("id", "")),
+                            "content": content,
+                        }
+                    )
+                continue
+
+            return BackendResponse(
+                content=last_text,
+                finish_reason=finish_reason,
+                usage=total_usage,
+                model=str(body.get("model", effective_model)),
+                backend=self.name,
+                raw={"turns": turn + 1},
+            )
+
+        raise RuntimeError(f"agent loop exceeded max_turns={effective_max_turns} without end_turn")
+
+    async def stream(
+        self,
+        messages: list[Message],
+        *,
+        model: str | None = None,
+        temperature: float = 1.0,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        resp = await self.complete(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+        yield resp.content
+
+    async def health_check(self) -> bool:
+        with suppress(Exception):
+            resp = await self._client.post(
+                f"{self.base_url}/chat/completions",
+                json={
+                    "model": self.default_model,
+                    "messages": [{"role": "user", "content": "."}],
+                    "max_tokens": 1,
+                },
+            )
+            return 200 <= getattr(resp, "status_code", 500) < 300
+        return False
+
+    def capabilities(self, model: str) -> BackendCapabilities:
+        return BackendCapabilities(
+            supports_streaming=False,
+            supports_tool_use=True,
+            supports_vision=False,
+            supports_system_prompt=True,
+            max_context_tokens=128_000,
+            is_local=True,
+            cost_per_1k_input_tokens=0.0,
+            cost_per_1k_output_tokens=0.0,
+        )
+
+    # ── System prompt + message assembly ────────────────────────────────────
+
+    def _build_messages(self, messages: list[Message], *, workspace: Path) -> list[dict[str, Any]]:
+        """Build the ``messages`` payload with system blocks prepended.
+
+        Ollama's OpenAI-compatible endpoint uses the standard role-based
+        messages. We prepend a single system message with workspace hints,
+        CI profile, and repo map. No prompt-caching envelope (Ollama is
+        local — caching is a cloud-bill concern).
+        """
+        system_texts: list[str] = [m.content for m in messages if m.role is MessageRole.SYSTEM]
+        conversation = [
+            {"role": m.role.value, "content": m.content}
+            for m in messages
+            if m.role is not MessageRole.SYSTEM
+        ]
+
+        system_parts: list[str] = [t for t in system_texts if t]
+        system_parts.append(
+            "You have tools to read, write, edit, search files and run bash inside the workspace. "
+            "All paths are relative to the workspace root."
+        )
+        system_parts.append(f"Workspace: {workspace}")
+
+        with suppress(Exception):
+            ci_block = detect_ci_profile(workspace).to_prompt()
+            if ci_block:
+                system_parts.append(ci_block)
+
+        with suppress(Exception):
+            map_block = build_repo_map(workspace).to_prompt(max_chars=2000)
+            if map_block:
+                system_parts.append(map_block)
+
+        return [{"role": "system", "content": "\n\n".join(system_parts)}, *conversation]
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _parse_args(raw: Any) -> dict[str, Any]:
+    """OpenAI-spec tool arguments are a JSON string; Ollama often agrees."""
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str) or not raw.strip():
+        return {}
+    try:
+        parsed = _json.loads(raw)
+    except _json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _default_httpx_client(timeout: float) -> _PostClient:
+    """Lazy import so the backend module stays importable without httpx."""
+    import httpx
+
+    return httpx.AsyncClient(timeout=timeout)  # type: ignore[return-value]
+
+
+registry.register("ollama-agent-loop", OllamaAgentLoopBackend)

--- a/tests/unit/test_ollama_agent_loop.py
+++ b/tests/unit/test_ollama_agent_loop.py
@@ -1,0 +1,204 @@
+"""Tests for OllamaAgentLoopBackend — multi-turn tool-use against a local model.
+
+Ollama's OpenAI-compatible endpoint (``/v1/chat/completions``) speaks the
+same JSON shape as OpenAI: we use ``registry.to_openai()`` for tool
+schemas and drive a tool_use loop the same way as the Anthropic agent
+loop.
+
+All HTTP is mocked via an injected async client so tests never touch
+localhost:11434.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from conductor.backends.base import Message, MessageRole
+from conductor.backends.ollama_agent_loop import OllamaAgentLoopBackend
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict[str, Any], status: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _FakeClient:
+    """Records every POST and returns canned JSON payloads in order."""
+
+    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+        self._payloads = list(payloads)
+        self.posts: list[dict[str, Any]] = []
+
+    async def post(
+        self, url: str, json: dict[str, Any], headers: dict[str, str] | None = None
+    ) -> _FakeResponse:
+        self.posts.append({"url": url, "json": json, "headers": headers or {}})
+        if not self._payloads:
+            raise AssertionError("unexpected extra POST — ran out of canned responses")
+        return _FakeResponse(self._payloads.pop(0))
+
+    async def aclose(self) -> None:
+        pass
+
+
+def _chat_completion(
+    *,
+    content: str | None = "done",
+    tool_calls: list[dict[str, Any]] | None = None,
+    finish_reason: str = "stop",
+    prompt_tokens: int = 20,
+    completion_tokens: int = 5,
+) -> dict[str, Any]:
+    """Construct a canned OpenAI-shaped chat.completions response."""
+    message: dict[str, Any] = {"role": "assistant"}
+    if content is not None:
+        message["content"] = content
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    return {
+        "id": "chatcmpl-x",
+        "model": "devstral",
+        "choices": [{"index": 0, "message": message, "finish_reason": finish_reason}],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+
+
+def _user(text: str) -> list[Message]:
+    return [Message(role=MessageRole.USER, content=text)]
+
+
+# ── Construction ────────────────────────────────────────────────────────────
+
+
+class TestInit:
+    def test_default_base_url(self, tmp_path: Path) -> None:
+        backend = OllamaAgentLoopBackend(workspace_dir=str(tmp_path))
+        assert backend.base_url == "http://localhost:11434/v1"
+
+    def test_custom_base_url(self, tmp_path: Path) -> None:
+        backend = OllamaAgentLoopBackend(
+            workspace_dir=str(tmp_path), base_url="http://node.local:22222/v1"
+        )
+        assert backend.base_url == "http://node.local:22222/v1"
+
+    def test_default_model_is_devstral(self, tmp_path: Path) -> None:
+        backend = OllamaAgentLoopBackend(workspace_dir=str(tmp_path))
+        assert backend.default_model == "devstral"
+
+
+# ── Loop control ────────────────────────────────────────────────────────────
+
+
+class TestLoopControl:
+    async def test_ends_on_finish_reason_stop(self, tmp_path: Path) -> None:
+        client = _FakeClient([_chat_completion(content="all done")])
+        backend = OllamaAgentLoopBackend(workspace_dir=str(tmp_path), client=client)
+        out = await backend.complete(_user("hi"))
+        assert out.content == "all done"
+        assert out.finish_reason == "stop"
+
+    async def test_tool_use_continues_loop(self, tmp_path: Path) -> None:
+        (tmp_path / "hello.txt").write_text("world")
+        tool_call = {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": '{"path": "hello.txt"}'},
+        }
+        client = _FakeClient(
+            [
+                _chat_completion(
+                    content=None,
+                    tool_calls=[tool_call],
+                    finish_reason="tool_calls",
+                ),
+                _chat_completion(content="I read it."),
+            ]
+        )
+        backend = OllamaAgentLoopBackend(workspace_dir=str(tmp_path), client=client)
+        out = await backend.complete(_user("read hello.txt"))
+        assert out.content == "I read it."
+        # Second POST must carry a tool result for call_1.
+        assert len(client.posts) == 2
+        follow_up_msgs = client.posts[1]["json"]["messages"]
+        tool_msg = follow_up_msgs[-1]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "call_1"
+        assert "world" in tool_msg["content"]
+
+    async def test_max_turns_raises_when_stuck_in_tool_loop(self, tmp_path: Path) -> None:
+        (tmp_path / "x").write_text("x")
+        looping_call = {
+            "id": "call_x",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": '{"path": "x"}'},
+        }
+        client = _FakeClient(
+            [
+                _chat_completion(
+                    content=None, tool_calls=[looping_call], finish_reason="tool_calls"
+                ),
+                _chat_completion(
+                    content=None, tool_calls=[looping_call], finish_reason="tool_calls"
+                ),
+                _chat_completion(
+                    content=None, tool_calls=[looping_call], finish_reason="tool_calls"
+                ),
+            ]
+        )
+        backend = OllamaAgentLoopBackend(workspace_dir=str(tmp_path), client=client, max_turns=3)
+        with pytest.raises(RuntimeError, match="max_turns"):
+            await backend.complete(_user("hi"))
+
+
+# ── Tool schema format ──────────────────────────────────────────────────────
+
+
+class TestToolSchemas:
+    async def test_uses_openai_function_calling_shape(self, tmp_path: Path) -> None:
+        client = _FakeClient([_chat_completion(content="ok")])
+        backend = OllamaAgentLoopBackend(workspace_dir=str(tmp_path), client=client)
+        await backend.complete(_user("hi"))
+        tools = client.posts[0]["json"]["tools"]
+        # OpenAI shape: {"type": "function", "function": {"name", "parameters", ...}}
+        for t in tools:
+            assert t["type"] == "function"
+            assert "name" in t["function"]
+            assert "parameters" in t["function"]
+        names = {t["function"]["name"] for t in tools}
+        assert {
+            "read_file",
+            "write_file",
+            "edit_file",
+            "glob_files",
+            "grep_files",
+            "run_bash",
+        } <= names
+
+
+# ── Capabilities ────────────────────────────────────────────────────────────
+
+
+class TestCapabilities:
+    def test_is_local_true(self, tmp_path: Path) -> None:
+        caps = OllamaAgentLoopBackend(workspace_dir=str(tmp_path)).capabilities("devstral")
+        assert caps.is_local is True
+        assert caps.cost_per_1k_input_tokens == 0.0
+        assert caps.cost_per_1k_output_tokens == 0.0
+        assert caps.supports_tool_use is True


### PR DESCRIPTION
## Summary

Closes **#75**. Brings the full agent loop (tool-use, CI profile injection, repo map, optional condensation, wall-clock timeout) to a locally-hosted model via Ollama's OpenAI-compatible endpoint. Zero API cost, zero data leaving the machine — the payoff of the MCP registry (#74) is that a new provider is *one file* that emits `to_openai()` instead of `to_anthropic()`.

## New

### `conductor/backends/ollama_agent_loop.py`
- `OllamaAgentLoopBackend` — `ILLMBackend` adapter with embedded multi-turn loop.
- Uses `conductor.tools.build_default_registry` (same as the Anthropic loop) — DRY across providers.
- Tool schemas via `registry.to_openai()` — same `ToolSpec` instances, a different emitter.
- Accepts an injected `client: _PostClient` for testability; prod default is `httpx.AsyncClient`.
- **Default model: `devstral`** — purpose-built for agentic code editing, 24B params, fits on 24 GB VRAM. Override via constructor or `OLLAMA_BASE_URL`.
- Reuses `WallClockTimeoutError` from the Anthropic loop — no duplicated exception class.
- Optional `Condenser` hook — shares the condensation primitive from #72.
- System prompt composition mirrors the Anthropic loop: workspace hint + CI profile (#69) + repo map (#73) + any inherited system messages.

## Tests (8 new)

`tests/unit/test_ollama_agent_loop.py`:
- **Init:** default `base_url`, custom `base_url`, default model is `devstral`.
- **Loop control:** ends on `finish_reason=stop`; `tool_use` continues loop with proper `tool_call_id` echo back; `max_turns` enforced.
- **Tool schemas:** OpenAI function-calling shape, all six built-ins present.
- **Capabilities:** `is_local=True`, zero cost, `supports_tool_use=True`.

## Design notes

- **LOD:** HTTP client is a `Protocol` — one `.post()` method. Tests pass a recorder; prod passes httpx. Backend knows nothing about HTTP internals.
- **DRY:** tools, CI profile detection, repo map, and condensation are all imported from the shared modules. Zero duplication with `AgentLoopBackend`.
- **Reversibility:** separate backend class instead of a provider flag on `AgentLoopBackend` — either can be deleted independently when their shapes diverge.
- **Agent Agnostic Development:** this is *exactly* the point of the MCP registry — one tool definition set, N provider emitters.
- **TDD:** 8 red-green tests cover construction, loop control, tool schema emission, capability flags.

## Follow-ups (not in this PR)

- `conductor init --backend ollama-agent-loop --model devstral` CLI prompt — touches typer plumbing; separate PR.
- Streaming tool_call deltas (OpenAI spec supports it) — for now `stream()` falls through to `complete()`.

## Test plan
- [x] 8 new unit tests pass locally
- [x] `ruff check` + `ruff format --check` clean
- [x] `mypy --strict` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)