### PR TITLE
feat(rules): .maxwell/rules/*.md with frontmatter globs (#97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: python -m pip install -e ".[dev]"
       - name: Run tests
-        run: python -m pytest --cov=maxwell_daemon --cov-report=xml --cov-report=term-missing
+        run: python -m pytest -p no:xvfb --cov=maxwell_daemon --cov-report=xml --cov-report=term-missing
       - name: Upload coverage artifact
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: python -m pip install -e ".[dev]"
+      - run: python -m venv .venv
+      - run: .venv/bin/python -m pip install -e ".[dev]"
       - name: Ruff check
-        run: python -m ruff check . --output-format=github
+        run: .venv/bin/python -m ruff check . --output-format=github
       - name: Ruff format check
-        run: python -m ruff format --check .
+        run: .venv/bin/python -m ruff format --check .
 
   typecheck:
     name: Typecheck (mypy --strict)
@@ -36,10 +37,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: python -m pip install -e ".[dev]"
-      - run: python -m mypy maxwell_daemon
+      - run: python -m venv .venv
+      - run: .venv/bin/python -m pip install -e ".[dev]"
+      - run: .venv/bin/python -m mypy maxwell_daemon
       - name: Mypy on tests
-        run: python -m mypy tests --no-strict-optional
+        run: .venv/bin/python -m mypy tests --no-strict-optional
         continue-on-error: true  # Tighten iteratively
 
   test:
@@ -54,9 +56,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - run: python -m pip install -e ".[dev]"
+      - run: python -m venv .venv
+      - run: .venv/bin/python -m pip install -e ".[dev]"
       - name: Run tests
-        run: python -m pytest -p no:xvfb --cov=maxwell_daemon --cov-report=xml --cov-report=term-missing
+        run: .venv/bin/python -m pytest -p no:xvfb --cov=maxwell_daemon --cov-report=xml --cov-report=term-missing
       - name: Upload coverage artifact
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v7
@@ -104,11 +107,12 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: python -m pip install bandit pip-audit
+      - run: python -m venv .venv
+      - run: .venv/bin/python -m pip install bandit pip-audit
       - name: Bandit (static analysis)
-        run: python -m bandit -r maxwell_daemon -c pyproject.toml
+        run: .venv/bin/python -m bandit -r maxwell_daemon -c pyproject.toml
       - name: pip-audit (dependency vulnerabilities)
-        run: python -m pip_audit --desc --strict || true  # report but don't fail until we triage
+        run: .venv/bin/python -m pip_audit --desc --strict || true  # report but don't fail until we triage
 
   build:
     name: Build distribution
@@ -119,8 +123,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: python -m pip install build
-      - run: python -m build
+      - run: python -m venv .venv
+      - run: .venv/bin/python -m pip install build
+      - run: .venv/bin/python -m build
       - uses: actions/upload-artifact@v7
         with:
           name: dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
     runs-on: [self-hosted, d-sorg-fleet-4core]
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - uses: actions/download-artifact@v8
         with:
           name: coverage-xml

--- a/maxwell_daemon/rules.py
+++ b/maxwell_daemon/rules.py
@@ -1,0 +1,181 @@
+"""``.maxwell/rules/*.md`` — frontmatter-guided rule auto-attachment.
+
+Cursor-style rules: each ``.md`` file under ``.maxwell/rules/`` carries a
+YAML frontmatter block declaring ``description``, ``globs``,
+``always_apply``, ``priority``. The loader turns them into
+:class:`Rule` objects; :func:`select_rules` picks the ones whose globs
+match the files the agent is touching this turn; :func:`render_rules`
+concatenates the selected rule bodies into a single prompt block.
+
+Why this is better than one big CLAUDE.md:
+
+* **Scoped activation.** ``tests/**/*.py`` rules only load when the
+  agent is in that territory — tokens unused elsewhere.
+* **Independent iteration.** A team member can add a rule without
+  touching the central doc.
+* **Budget-aware.** :func:`select_rules` honours a ``max_chars`` cap,
+  dropping the lowest-priority rules until the budget fits.
+
+DbC / LOD: the loader is pure (directory -> tuple of rules); selection
+is pure (rules x touched files -> subset). No module here reaches into
+the agent loop or the prompt assembler — those integrate via
+:func:`render_rules` at the call site.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+__all__ = [
+    "Rule",
+    "RuleLoadError",
+    "load_rules",
+    "render_rules",
+    "select_rules",
+]
+
+
+_FRONTMATTER_RE = re.compile(
+    r"\A---\s*\n(?P<yaml>.*?)\n---\s*\n?(?P<body>.*)\Z",
+    re.DOTALL,
+)
+
+
+class RuleLoadError(ValueError):
+    """Raised when a rule file is structurally invalid."""
+
+
+@dataclass(slots=True, frozen=True)
+class Rule:
+    """One ``.md`` rule with its parsed frontmatter."""
+
+    name: str
+    description: str
+    globs: tuple[str, ...]
+    always_apply: bool
+    priority: int
+    body: str
+    source: Path
+
+
+def load_rules(directory: Path) -> tuple[Rule, ...]:
+    """Load every ``*.md`` rule under ``directory``.
+
+    Returns an empty tuple if ``directory`` doesn't exist. Raises
+    :class:`RuleLoadError` on *any* structurally invalid rule — we'd
+    rather fail loudly than silently misbehave, because "rule not
+    applied" isn't a visible failure mode otherwise.
+
+    Ordering: descending by ``priority``; ties broken by filename.
+    """
+    if not directory.is_dir():
+        return ()
+    rules: list[Rule] = []
+    for path in sorted(directory.iterdir()):
+        if not path.is_file() or path.suffix != ".md":
+            continue
+        rules.append(_parse_rule(path))
+    rules.sort(key=lambda r: (-r.priority, r.name))
+    return tuple(rules)
+
+
+def _parse_rule(path: Path) -> Rule:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    match = _FRONTMATTER_RE.match(text)
+    if match is None:
+        raise RuleLoadError(f"{path}: no YAML frontmatter block (expected --- ... --- at top)")
+    try:
+        parsed: Any = yaml.safe_load(match.group("yaml")) or {}
+    except yaml.YAMLError as e:
+        raise RuleLoadError(f"{path}: YAML frontmatter is invalid: {e}") from e
+    if not isinstance(parsed, dict):
+        raise RuleLoadError(f"{path}: YAML frontmatter must be a mapping")
+
+    description = str(parsed.get("description") or "")
+    raw_globs = parsed.get("globs") or []
+    if not isinstance(raw_globs, list):
+        raise RuleLoadError(f"{path}: globs must be a list")
+    globs = tuple(str(g) for g in raw_globs)
+    always_apply = bool(parsed.get("always_apply", False))
+    priority = int(parsed.get("priority", 0))
+
+    body = match.group("body").strip()
+    return Rule(
+        name=path.stem,
+        description=description,
+        globs=globs,
+        always_apply=always_apply,
+        priority=priority,
+        body=body,
+        source=path,
+    )
+
+
+def select_rules(
+    rules: tuple[Rule, ...],
+    *,
+    touched: tuple[str, ...],
+    max_chars: int | None = None,
+) -> tuple[Rule, ...]:
+    """Pick the subset of ``rules`` that apply to ``touched`` under ``max_chars``.
+
+    A rule is eligible when either ``always_apply`` is true or any of
+    its globs matches at least one path in ``touched``. Selected rules
+    are emitted in descending priority order (same as ``load_rules``).
+
+    When ``max_chars`` is set, we pack rules in priority order until
+    the next rule would push the total body size over budget — that
+    rule and all lower-priority rules are dropped.
+    """
+    eligible = sorted(
+        (r for r in rules if _rule_matches(r, touched)),
+        key=lambda r: (-r.priority, r.name),
+    )
+    if max_chars is None:
+        return tuple(eligible)
+
+    selected: list[Rule] = []
+    used = 0
+    for rule in eligible:
+        if used + len(rule.body) > max_chars:
+            continue
+        selected.append(rule)
+        used += len(rule.body)
+    return tuple(selected)
+
+
+def _rule_matches(rule: Rule, touched: tuple[str, ...]) -> bool:
+    if rule.always_apply:
+        return True
+    if not rule.globs:
+        return False
+    for glob in rule.globs:
+        for path in touched:
+            if fnmatch.fnmatch(path, glob):
+                return True
+    return False
+
+
+def render_rules(rules: tuple[Rule, ...]) -> str:
+    """Concatenate selected rules into one markdown block.
+
+    Each rule becomes ``## Rule: <name>\\n<description>\\n\\n<body>``.
+    Empty input yields an empty string so callers can splice the
+    result unconditionally.
+    """
+    if not rules:
+        return ""
+    sections: list[str] = []
+    for rule in rules:
+        parts = [f"## Rule: {rule.name}"]
+        if rule.description:
+            parts.append(rule.description)
+        parts.append(rule.body)
+        sections.append("\n".join(parts))
+    return "\n\n".join(sections)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "ruff>=0.6.0",
     "mypy>=1.11.0",
     "opentelemetry-sdk>=1.30.0",
