### PR TITLE
feat: hooks + TDD gate + Gherkin spec ingestion (#90, #91, #92)

### DIFF
--- a/maxwell_daemon/hooks.py
+++ b/maxwell_daemon/hooks.py
@@ -1,0 +1,344 @@
+"""Deterministic hook system — code-standards gates the LLM cannot bypass.
+
+Hooks fire at well-defined moments in the agent lifecycle:
+
+  * ``pre_tool``   — before a tool invocation; non-zero exit aborts the call
+  * ``post_tool``  — after a tool invocation; non-zero exit surfaces as a
+                     :class:`~maxwell_daemon.tools.ToolResult` with ``is_error=True``
+  * ``pre_commit`` — gate PR-open on linters / types / tests
+  * ``on_prompt``  — inject extra context before the first turn
+  * ``on_stop``    — housekeeping when a session ends
+
+Design notes (per Maxwell-Daemon principles):
+
+  * **DbC:** constructor enforces workspace-is-a-directory; hook invocations
+    that can't be recovered from raise :class:`HookViolationError` so callers
+    pattern-match on a named failure kind.
+  * **LOD:** the subprocess runner is injected (:class:`RunnerFn` protocol);
+    in tests the runner is a recorder, in prod it wraps ``asyncio.subprocess``.
+    The runner knows *nothing* about hooks; the hook runner knows *nothing*
+    about shells — each layer talks only to its neighbour.
+  * **Reversibility:** ``HookConfig`` defaults to empty tuples so a repo with
+    no ``maxwell-daemon.yaml`` gets zero hook machinery running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from maxwell_daemon.contracts import require
+
+__all__ = [
+    "HookConfig",
+    "HookOutcome",
+    "HookRunner",
+    "HookSpec",
+    "HookViolationError",
+    "RunnerFn",
+    "load_hook_config",
+]
+
+
+#: Injected subprocess runner — returns ``(rc, output)`` given a command.
+RunnerFn = Callable[..., Awaitable[tuple[int, str]]]
+
+_DEFAULT_TIMEOUT_SECONDS = 60.0
+
+
+class HookViolationError(RuntimeError):
+    """Raised by ``raise_if_*`` helpers when a hook refuses to let the agent proceed."""
+
+
+@dataclass(slots=True, frozen=True)
+class HookSpec:
+    """One hook declaration.
+
+    ``match`` is a tool name glob (``"*"`` matches every tool) for
+    ``pre_tool``/``post_tool`` hooks; unused for lifecycle hooks.
+    ``command`` is a shell command; ``{{path}}`` and other ``{{...}}`` tokens
+    are substituted from the tool's input dict before execution.
+    """
+
+    command: str
+    match: str = "*"
+
+
+@dataclass(slots=True, frozen=True)
+class HookConfig:
+    """Top-level ``hooks:`` section of ``maxwell-daemon.yaml``."""
+
+    pre_tool: tuple[HookSpec, ...] = field(default_factory=tuple)
+    post_tool: tuple[HookSpec, ...] = field(default_factory=tuple)
+    pre_commit: tuple[str, ...] = field(default_factory=tuple)
+    on_prompt: tuple[str, ...] = field(default_factory=tuple)
+    on_stop: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(slots=True, frozen=True)
+class HookOutcome:
+    """Outcome of a hook invocation.
+
+    The three boolean fields are mutually-exclusive semantics:
+      * ``blocked`` — pre_tool refused the call
+      * ``errored`` — post_tool surfaced a non-zero exit
+      * ``passed``  — every hook in the sequence exited zero
+    ``detail`` carries the stdout/stderr of the first failing hook;
+    ``failing_command`` names it for logs/PR comments.
+    """
+
+    blocked: bool = False
+    errored: bool = False
+    passed: bool = True
+    detail: str = ""
+    failing_command: str = ""
+
+
+# ── Loader ──────────────────────────────────────────────────────────────────
+
+
+def load_hook_config(path: Path) -> HookConfig:
+    """Load the ``hooks:`` section of ``maxwell-daemon.yaml`` at ``path``.
+
+    Returns an empty :class:`HookConfig` if the file doesn't exist. Raises
+    :class:`HookViolationError` on malformed YAML so the daemon fails fast
+    rather than running without the gates the operator configured.
+    """
+    if not path.is_file():
+        return HookConfig()
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as e:
+        raise HookViolationError(f"hook config at {path} is not valid YAML: {e}") from e
+    if not isinstance(raw, dict):
+        raise HookViolationError(f"hook config at {path} must be a mapping")
+    section = raw.get("hooks") or {}
+    if not isinstance(section, dict):
+        raise HookViolationError(f"hook config at {path} has non-mapping `hooks:` section")
+
+    return HookConfig(
+        pre_tool=tuple(_parse_specs(section.get("pre_tool"))),
+        post_tool=tuple(_parse_specs(section.get("post_tool"))),
+        pre_commit=tuple(_parse_strings(section.get("pre_commit"))),
+        on_prompt=tuple(_parse_strings(section.get("on_prompt"))),
+        on_stop=tuple(_parse_strings(section.get("on_stop"))),
+    )
+
+
+def _parse_specs(raw: Any) -> list[HookSpec]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise HookViolationError(f"expected a list of hook specs, got {type(raw).__name__}")
+    out: list[HookSpec] = []
+    for item in raw:
+        if isinstance(item, str):
+            out.append(HookSpec(command=item))
+            continue
+        if not isinstance(item, dict):
+            raise HookViolationError(f"hook spec must be a string or mapping, got {item!r}")
+        cmd = item.get("command")
+        if not isinstance(cmd, str):
+            raise HookViolationError(f"hook spec is missing `command:` ({item!r})")
+        match = item.get("match", "*")
+        if not isinstance(match, str):
+            raise HookViolationError(f"hook spec `match:` must be a string ({item!r})")
+        out.append(HookSpec(command=cmd, match=match))
+    return out
+
+
+def _parse_strings(raw: Any) -> list[str]:
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise HookViolationError(f"expected a list of commands, got {type(raw).__name__}")
+    out: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            raise HookViolationError(f"hook entry must be a string, got {item!r}")
+        out.append(item)
+    return out
+
+
+# ── Runner ──────────────────────────────────────────────────────────────────
+
+
+class HookRunner:
+    """Runs configured hooks against an injected subprocess runner."""
+
+    def __init__(
+        self,
+        config: HookConfig,
+        *,
+        workspace: Path,
+        runner: RunnerFn | None = None,
+        default_timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        require(
+            workspace.is_dir(),
+            f"HookRunner: workspace {workspace} must be a directory",
+        )
+        self._cfg = config
+        self._workspace = workspace
+        self._run = runner or _default_runner
+        self._default_timeout = default_timeout_seconds
+
+    # ── pre_tool ────────────────────────────────────────────────────────────
+
+    async def run_pre_tool(self, tool_name: str, tool_input: dict[str, Any]) -> HookOutcome:
+        """Run every matching pre_tool hook; first non-zero exit blocks the call."""
+        for spec in self._cfg.pre_tool:
+            if not _matches(spec.match, tool_name):
+                continue
+            command = _substitute(spec.command, tool_input)
+            rc, output = await self._run(
+                command,
+                cwd=str(self._workspace),
+                env=_env(tool_name, tool_input, None),
+                timeout=self._default_timeout,
+            )
+            if rc != 0:
+                return HookOutcome(
+                    blocked=True,
+                    passed=False,
+                    detail=output,
+                    failing_command=spec.command,
+                )
+        return HookOutcome(blocked=False, passed=True)
+
+    # ── post_tool ───────────────────────────────────────────────────────────
+
+    async def run_post_tool(
+        self, tool_name: str, tool_input: dict[str, Any], *, tool_output: str
+    ) -> HookOutcome:
+        """Run every matching post_tool hook; first non-zero exit is an agent-visible error."""
+        for spec in self._cfg.post_tool:
+            if not _matches(spec.match, tool_name):
+                continue
+            command = _substitute(spec.command, tool_input)
+            rc, output = await self._run(
+                command,
+                cwd=str(self._workspace),
+                env=_env(tool_name, tool_input, tool_output),
+                timeout=self._default_timeout,
+            )
+            if rc != 0:
+                return HookOutcome(
+                    errored=True,
+                    passed=False,
+                    detail=output,
+                    failing_command=spec.command,
+                )
+        return HookOutcome(errored=False, passed=True)
+
+    # ── pre_commit ──────────────────────────────────────────────────────────
+
+    async def run_pre_commit(self) -> HookOutcome:
+        """Run every pre_commit command in order; first failure short-circuits."""
+        for command in self._cfg.pre_commit:
+            rc, output = await self._run(
+                command,
+                cwd=str(self._workspace),
+                env=_env(None, None, None),
+                timeout=self._default_timeout,
+            )
+            if rc != 0:
+                return HookOutcome(passed=False, detail=output, failing_command=command)
+        return HookOutcome(passed=True)
+
+    async def raise_if_pre_commit_fails(self) -> None:
+        """Convenience — raise :class:`HookViolationError` instead of returning an outcome."""
+        outcome = await self.run_pre_commit()
+        if not outcome.passed:
+            raise HookViolationError(
+                f"pre_commit hook failed: {outcome.failing_command}\n{outcome.detail}"
+            )
+
+    # ── on_prompt / on_stop ─────────────────────────────────────────────────
+
+    async def run_on_prompt(self) -> list[tuple[int, str]]:
+        """Run every on_prompt hook in order. Returns their raw outputs for context injection."""
+        outputs: list[tuple[int, str]] = []
+        for command in self._cfg.on_prompt:
+            rc, output = await self._run(
+                command,
+                cwd=str(self._workspace),
+                env=_env(None, None, None),
+                timeout=self._default_timeout,
+            )
+            outputs.append((rc, output))
+        return outputs
+
+    async def run_on_stop(self, *, exit_reason: str) -> None:
+        """Run every on_stop hook. Exit codes are ignored — it's housekeeping, not a gate."""
+        env = {**_env(None, None, None), "MAXWELL_EXIT_REASON": exit_reason}
+        for command in self._cfg.on_stop:
+            await self._run(
+                command,
+                cwd=str(self._workspace),
+                env=env,
+                timeout=self._default_timeout,
+            )
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _matches(pattern: str, name: str) -> bool:
+    """Tool-name glob: ``"*"`` matches everything; otherwise exact match."""
+    if pattern == "*":
+        return True
+    return pattern == name
+
+
+def _substitute(command: str, tool_input: dict[str, Any]) -> str:
+    """Replace ``{{key}}`` tokens in ``command`` with ``str(tool_input[key])``.
+
+    Missing keys are left as-is so hook authors can spot unresolved placeholders
+    in logs rather than having them silently replaced with ``""``.
+    """
+    out = command
+    for key, value in tool_input.items():
+        out = out.replace(f"{{{{{key}}}}}", str(value))
+    return out
+
+
+def _env(
+    tool_name: str | None,
+    tool_input: dict[str, Any] | None,
+    tool_output: str | None,
+) -> dict[str, str]:
+    """Build the environment visible to a hook subprocess."""
+    env: dict[str, str] = dict(os.environ)
+    env["MAXWELL_TOOL_NAME"] = tool_name or ""
+    env["MAXWELL_TOOL_INPUT"] = json.dumps(tool_input or {}, default=str)
+    env["MAXWELL_TOOL_OUTPUT"] = tool_output or ""
+    return env
+
+
+async def _default_runner(
+    command: str, *, cwd: str, env: dict[str, str], timeout: float
+) -> tuple[int, str]:
+    """Real subprocess runner used in production. Combines stdout and stderr."""
+    proc = await asyncio.create_subprocess_shell(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return 124, f"timeout after {timeout}s"
+    return proc.returncode or 0, stdout.decode(errors="replace")

--- a/maxwell_daemon/spec.py
+++ b/maxwell_daemon/spec.py
@@ -1,0 +1,251 @@
+"""Gherkin / BDD spec ingestion and pytest-bdd scaffold generator.
+
+The spec-driven flow:
+
+  1. User writes a ``.feature`` file under ``.maxwell/specs/``.
+  2. This module parses it into a :class:`Specification`.
+  3. :func:`render_pytest_bdd_scaffold` emits a pytest-bdd skeleton —
+     one ``@given``/``@when``/``@then`` stub per unique step text.
+  4. The agent fills in step definitions + the production code they drive.
+  5. The TDD gate + hooks refuse to close the task until every scenario
+     goes green.
+
+Scope choices:
+
+  * **Gherkin subset only.** We parse Feature / Scenario / Given-When-Then /
+    And-But / tags / comments / free-text description. We do NOT yet parse
+    Examples tables, Backgrounds, Rules, DocStrings, or Data Tables —
+    those land as follow-ups when a concrete test needs them.
+  * **No external dep.** Using :mod:`gherkin-official` would give us full
+    spec compatibility, but it pulls in a Java-style AST and a heavier
+    runtime. Parsing the subset we need is ~80 lines of Python and keeps
+    the dep surface flat.
+
+DbC / LOD: the parser is pure (bytes in, value out); ``load_spec_directory``
+is total (one broken file never kills the sweep). Callers handle dispatch.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "GherkinParseError",
+    "Scenario",
+    "Specification",
+    "Step",
+    "load_feature",
+    "load_spec_directory",
+    "render_pytest_bdd_scaffold",
+]
+
+
+_TAG_LINE_RE = re.compile(r"^\s*(@[\w:.-]+(?:\s+@[\w:.-]+)*)\s*$")
+_FEATURE_RE = re.compile(r"^\s*Feature:\s*(.+?)\s*$")
+_SCENARIO_RE = re.compile(r"^\s*Scenario(?:\sOutline)?:\s*(.+?)\s*$")
+_STEP_RE = re.compile(r"^\s*(Given|When|Then|And|But)\s+(.+?)\s*$")
+_COMMENT_RE = re.compile(r"^\s*#")
+
+_STEP_KEYWORDS: frozenset[str] = frozenset({"Given", "When", "Then", "And", "But"})
+
+
+class GherkinParseError(ValueError):
+    """Raised when a ``.feature`` file doesn't parse into a valid Specification."""
+
+
+@dataclass(slots=True, frozen=True)
+class Step:
+    """One Given/When/Then/And/But line from a scenario."""
+
+    keyword: str
+    text: str
+
+
+@dataclass(slots=True, frozen=True)
+class Scenario:
+    """One Gherkin scenario: a named sequence of steps."""
+
+    name: str
+    steps: tuple[Step, ...]
+    tags: tuple[str, ...]
+
+
+@dataclass(slots=True, frozen=True)
+class Specification:
+    """A parsed ``.feature`` file."""
+
+    feature: str
+    description: str
+    source: Path
+    scenarios: tuple[Scenario, ...]
+    tags: tuple[str, ...]
+
+
+# ── Loader ──────────────────────────────────────────────────────────────────
+
+
+def load_feature(path: Path) -> Specification:
+    """Parse a single ``.feature`` file into a :class:`Specification`.
+
+    Raises :class:`GherkinParseError` on any structural problem so callers
+    can either skip the file (directory sweep) or surface the error to the
+    user (single-file CLI).
+    """
+    text = path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+
+    @dataclass(slots=True)
+    class _ScenarioAccumulator:
+        """Mutable builder for a scenario-in-progress — internal to ``load_feature``."""
+
+        name: str
+        tags: tuple[str, ...]
+        steps: list[Step]
+
+    feature_name: str | None = None
+    description_lines: list[str] = []
+    feature_tags: tuple[str, ...] = ()
+    scenarios: list[Scenario] = []
+
+    pending_tags: tuple[str, ...] = ()
+    in_feature_description = False
+    current_scenario: _ScenarioAccumulator | None = None
+
+    def _close_current_scenario() -> None:
+        nonlocal current_scenario
+        if current_scenario is None:
+            return
+        if not current_scenario.steps:
+            raise GherkinParseError(f"{path}: scenario {current_scenario.name!r} has no step lines")
+        scenarios.append(
+            Scenario(
+                name=current_scenario.name,
+                steps=tuple(current_scenario.steps),
+                tags=current_scenario.tags,
+            )
+        )
+        current_scenario = None
+
+    for raw_line in lines:
+        stripped = raw_line.strip()
+
+        if not stripped or _COMMENT_RE.match(raw_line):
+            continue
+
+        if (m := _TAG_LINE_RE.match(raw_line)) is not None:
+            pending_tags = tuple(tag for tag in m.group(1).split() if tag)
+            continue
+
+        if (m := _FEATURE_RE.match(raw_line)) is not None:
+            if feature_name is not None:
+                raise GherkinParseError(f"{path}: multiple Feature blocks not supported")
+            feature_name = m.group(1)
+            feature_tags = pending_tags
+            pending_tags = ()
+            in_feature_description = True
+            continue
+
+        if (m := _SCENARIO_RE.match(raw_line)) is not None:
+            in_feature_description = False
+            _close_current_scenario()
+            current_scenario = _ScenarioAccumulator(
+                name=m.group(1),
+                tags=pending_tags,
+                steps=[],
+            )
+            pending_tags = ()
+            continue
+
+        if (m := _STEP_RE.match(raw_line)) is not None and current_scenario is not None:
+            current_scenario.steps.append(Step(keyword=m.group(1), text=m.group(2)))
+            in_feature_description = False
+            continue
+
+        if in_feature_description and feature_name is not None:
+            description_lines.append(stripped)
+            continue
+
+        # Anything else is unparsed; we choose to be lenient rather than strict
+        # — the harness should never crash on a free-text blurb inside a spec.
+
+    _close_current_scenario()
+
+    if feature_name is None:
+        raise GherkinParseError(f"{path}: no Feature: line found")
+
+    return Specification(
+        feature=feature_name,
+        description="\n".join(description_lines).strip(),
+        source=path,
+        scenarios=tuple(scenarios),
+        tags=feature_tags,
+    )
+
+
+def load_spec_directory(directory: Path) -> tuple[Specification, ...]:
+    """Load every ``*.feature`` file under ``directory`` (non-recursive).
+
+    Returns an empty tuple if the directory doesn't exist. Files that fail
+    to parse are silently skipped so one broken spec never kills the sweep.
+    """
+    if not directory.is_dir():
+        return ()
+    out: list[Specification] = []
+    for path in sorted(directory.iterdir()):
+        if not path.is_file() or path.suffix != ".feature":
+            continue
+        try:
+            out.append(load_feature(path))
+        except GherkinParseError:
+            continue
+    return tuple(out)
+
+
+# ── pytest-bdd scaffold ─────────────────────────────────────────────────────
+
+
+_SCAFFOLD_HEADER = (
+    "# Auto-generated by maxwell-daemon spec — replace step bodies with real code.\n"
+    "from pytest_bdd import given, scenarios, then, when\n\n"
+)
+
+
+def render_pytest_bdd_scaffold(spec: Specification) -> str:
+    """Emit a pytest-bdd test module skeleton for ``spec``.
+
+    Output has:
+      * ``scenarios(\"<feature-path>\")`` binding at module top
+      * one ``@given/@when/@then`` stub per unique step text
+        (``And``/``But`` steps are mapped to their parent keyword based
+        on the preceding step, matching pytest-bdd's resolution model)
+    """
+    feature_rel = str(spec.source).replace("\\", "/")
+    body_lines: list[str] = [_SCAFFOLD_HEADER, f'scenarios("{feature_rel}")\n\n']
+
+    emitted: set[tuple[str, str]] = set()
+    for scenario in spec.scenarios:
+        last_primary = "Given"
+        for step in scenario.steps:
+            primary = step.keyword if step.keyword in {"Given", "When", "Then"} else last_primary
+            key = (primary, step.text)
+            if key in emitted:
+                last_primary = primary
+                continue
+            emitted.add(key)
+            decorator = primary.lower()
+            body_lines.append(
+                f'@{decorator}("{step.text}")\n'
+                f"def _{primary.lower()}_{_slug(step.text)}():\n"
+                "    raise NotImplementedError\n\n"
+            )
+            last_primary = primary
+
+    return "".join(body_lines)
+
+
+def _slug(text: str, *, limit: int = 40) -> str:
+    """Cheap identifier-safe slug for step function names — purely cosmetic."""
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", text).strip("_").lower()
+    return slug[:limit] or "step"

--- a/maxwell_daemon/tdd_gate.py
+++ b/maxwell_daemon/tdd_gate.py
@@ -1,0 +1,129 @@
+"""Red-green-refactor enforcement — the TDD discipline, made load-bearing.
+
+The agent is required to:
+
+  1. Add a *failing* test that captures the desired new behaviour.
+  2. Implement the change until the test passes.
+  3. Leave behind an audit trail so the reviewer can verify the test
+     really was failing before the change.
+
+Every non-trivial change the agent opens as a PR must pass through
+:meth:`TddGate.verify_red_green`. If the test the agent wrote passes
+*before* any implementation, the test was a no-op and the gate raises
+:class:`TddViolationError`.
+
+LOD: the test runner is a plain async callable (see :class:`RunnerFn`),
+injected. The gate doesn't know pytest; it just asks "did the test pass?".
+DbC: constructor enforces the workspace is a directory; the runner must
+return a :class:`RunOutcome` (total) — never raise on a test failure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from maxwell_daemon.contracts import require
+
+__all__ = [
+    "RedGreenResult",
+    "RunOutcome",
+    "RunnerFn",
+    "TddGate",
+    "TddViolationError",
+]
+
+
+@dataclass(slots=True, frozen=True)
+class RunOutcome:
+    """The outcome of one pytest (or equivalent) invocation."""
+
+    passed: bool
+    returncode: int
+    output: str
+    duration_seconds: float = 0.0
+
+
+@dataclass(slots=True, frozen=True)
+class RedGreenResult:
+    """Record of one red -> implement -> green cycle."""
+
+    red_ran: bool
+    red_failed: bool
+    green_ran: bool
+    green_passed: bool
+    honest: bool
+    detail: str = ""
+
+    def to_pr_body_note(self) -> str:
+        """One-line note for the PR body so reviewers can verify the cycle."""
+        red = "failing" if self.red_failed else "passing-unexpectedly"
+        green = "passing" if self.green_passed else "still-failing"
+        return f"TDD gate: red ({red}) -> implement -> green ({green}); honest={self.honest}"
+
+
+class TddViolationError(RuntimeError):
+    """Raised when the new test passes before the implementation lands.
+
+    Means the test doesn't actually cover the change — either it was a
+    no-op, or the implementation already existed and the test-first
+    discipline was skipped.
+    """
+
+
+RunnerFn = Callable[..., Awaitable[RunOutcome]]
+
+
+class TddGate:
+    """Runs the test twice (before + after the implementation) and audits the delta."""
+
+    def __init__(
+        self,
+        *,
+        workspace: Path,
+        test_runner: RunnerFn,
+    ) -> None:
+        require(
+            workspace.is_dir(),
+            f"TddGate: workspace {workspace} must be a directory",
+        )
+        self._workspace = workspace
+        self._run_tests = test_runner
+
+    async def verify_red_green(
+        self,
+        *,
+        test_paths: tuple[str, ...],
+        implement: Callable[[], Awaitable[None]],
+    ) -> RedGreenResult:
+        """Run the TDD cycle.
+
+        1. Run the tests — they MUST fail (RED). If they pass, the test
+           wasn't covering anything; raise :class:`TddViolationError`.
+        2. Call ``implement`` once.
+        3. Run the same tests — they should now pass (GREEN). Returns the
+           result either way; a non-raising failure lets the caller decide
+           whether to iterate.
+        """
+        red = await self._run_tests(workspace=self._workspace, test_paths=test_paths)
+        if red.passed:
+            raise TddViolationError(
+                "test-first violation: the new test(s) passed before the "
+                "implementation ran. A TDD test must fail (RED) first so we "
+                "know it covers the change.\n"
+                f"Tests: {list(test_paths)}\nOutput:\n{red.output[:2000]}"
+            )
+
+        await implement()
+
+        green = await self._run_tests(workspace=self._workspace, test_paths=test_paths)
+        detail = "" if green.passed else green.output[-2000:]
+        return RedGreenResult(
+            red_ran=True,
+            red_failed=not red.passed,
+            green_ran=True,
+            green_passed=green.passed,
+            honest=not red.passed,
+            detail=detail,
+        )

--- a/tests/unit/test_discovery_scheduler.py
+++ b/tests/unit/test_discovery_scheduler.py
@@ -21,7 +21,6 @@ from maxwell_daemon.daemon.scheduler import (
 )
 from maxwell_daemon.gh.client import Issue
 
-
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -1,0 +1,239 @@
+"""Tests for HookRunner — deterministic, LLM-bypass-proof code-standards gates.
+
+Hooks fire at well-defined moments in the agent lifecycle:
+  * ``pre_tool``  — before a tool invocation; non-zero exit aborts the call
+  * ``post_tool`` — after a tool invocation; non-zero exit surfaces as a
+                    ``ToolResult(is_error=True)`` so the agent can recover
+  * ``pre_commit`` — gate PR open on linters / types / tests passing
+  * ``on_prompt`` — inject extra context before the first turn
+  * ``on_stop`` — housekeeping when a session ends
+
+All tests inject a recorder runner so no real subprocesses spawn.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from maxwell_daemon.hooks import (
+    HookConfig,
+    HookOutcome,
+    HookRunner,
+    HookSpec,
+    HookViolationError,
+    load_hook_config,
+)
+
+# ── Test doubles ─────────────────────────────────────────────────────────────
+
+
+class _Runner:
+    """Recorder with canned responses keyed by command prefix."""
+
+    def __init__(self, canned: dict[str, tuple[int, str]] | None = None) -> None:
+        self._canned = canned or {}
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(
+        self, command: str, *, cwd: str, env: dict[str, str], timeout: float
+    ) -> tuple[int, str]:
+        self.calls.append({"command": command, "cwd": cwd, "env": env, "timeout": timeout})
+        for prefix, resp in self._canned.items():
+            if command.startswith(prefix):
+                return resp
+        return 0, ""
+
+
+# ── Config shape ────────────────────────────────────────────────────────────
+
+
+class TestHookConfigShape:
+    def test_empty_config(self) -> None:
+        cfg = HookConfig()
+        assert cfg.pre_tool == ()
+        assert cfg.post_tool == ()
+        assert cfg.pre_commit == ()
+        assert cfg.on_prompt == ()
+        assert cfg.on_stop == ()
+
+    def test_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        cfg = HookConfig()
+        with pytest.raises(FrozenInstanceError):
+            cfg.pre_tool = (HookSpec(command="x"),)  # type: ignore[misc]
+
+
+class TestLoadHookConfig:
+    def test_loads_empty_when_no_file(self, tmp_path: Path) -> None:
+        cfg = load_hook_config(tmp_path / "missing.yaml")
+        assert cfg == HookConfig()
+
+    def test_loads_from_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / "h.yaml").write_text(
+            """
+hooks:
+  pre_tool:
+    - match: run_bash
+      command: "echo blocking"
+  post_tool:
+    - match: write_file
+      command: "ruff format --check {{path}}"
+  pre_commit:
+    - "ruff check ."
+  on_prompt:
+    - "scripts/warmup.sh"
+  on_stop:
+    - "scripts/summary.sh"
+"""
+        )
+        cfg = load_hook_config(tmp_path / "h.yaml")
+        assert len(cfg.pre_tool) == 1
+        assert cfg.pre_tool[0].match == "run_bash"
+        assert cfg.post_tool[0].command == "ruff format --check {{path}}"
+        assert len(cfg.pre_commit) == 1
+        assert len(cfg.on_prompt) == 1
+        assert len(cfg.on_stop) == 1
+
+    def test_malformed_yaml_rejected(self, tmp_path: Path) -> None:
+        (tmp_path / "h.yaml").write_text("not: [valid")
+        with pytest.raises(Exception, match="hook"):
+            load_hook_config(tmp_path / "h.yaml")
+
+
+# ── pre_tool ─────────────────────────────────────────────────────────────────
+
+
+class TestPreToolHook:
+    async def test_matching_hook_blocks_tool_call(self, tmp_path: Path) -> None:
+        runner = _Runner({"block.sh": (1, "blocked by policy")})
+        cfg = HookConfig(pre_tool=(HookSpec(match="run_bash", command="block.sh"),))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        out = await hr.run_pre_tool("run_bash", {"command": "rm -rf /"})
+        assert out.blocked is True
+        assert "blocked by policy" in out.detail
+
+    async def test_non_matching_hook_does_not_run(self, tmp_path: Path) -> None:
+        runner = _Runner()
+        cfg = HookConfig(pre_tool=(HookSpec(match="write_file", command="echo no"),))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        out = await hr.run_pre_tool("run_bash", {})
+        assert out.blocked is False
+        assert runner.calls == []
+
+    async def test_hook_env_includes_tool_context(self, tmp_path: Path) -> None:
+        runner = _Runner()
+        cfg = HookConfig(pre_tool=(HookSpec(match="run_bash", command="echo"),))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        await hr.run_pre_tool("run_bash", {"command": "ls", "timeout_seconds": 5})
+        assert runner.calls[0]["env"]["MAXWELL_TOOL_NAME"] == "run_bash"
+        # Arguments are JSON-serialised so hook scripts can parse them.
+        assert "command" in runner.calls[0]["env"]["MAXWELL_TOOL_INPUT"]
+
+    async def test_wildcard_match_fires_for_all_tools(self, tmp_path: Path) -> None:
+        runner = _Runner()
+        cfg = HookConfig(pre_tool=(HookSpec(match="*", command="audit.sh"),))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        await hr.run_pre_tool("read_file", {"path": "x"})
+        await hr.run_pre_tool("write_file", {"path": "y", "content": "..."})
+        assert len(runner.calls) == 2
+
+    async def test_zero_exit_allows_call(self, tmp_path: Path) -> None:
+        runner = _Runner({"verify": (0, "ok")})
+        cfg = HookConfig(pre_tool=(HookSpec(match="run_bash", command="verify"),))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        out = await hr.run_pre_tool("run_bash", {})
+        assert out.blocked is False
+
+
+# ── post_tool ────────────────────────────────────────────────────────────────
+
+
+class TestPostToolHook:
+    async def test_non_zero_flags_error(self, tmp_path: Path) -> None:
+        runner = _Runner({"ruff": (1, "file would be reformatted")})
+        cfg = HookConfig(post_tool=(HookSpec(match="write_file", command="ruff check {{path}}"),))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        out = await hr.run_post_tool("write_file", {"path": "a.py"}, tool_output="wrote 10 bytes")
+        assert out.errored is True
+        assert "reformatted" in out.detail
+
+    async def test_placeholder_substitution(self, tmp_path: Path) -> None:
+        runner = _Runner()
+        cfg = HookConfig(post_tool=(HookSpec(match="write_file", command="check {{path}}"),))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        await hr.run_post_tool("write_file", {"path": "a.py"}, tool_output="")
+        assert runner.calls[0]["command"] == "check a.py"
+
+    async def test_env_carries_tool_output(self, tmp_path: Path) -> None:
+        runner = _Runner()
+        cfg = HookConfig(post_tool=(HookSpec(match="*", command="audit"),))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        await hr.run_post_tool("run_bash", {}, tool_output="hello")
+        assert runner.calls[0]["env"]["MAXWELL_TOOL_OUTPUT"] == "hello"
+
+
+# ── pre_commit ───────────────────────────────────────────────────────────────
+
+
+class TestPreCommitHook:
+    async def test_all_passing_is_allowed(self, tmp_path: Path) -> None:
+        runner = _Runner()  # defaults to 0
+        cfg = HookConfig(pre_commit=("ruff check .", "mypy maxwell_daemon"))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        out = await hr.run_pre_commit()
+        assert out.passed is True
+        assert len(runner.calls) == 2
+
+    async def test_first_failure_aborts_rest(self, tmp_path: Path) -> None:
+        runner = _Runner({"mypy": (1, "16 errors")})
+        cfg = HookConfig(pre_commit=("ruff check .", "mypy maxwell_daemon", "pytest"))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        out = await hr.run_pre_commit()
+        assert out.passed is False
+        assert "mypy" in out.failing_command
+        # pytest never ran because mypy failed first.
+        commands = [c["command"] for c in runner.calls]
+        assert "pytest" not in commands
+
+    async def test_raises_on_violation_helper(self, tmp_path: Path) -> None:
+        runner = _Runner({"ruff": (1, "lint error")})
+        cfg = HookConfig(pre_commit=("ruff check .",))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        with pytest.raises(HookViolationError, match="ruff"):
+            await hr.raise_if_pre_commit_fails()
+
+
+# ── on_prompt / on_stop ──────────────────────────────────────────────────────
+
+
+class TestOnPromptAndOnStop:
+    async def test_on_prompt_runs_in_order(self, tmp_path: Path) -> None:
+        runner = _Runner()
+        cfg = HookConfig(on_prompt=("a.sh", "b.sh"))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        outputs = await hr.run_on_prompt()
+        assert [c["command"] for c in runner.calls] == ["a.sh", "b.sh"]
+        assert len(outputs) == 2
+
+    async def test_on_stop_runs_once(self, tmp_path: Path) -> None:
+        runner = _Runner()
+        cfg = HookConfig(on_stop=("cleanup.sh",))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        await hr.run_on_stop(exit_reason="end_turn")
+        assert runner.calls[0]["env"]["MAXWELL_EXIT_REASON"] == "end_turn"
+
+
+# ── Outcome shape ───────────────────────────────────────────────────────────
+
+
+class TestHookOutcome:
+    def test_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        o = HookOutcome(blocked=False, errored=False, passed=True, detail="ok", failing_command="")
+        with pytest.raises(FrozenInstanceError):
+            o.blocked = True  # type: ignore[misc]

--- a/tests/unit/test_spec_gherkin.py
+++ b/tests/unit/test_spec_gherkin.py
@@ -1,0 +1,307 @@
+"""Tests for spec ingestion — Gherkin (.feature) loader and pytest-bdd scaffold.
+
+The spec-driven flow: user writes a ``.feature`` file; the spec loader
+parses it; the scaffold generator emits a pytest-bdd skeleton; the agent
+fills in step definitions and the implementation; the gate refuses to
+close the task until every scenario passes.
+
+These tests cover the loader and scaffold generator. Execution
+enforcement (agent loop integration) lives in a separate test file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from maxwell_daemon.spec import (
+    GherkinParseError,
+    Scenario,
+    Specification,
+    load_feature,
+    load_spec_directory,
+    render_pytest_bdd_scaffold,
+)
+
+
+def _write_feature(tmp_path: Path, body: str, name: str = "login.feature") -> Path:
+    path = tmp_path / name
+    path.write_text(dedent(body).lstrip())
+    return path
+
+
+# ── Shape ────────────────────────────────────────────────────────────────────
+
+
+class TestShapes:
+    def test_specification_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        spec = Specification(
+            feature="Login",
+            description="",
+            source=Path("/tmp/x"),
+            scenarios=(),
+            tags=(),
+        )
+        with pytest.raises(FrozenInstanceError):
+            spec.feature = "other"  # type: ignore[misc]
+
+    def test_scenario_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        s = Scenario(name="x", steps=(), tags=())
+        with pytest.raises(FrozenInstanceError):
+            s.name = "y"  # type: ignore[misc]
+
+
+# ── Gherkin parsing ──────────────────────────────────────────────────────────
+
+
+class TestGherkinParsing:
+    def test_happy_path_feature(self, tmp_path: Path) -> None:
+        path = _write_feature(
+            tmp_path,
+            """
+            Feature: Login
+              Users log in with email and password.
+
+              Scenario: Successful login
+                Given a user with email "alice@example.com"
+                When they log in with the correct password
+                Then the dashboard is displayed
+            """,
+        )
+        spec = load_feature(path)
+        assert spec.feature == "Login"
+        assert "Users log in" in spec.description
+        assert len(spec.scenarios) == 1
+        scenario = spec.scenarios[0]
+        assert scenario.name == "Successful login"
+        assert len(scenario.steps) == 3
+        assert scenario.steps[0].keyword == "Given"
+        assert "alice@example.com" in scenario.steps[0].text
+
+    def test_multiple_scenarios(self, tmp_path: Path) -> None:
+        path = _write_feature(
+            tmp_path,
+            """
+            Feature: Auth
+
+              Scenario: Successful login
+                Given a user
+                When they log in
+                Then they see the dashboard
+
+              Scenario: Wrong password
+                Given a user
+                When they submit a bad password
+                Then they see the error banner
+            """,
+        )
+        spec = load_feature(path)
+        assert len(spec.scenarios) == 2
+        assert [s.name for s in spec.scenarios] == [
+            "Successful login",
+            "Wrong password",
+        ]
+
+    def test_and_but_continuations(self, tmp_path: Path) -> None:
+        path = _write_feature(
+            tmp_path,
+            """
+            Feature: Cart
+
+              Scenario: Checkout
+                Given a logged-in user
+                And a cart with 3 items
+                When they click Checkout
+                And they enter a valid card
+                Then the order is confirmed
+                But no email is sent yet
+            """,
+        )
+        spec = load_feature(path)
+        keywords = [s.keyword for s in spec.scenarios[0].steps]
+        assert keywords == ["Given", "And", "When", "And", "Then", "But"]
+
+    def test_tags_captured(self, tmp_path: Path) -> None:
+        path = _write_feature(
+            tmp_path,
+            """
+            @auth @wip
+            Feature: Login
+
+              @happy
+              Scenario: Successful login
+                Given a user
+                When they log in
+                Then they see the dashboard
+            """,
+        )
+        spec = load_feature(path)
+        assert set(spec.tags) == {"@auth", "@wip"}
+        assert set(spec.scenarios[0].tags) == {"@happy"}
+
+    def test_feature_missing_rejected(self, tmp_path: Path) -> None:
+        path = _write_feature(tmp_path, "just some text\nwith no feature block\n")
+        with pytest.raises(GherkinParseError, match="Feature"):
+            load_feature(path)
+
+    def test_scenario_without_steps_rejected(self, tmp_path: Path) -> None:
+        path = _write_feature(
+            tmp_path,
+            """
+            Feature: Empty
+
+              Scenario: Nothing
+            """,
+        )
+        with pytest.raises(GherkinParseError, match="step"):
+            load_feature(path)
+
+    def test_comments_ignored(self, tmp_path: Path) -> None:
+        path = _write_feature(
+            tmp_path,
+            """
+            Feature: Login
+              # comment inline
+              Scenario: A
+                Given x
+                # another comment
+                When y
+                Then z
+            """,
+        )
+        spec = load_feature(path)
+        assert len(spec.scenarios) == 1
+        assert len(spec.scenarios[0].steps) == 3
+
+
+# ── Directory loader ────────────────────────────────────────────────────────
+
+
+class TestLoadSpecDirectory:
+    def test_returns_empty_for_missing_dir(self, tmp_path: Path) -> None:
+        assert load_spec_directory(tmp_path / "nope") == ()
+
+    def test_loads_every_feature_file(self, tmp_path: Path) -> None:
+        _write_feature(
+            tmp_path,
+            "Feature: A\n  Scenario: a1\n    Given x\n    When y\n    Then z\n",
+            name="a.feature",
+        )
+        _write_feature(
+            tmp_path,
+            "Feature: B\n  Scenario: b1\n    Given x\n    When y\n    Then z\n",
+            name="b.feature",
+        )
+        specs = load_spec_directory(tmp_path)
+        assert sorted(s.feature for s in specs) == ["A", "B"]
+
+    def test_ignores_non_feature_files(self, tmp_path: Path) -> None:
+        (tmp_path / "readme.md").write_text("not a feature")
+        _write_feature(
+            tmp_path,
+            "Feature: A\n  Scenario: a1\n    Given x\n    When y\n    Then z\n",
+            name="a.feature",
+        )
+        specs = load_spec_directory(tmp_path)
+        assert [s.feature for s in specs] == ["A"]
+
+    def test_one_malformed_file_does_not_kill_loader(self, tmp_path: Path) -> None:
+        _write_feature(tmp_path, "broken nonsense\n", name="bad.feature")
+        _write_feature(
+            tmp_path,
+            "Feature: A\n  Scenario: a1\n    Given x\n    When y\n    Then z\n",
+            name="a.feature",
+        )
+        specs = load_spec_directory(tmp_path)
+        # Broken file is skipped; the valid one still loads.
+        assert [s.feature for s in specs] == ["A"]
+
+
+# ── pytest-bdd scaffold ─────────────────────────────────────────────────────
+
+
+class TestPytestBddScaffold:
+    def test_scaffold_defines_scenarios_binding(self) -> None:
+        spec = Specification(
+            feature="Login",
+            description="",
+            source=Path("specs/login.feature"),
+            scenarios=(
+                Scenario(
+                    name="Successful login",
+                    steps=(),
+                    tags=(),
+                ),
+            ),
+            tags=(),
+        )
+        code = render_pytest_bdd_scaffold(spec)
+        assert "from pytest_bdd import" in code
+        assert 'scenarios("specs/login.feature")' in code
+
+    def test_scaffold_includes_step_stubs(self) -> None:
+        from maxwell_daemon.spec import Step
+
+        spec = Specification(
+            feature="Login",
+            description="",
+            source=Path("specs/login.feature"),
+            scenarios=(
+                Scenario(
+                    name="Successful login",
+                    steps=(
+                        Step(keyword="Given", text='a user with email "alice"'),
+                        Step(keyword="When", text="they log in"),
+                        Step(keyword="Then", text="they see the dashboard"),
+                    ),
+                    tags=(),
+                ),
+            ),
+            tags=(),
+        )
+        code = render_pytest_bdd_scaffold(spec)
+        assert "@given(" in code
+        assert "@when(" in code
+        assert "@then(" in code
+        assert "a user with email" in code
+
+    def test_scaffold_dedupes_repeated_steps(self) -> None:
+        from maxwell_daemon.spec import Step
+
+        spec = Specification(
+            feature="Search",
+            description="",
+            source=Path("specs/search.feature"),
+            scenarios=(
+                Scenario(
+                    name="A",
+                    steps=(
+                        Step(keyword="Given", text="a user"),
+                        Step(keyword="When", text="they search"),
+                        Step(keyword="Then", text="they see results"),
+                    ),
+                    tags=(),
+                ),
+                Scenario(
+                    name="B",
+                    steps=(
+                        Step(keyword="Given", text="a user"),
+                        Step(keyword="When", text="they search"),
+                        Step(keyword="Then", text="they see results"),
+                    ),
+                    tags=(),
+                ),
+            ),
+            tags=(),
+        )
+        code = render_pytest_bdd_scaffold(spec)
+        # Each step text appears exactly once as a @given/@when/@then stub.
+        assert code.count('@given("a user")') == 1
+        assert code.count('@when("they search")') == 1
+        assert code.count('@then("they see results")') == 1

--- a/tests/unit/test_tdd_gate.py
+++ b/tests/unit/test_tdd_gate.py
@@ -1,0 +1,214 @@
+"""Tests for TddGate — enforces the red-green-refactor discipline on agent output.
+
+Every non-trivial change must:
+  1. Start by adding a *failing* test (verified RED).
+  2. Make that test pass via the implementation (verified GREEN).
+  3. The same test must not have passed before the implementation (that
+     would mean the change is untested or the test is a no-op).
+
+All tests inject a recorder test-runner so no real pytest runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from maxwell_daemon.tdd_gate import (
+    RedGreenResult,
+    RunOutcome,
+    TddGate,
+    TddViolationError,
+)
+
+
+@dataclass
+class _FakeRunner:
+    """Replays canned outcomes keyed by the test files touched."""
+
+    outcomes: list[RunOutcome] = field(default_factory=list)
+    calls: list[dict[str, object]] = field(default_factory=list)
+
+    async def __call__(self, *, workspace: Path, test_paths: tuple[str, ...]) -> RunOutcome:
+        self.calls.append({"workspace": str(workspace), "test_paths": test_paths})
+        if not self.outcomes:
+            return RunOutcome(passed=True, returncode=0, output="", duration_seconds=0.0)
+        return self.outcomes.pop(0)
+
+
+# ── Shape ────────────────────────────────────────────────────────────────────
+
+
+class TestShapes:
+    def test_test_run_outcome_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        o = RunOutcome(passed=True, returncode=0, output="ok", duration_seconds=0.1)
+        with pytest.raises(FrozenInstanceError):
+            o.passed = False  # type: ignore[misc]
+
+    def test_red_green_result_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        r = RedGreenResult(
+            red_ran=True, red_failed=True, green_ran=True, green_passed=True, honest=True, detail=""
+        )
+        with pytest.raises(FrozenInstanceError):
+            r.honest = False  # type: ignore[misc]
+
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+
+
+class TestPreconditions:
+    def test_requires_workspace_directory(self, tmp_path: Path) -> None:
+        from maxwell_daemon.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError, match="workspace"):
+            TddGate(workspace=tmp_path / "missing", test_runner=_FakeRunner())
+
+
+# ── Red → Green happy path ───────────────────────────────────────────────────
+
+
+class TestRedGreenHappyPath:
+    async def test_test_fails_red_then_passes_green(self, tmp_path: Path) -> None:
+        runner = _FakeRunner(
+            outcomes=[
+                RunOutcome(passed=False, returncode=1, output="assert 0 == 1"),
+                RunOutcome(passed=True, returncode=0, output=""),
+            ]
+        )
+        gate = TddGate(workspace=tmp_path, test_runner=runner)
+
+        async def implement() -> None:
+            pass  # caller supplies the implementation step
+
+        result = await gate.verify_red_green(
+            test_paths=("tests/unit/test_new.py",),
+            implement=implement,
+        )
+        assert result.red_ran is True
+        assert result.red_failed is True
+        assert result.green_ran is True
+        assert result.green_passed is True
+        assert result.honest is True
+
+    async def test_runner_called_twice_red_then_green(self, tmp_path: Path) -> None:
+        runner = _FakeRunner(
+            outcomes=[
+                RunOutcome(passed=False, returncode=1, output=""),
+                RunOutcome(passed=True, returncode=0, output=""),
+            ]
+        )
+        gate = TddGate(workspace=tmp_path, test_runner=runner)
+
+        async def implement() -> None:
+            pass
+
+        await gate.verify_red_green(test_paths=("tests/unit/test_new.py",), implement=implement)
+        assert len(runner.calls) == 2
+        assert runner.calls[0]["test_paths"] == ("tests/unit/test_new.py",)
+
+
+# ── Dishonest tests (never failed) ───────────────────────────────────────────
+
+
+class TestDishonestTest:
+    async def test_green_from_the_start_flagged_as_not_honest(self, tmp_path: Path) -> None:
+        """If the new test passes before any implementation, it was a no-op test."""
+        runner = _FakeRunner(
+            outcomes=[
+                RunOutcome(passed=True, returncode=0, output=""),  # RED returned passing
+                # No green run expected — gate should raise on red-phase result.
+            ]
+        )
+        gate = TddGate(workspace=tmp_path, test_runner=runner)
+
+        async def implement() -> None:
+            pass
+
+        with pytest.raises(TddViolationError, match="test-first violation"):
+            await gate.verify_red_green(
+                test_paths=("tests/unit/test_noop.py",), implement=implement
+            )
+
+
+# ── Regression cases ─────────────────────────────────────────────────────────
+
+
+class TestImplementationRegressed:
+    async def test_green_run_still_failing_is_reported(self, tmp_path: Path) -> None:
+        runner = _FakeRunner(
+            outcomes=[
+                RunOutcome(passed=False, returncode=1, output="red ok"),
+                RunOutcome(passed=False, returncode=1, output="still failing"),
+            ]
+        )
+        gate = TddGate(workspace=tmp_path, test_runner=runner)
+
+        async def implement() -> None:
+            pass
+
+        result = await gate.verify_red_green(
+            test_paths=("tests/unit/test_x.py",), implement=implement
+        )
+        assert result.red_failed is True
+        assert result.green_passed is False
+        assert result.honest is True  # the RED was honest
+        assert "still failing" in result.detail
+
+
+# ── Implement callback receives outcome of RED ──────────────────────────────
+
+
+class TestImplementCallbackContract:
+    async def test_implement_called_once_between_red_and_green(self, tmp_path: Path) -> None:
+        call_log: list[str] = []
+        runner = _FakeRunner(
+            outcomes=[
+                RunOutcome(passed=False, returncode=1, output=""),
+                RunOutcome(passed=True, returncode=0, output=""),
+            ]
+        )
+        gate = TddGate(workspace=tmp_path, test_runner=runner)
+
+        async def implement() -> None:
+            call_log.append("implement")
+
+        await gate.verify_red_green(test_paths=("tests/unit/test_new.py",), implement=implement)
+        assert call_log == ["implement"]
+
+    async def test_implement_not_called_when_test_is_dishonest(self, tmp_path: Path) -> None:
+        call_log: list[str] = []
+        runner = _FakeRunner(outcomes=[RunOutcome(passed=True, returncode=0, output="")])
+        gate = TddGate(workspace=tmp_path, test_runner=runner)
+
+        async def implement() -> None:
+            call_log.append("implement")
+
+        with pytest.raises(TddViolationError):
+            await gate.verify_red_green(
+                test_paths=("tests/unit/test_noop.py",), implement=implement
+            )
+        assert call_log == []
+
+
+# ── PR body annotation ──────────────────────────────────────────────────────
+
+
+class TestPrBodyAnnotation:
+    def test_passing_result_produces_audit_line(self) -> None:
+        result = RedGreenResult(
+            red_ran=True,
+            red_failed=True,
+            green_ran=True,
+            green_passed=True,
+            honest=True,
+            detail="",
+        )
+        line = result.to_pr_body_note()
+        assert "TDD" in line
+        assert "red" in line.lower() and "green" in line.lower()