+    "tomli>=2.0.0",
     "types-pyyaml",
 ]
 all = ["maxwell-daemon[ollama,google,azure,grpc,dev]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,10 @@ module = ["prometheus_client", "prometheus_client.*", "opentelemetry.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = ["tomli"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["anthropic", "anthropic.*", "openai", "openai.*"]
 ignore_missing_imports = false
 

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -1,0 +1,295 @@
+"""Tests for the rules system — ``.maxwell/rules/*.md`` with frontmatter globs.
+
+Cursor-style rules: each ``.md`` file under ``.maxwell/rules/`` carries a
+YAML frontmatter block declaring ``description``, ``globs``,
+``always_apply``, ``priority``. Rules auto-attach to the agent's
+context when the touched file set matches the globs (or when
+``always_apply`` is true).
+
+Strictly better than a single ``CLAUDE.md`` because:
+  * Rules activate only when their context matters (cheap prompt).
+  * Per-file-type guidance goes in its own rule.
+  * Priority orders overlapping rules deterministically.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from maxwell_daemon.rules import (
+    Rule,
+    RuleLoadError,
+    load_rules,
+    select_rules,
+)
+
+
+def _write_rule(
+    rules_dir: Path,
+    name: str,
+    *,
+    description: str = "",
+    globs: list[str] | None = None,
+    always_apply: bool = False,
+    priority: int = 0,
+    body: str = "rule body",
+) -> Path:
+    rules_dir.mkdir(parents=True, exist_ok=True)
+    path = rules_dir / name
+    lines = ["---", f"description: {description}"]
+    if globs:
+        glob_list = ", ".join(f'"{g}"' for g in globs)
+        lines.append(f"globs: [{glob_list}]")
+    lines.append(f"always_apply: {str(always_apply).lower()}")
+    lines.append(f"priority: {priority}")
+    lines.append("---")
+    lines.append(body)
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+# ── Shape ────────────────────────────────────────────────────────────────────
+
+
+class TestRuleShape:
+    def test_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        r = Rule(
+            name="x",
+            description="",
+            globs=(),
+            always_apply=False,
+            priority=0,
+            body="",
+            source=Path("/x"),
+        )
+        with pytest.raises(FrozenInstanceError):
+            r.priority = 10  # type: ignore[misc]
+
+
+# ── Loading ────────────────────────────────────────────────────────────────
+
+
+class TestLoadRules:
+    def test_empty_directory_returns_empty(self, tmp_path: Path) -> None:
+        assert load_rules(tmp_path / "missing") == ()
+
+    def test_parses_frontmatter_and_body(self, tmp_path: Path) -> None:
+        _write_rule(
+            tmp_path / "rules",
+            "test-style.md",
+            description="How we write tests",
+            globs=["tests/**/*.py"],
+            always_apply=False,
+            priority=5,
+            body="Use pytest parametrize for combinations.",
+        )
+        rules = load_rules(tmp_path / "rules")
+        assert len(rules) == 1
+        r = rules[0]
+        assert r.name == "test-style"
+        assert r.description == "How we write tests"
+        assert r.globs == ("tests/**/*.py",)
+        assert r.always_apply is False
+        assert r.priority == 5
+        assert "pytest parametrize" in r.body
+
+    def test_sorted_by_priority_descending(self, tmp_path: Path) -> None:
+        rd = tmp_path / "rules"
+        _write_rule(rd, "low.md", priority=1)
+        _write_rule(rd, "mid.md", priority=5)
+        _write_rule(rd, "high.md", priority=10)
+        rules = load_rules(rd)
+        assert [r.name for r in rules] == ["high", "mid", "low"]
+
+    def test_missing_frontmatter_raises(self, tmp_path: Path) -> None:
+        rd = tmp_path / "rules"
+        rd.mkdir()
+        (rd / "bad.md").write_text("just some text, no frontmatter\n")
+        with pytest.raises(RuleLoadError, match="frontmatter"):
+            load_rules(rd)
+
+    def test_malformed_yaml_frontmatter_raises(self, tmp_path: Path) -> None:
+        rd = tmp_path / "rules"
+        rd.mkdir()
+        (rd / "bad.md").write_text("---\nnot: [valid\n---\nbody\n")
+        with pytest.raises(RuleLoadError, match="YAML"):
+            load_rules(rd)
+
+    def test_non_md_files_ignored(self, tmp_path: Path) -> None:
+        rd = tmp_path / "rules"
+        rd.mkdir()
+        (rd / "readme.txt").write_text("not a rule\n")
+        _write_rule(rd, "real.md")
+        rules = load_rules(rd)
+        assert [r.name for r in rules] == ["real"]
+
+    def test_default_values_when_frontmatter_fields_missing(self, tmp_path: Path) -> None:
+        rd = tmp_path / "rules"
+        rd.mkdir()
+        (rd / "minimal.md").write_text("---\ndescription: minimal\n---\nbody\n")
+        rules = load_rules(rd)
+        assert rules[0].globs == ()
+        assert rules[0].always_apply is False
+        assert rules[0].priority == 0
+
+
+# ── Selection / matching ────────────────────────────────────────────────────
+
+
+class TestSelectRules:
+    def test_always_apply_rule_always_selected(self, tmp_path: Path) -> None:
+        always = Rule(
+            name="a",
+            description="",
+            globs=(),
+            always_apply=True,
+            priority=0,
+            body="always",
+            source=tmp_path / "a.md",
+        )
+        selected = select_rules((always,), touched=())
+        assert selected == (always,)
+
+    def test_glob_matched_rule_selected(self, tmp_path: Path) -> None:
+        rule = Rule(
+            name="py",
+            description="",
+            globs=("**/*.py",),
+            always_apply=False,
+            priority=0,
+            body="",
+            source=tmp_path / "py.md",
+        )
+        selected = select_rules((rule,), touched=("src/foo.py",))
+        assert selected == (rule,)
+
+    def test_unmatched_rule_excluded(self, tmp_path: Path) -> None:
+        rule = Rule(
+            name="py",
+            description="",
+            globs=("**/*.py",),
+            always_apply=False,
+            priority=0,
+            body="",
+            source=tmp_path / "py.md",
+        )
+        selected = select_rules((rule,), touched=("README.md", "docs/x.rst"))
+        assert selected == ()
+
+    def test_any_matching_glob_selects(self, tmp_path: Path) -> None:
+        rule = Rule(
+            name="multi",
+            description="",
+            globs=("**/*.py", "tests/**"),
+            always_apply=False,
+            priority=0,
+            body="",
+            source=tmp_path / "x.md",
+        )
+        selected = select_rules((rule,), touched=("tests/unit/test_x.md",))
+        assert selected == (rule,)
+
+    def test_priority_order_preserved_among_selected(self, tmp_path: Path) -> None:
+        hi = Rule(
+            name="hi",
+            description="",
+            globs=(),
+            always_apply=True,
+            priority=10,
+            body="",
+            source=tmp_path / "hi.md",
+        )
+        lo = Rule(
+            name="lo",
+            description="",
+            globs=(),
+            always_apply=True,
+            priority=1,
+            body="",
+            source=tmp_path / "lo.md",
+        )
+        selected = select_rules((lo, hi), touched=())
+        assert [r.name for r in selected] == ["hi", "lo"]
+
+    def test_budget_caps_included_rules(self, tmp_path: Path) -> None:
+        """If the composed rule body would exceed ``max_chars``, drop the
+        lowest-priority rules until it fits."""
+        big = Rule(
+            name="big",
+            description="",
+            globs=(),
+            always_apply=True,
+            priority=1,
+            body="x" * 2000,
+            source=tmp_path / "big.md",
+        )
+        small = Rule(
+            name="small",
+            description="",
+            globs=(),
+            always_apply=True,
+            priority=10,
+            body="small body",
+            source=tmp_path / "small.md",
+        )
+        selected = select_rules((big, small), touched=(), max_chars=200)
+        names = [r.name for r in selected]
+        # High-priority 'small' kept; low-priority 'big' dropped.
+        assert "small" in names
+        assert "big" not in names
+
+    def test_combined_rule_body_never_exceeds_budget(self, tmp_path: Path) -> None:
+        one = Rule(
+            name="one",
+            description="",
+            globs=(),
+            always_apply=True,
+            priority=1,
+            body="a" * 100,
+            source=tmp_path / "one.md",
+        )
+        two = Rule(
+            name="two",
+            description="",
+            globs=(),
+            always_apply=True,
+            priority=2,
+            body="b" * 100,
+            source=tmp_path / "two.md",
+        )
+        selected = select_rules((one, two), touched=(), max_chars=150)
+        total_body = sum(len(r.body) for r in selected)
+        assert total_body <= 150
+
+
+# ── Rendering ──────────────────────────────────────────────────────────────
+
+
+class TestRenderRules:
+    def test_renders_as_markdown_sections(self, tmp_path: Path) -> None:
+        from maxwell_daemon.rules import render_rules
+
+        rules = (
+            Rule(
+                name="style",
+                description="Code style rules",
+                globs=(),
+                always_apply=True,
+                priority=5,
+                body="Use ruff format.",
+                source=tmp_path / "style.md",
+            ),
+        )
+        out = render_rules(rules)
+        assert "## Rule: style" in out
+        assert "Use ruff format." in out
+        assert "Code style rules" in out
+
+    def test_empty_rules_renders_empty_string(self) -> None:
+        from maxwell_daemon.rules import render_rules
+
+        assert render_rules(()) == ""

--- a/tests/unit/test_tool_result_compression.py
+++ b/tests/unit/test_tool_result_compression.py
@@ -83,23 +83,17 @@ class TestHeadTailTruncation:
     def test_head_tail_applied_when_too_long(self) -> None:
         lines = [f"line {i}" for i in range(500)]
         output = "\n".join(lines)
-        compressor = ToolResultCompressor(
-            head_lines=5, tail_lines=5, max_chars=100
-        )
+        compressor = ToolResultCompressor(head_lines=5, tail_lines=5, max_chars=100)
         result = compressor.compress("run_bash", output)
         assert result.strategy == "head_tail"
         # First 5 lines preserved verbatim.
         assert result.content.startswith("line 0\nline 1\nline 2\nline 3\nline 4\n")
         # Last 5 lines preserved verbatim.
-        assert result.content.rstrip().endswith(
-            "line 495\nline 496\nline 497\nline 498\nline 499"
-        )
+        assert result.content.rstrip().endswith("line 495\nline 496\nline 497\nline 498\nline 499")
 
     def test_head_tail_contains_truncation_marker(self) -> None:
         output = "\n".join(f"L{i}" for i in range(200))
-        compressor = ToolResultCompressor(
-            head_lines=3, tail_lines=3, max_chars=20
-        )
+        compressor = ToolResultCompressor(head_lines=3, tail_lines=3, max_chars=20)
         result = compressor.compress("run_bash", output)
         assert "truncated" in result.content
         # Marker should record how many lines vanished: 200 - 3 - 3 = 194.
@@ -107,17 +101,13 @@ class TestHeadTailTruncation:
 
     def test_head_tail_compressed_shorter_than_original(self) -> None:
         output = "\n".join(f"line {i}" for i in range(1000))
-        compressor = ToolResultCompressor(
-            head_lines=10, tail_lines=10, max_chars=50
-        )
+        compressor = ToolResultCompressor(head_lines=10, tail_lines=10, max_chars=50)
         result = compressor.compress("run_bash", output)
         assert len(result.content) < len(output)
 
     def test_unknown_tool_still_head_tail_when_long(self) -> None:
         output = "\n".join(f"line {i}" for i in range(400))
-        compressor = ToolResultCompressor(
-            head_lines=2, tail_lines=2, max_chars=30
-        )
+        compressor = ToolResultCompressor(head_lines=2, tail_lines=2, max_chars=30)
         result = compressor.compress("unknown_tool", output)
         assert result.strategy == "head_tail"
 
@@ -158,9 +148,7 @@ class TestDedup:
         # the strategy must then fall through to head_tail.
         lines = [f"unique_{i}" for i in range(500)]
         output = "\n".join(lines)
-        compressor = ToolResultCompressor(
-            head_lines=3, tail_lines=3, max_chars=50
-        )
+        compressor = ToolResultCompressor(head_lines=3, tail_lines=3, max_chars=50)
         result = compressor.compress("grep_files", output)
         assert result.strategy == "head_tail"
         assert "truncated" in result.content
@@ -169,9 +157,7 @@ class TestDedup:
         # run_bash isn't in the dedup set; duplicate lines are untouched when
         # we go through head_tail.
         output = ("same\n" * 200) + "end\n"
-        compressor = ToolResultCompressor(
-            head_lines=5, tail_lines=5, max_chars=30
-        )
+        compressor = ToolResultCompressor(head_lines=5, tail_lines=5, max_chars=30)
         result = compressor.compress("run_bash", output)
         assert result.strategy == "head_tail"
 
@@ -202,9 +188,7 @@ class TestCompressionResultAccounting:
 
     def test_accounting_on_truncation_compressed_is_smaller(self) -> None:
         output = "\n".join(f"line_{i}" for i in range(1000))
-        compressor = ToolResultCompressor(
-            head_lines=5, tail_lines=5, max_chars=50
-        )
+        compressor = ToolResultCompressor(head_lines=5, tail_lines=5, max_chars=50)
         result = compressor.compress("run_bash", output)
         assert result.compressed_bytes < result.original_bytes
 


### PR DESCRIPTION
Cursor-style rule files. YAML frontmatter (`description`, `globs`, `always_apply`, `priority`) drives auto-attachment when the agent's touched-file set matches. Budget-aware packing drops lowest-priority rules when they'd overflow. 17 new tests, all green. `mypy --strict` + `ruff` clean.

**Follow-up:** wire `load_rules` + `select_rules` into `AgentLoopBackend._build_system_blocks` so rules auto-splice into each turn's system prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)