### PR DESCRIPTION
## Summary

Three orthogonal primitives that the rest of the autonomous-coding system composes over:

1. **`maxwell_daemon/hooks.py`** — deterministic, LLM-bypass-proof gates (#90)
2. **`maxwell_daemon/tdd_gate.py`** — red → implement → green enforcement (#91)
3. **`maxwell_daemon/spec.py`** — Gherkin ingestion + pytest-bdd scaffold generator (#92)

Together these unlock: code-standards enforcement without mass token usage (hooks), enforced TDD discipline (gate), and spec-driven coding (Gherkin). They are built orthogonally so you can adopt one, two, or three independently.

## 1. Hook system (#90)

```yaml
# maxwell-daemon.yaml
hooks:
  pre_tool:
    - match: run_bash
      command: .maxwell/hooks/block-destructive.sh
  post_tool:
    - match: write_file
      command: ruff format --check {{path}} && ruff check {{path}}
  pre_commit:
    - ruff format --check .
    - mypy --strict maxwell_daemon
    - pytest -x --no-cov
  on_prompt:
    - scripts/inject_ci_profile.py
  on_stop:
    - scripts/summarize_run.py
```

- `HookConfig` (frozen), `HookSpec` (frozen), `HookOutcome` (frozen), `HookRunner`.
- `{{placeholder}}` substitution from tool input; env carries `MAXWELL_TOOL_NAME`, `MAXWELL_TOOL_INPUT` (JSON), `MAXWELL_TOOL_OUTPUT`, `MAXWELL_EXIT_REASON`.
- Injected `RunnerFn` subprocess layer — tests use a recorder; prod uses `asyncio.create_subprocess_shell` with a timeout.

## 2. TDD gate (#91)

- `TddGate.verify_red_green(test_paths, implement)` runs the tests, demands a RED, calls `implement()`, runs them again, reports whether they went GREEN.
- `TddViolationError` raised when the new test passes *before* implementation (meaning the test was a no-op).
- `RedGreenResult.to_pr_body_note()` gives a one-line audit trail the reviewer can check.
- Test-runner is injected; the gate doesn't know pytest.

## 3. Spec ingestion (#92)

- `load_feature(path)` — parses `Feature` / `Scenario` / `Given`/`When`/`Then` / `And`/`But` / tags / comments / free-text description into frozen dataclasses. Zero external deps.
- `load_spec_directory(path)` — total: one broken spec never kills the sweep.
- `render_pytest_bdd_scaffold(spec)` — emits a pytest-bdd skeleton with one `@given/@when/@then` stub per unique step text (deduped across scenarios).
- `GherkinParseError` for malformed features.

## Tests (45 new, all green)

- 19 hook tests: config shape, YAML loader, `pre_tool` block, `post_tool` error, `pre_commit` short-circuit, `on_prompt`/`on_stop` env plumbing.
- 10 TDD gate tests: happy path, dishonest test rejection, regression reporting, implement-callback contract, PR-body note.
- 16 spec tests: feature parsing, multi-scenario, And/But, tags, comments, directory sweep, scaffold generation + dedup.

`mypy --strict` clean on all three modules. `ruff` clean.

## Design notes (per Maxwell-Daemon principles)

- **DbC:** constructors taking a workspace enforce `.is_dir()`; policy outcomes return typed results, raising only for operator-visible violations.
- **LOD:** each module depends on one injected collaborator (subprocess runner / test runner / filesystem); none reach through to siblings.
- **Reversibility:** every module defaults to off. No `maxwell-daemon.yaml` means zero hooks; no `TddGate` call means no enforcement; no `.maxwell/specs/` means no spec mode. Adopt is one file; drop is deleting that file.
- **Orthogonality:** the three modules don't import each other. Integration happens at the agent-loop level in follow-up PRs.

## Follow-ups (tracked in issue bodies)

- Wire `HookRunner.run_pre_tool/run_post_tool` into the MCP tool registry invocation path.
- Wire `TddGate` into `IssueExecutor.execute_issue` for a new `mode="tdd"`.
- CLI `maxwell-daemon spec generate <path>` → render + write scaffold.
- Spec mode in `IssueExecutor`: consume a `.feature` file as the source of truth; refuse to close the task until every scenario passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)