### PR TITLE
feat(backends): Codex CLI + Continue CLI subprocess wrappers (#93, #94)

### DIFF
--- a/maxwell_daemon/backends/codex_cli.py
+++ b/maxwell_daemon/backends/codex_cli.py
@@ -1,0 +1,158 @@
+"""Codex CLI backend — shells out to OpenAI's `codex exec` for headless use.
+
+The `codex` binary (openai/codex, Rust) ships three approval modes — ``suggest``,
+``auto-edit``, ``full-auto`` — and a `--profile` flag to swap model/provider per
+invocation. We use `codex exec` (one-shot/CI mode) and pipe the concatenated
+prompt over stdin. Auth is whatever the user's `codex` login already uses; we
+don't manage keys here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any, Literal
+
+from maxwell_daemon.backends.base import (
+    BackendCapabilities,
+    BackendResponse,
+    BackendUnavailableError,
+    ILLMBackend,
+    Message,
+    MessageRole,
+    TokenUsage,
+)
+from maxwell_daemon.backends.registry import registry
+
+__all__ = ["CodexCLIBackend"]
+
+RunnerFn = Callable[..., Awaitable[tuple[int, bytes, bytes]]]
+
+ApprovalMode = Literal["suggest", "auto-edit", "full-auto"]
+
+
+async def _default_runner(
+    *argv: str, cwd: str | None = None, stdin: bytes | None = None
+) -> tuple[int, bytes, bytes]:
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        cwd=cwd,
+        stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate(input=stdin)
+    return proc.returncode or 0, stdout, stderr
+
+
+class CodexCLIBackend(ILLMBackend):
+    name = "codex-cli"
+
+    def __init__(
+        self,
+        *,
+        runner: RunnerFn | None = None,
+        binary: str = "codex",
+        approval: ApprovalMode = "suggest",
+        profile: str | None = None,
+        timeout: float = 300.0,
+    ) -> None:
+        self._run = runner or _default_runner
+        self._binary = binary
+        self._approval: ApprovalMode = approval
+        self._profile = profile
+        self._timeout = timeout
+
+    def _format_prompt(self, messages: list[Message]) -> str:
+        system_parts: list[str] = []
+        user_parts: list[str] = []
+        for m in messages:
+            if m.role is MessageRole.SYSTEM:
+                system_parts.append(m.content)
+            else:
+                user_parts.append(m.content)
+        head = "\n\n".join(system_parts).strip()
+        body = "\n\n".join(user_parts).strip()
+        return f"{head}\n\n{body}" if head else body
+
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        model: str,
+        temperature: float = 1.0,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> BackendResponse:
+        prompt = self._format_prompt(messages)
+        if not prompt:
+            raise BackendUnavailableError("codex-cli: refusing to send empty prompt")
+
+        argv: list[str] = [self._binary, "exec", "--approval", self._approval]
+        if self._profile:
+            argv += ["--profile", self._profile]
+        argv += ["--model", model]
+
+        try:
+            rc, stdout, stderr = await asyncio.wait_for(
+                self._run(*argv, stdin=prompt.encode()),
+                timeout=self._timeout,
+            )
+        except (FileNotFoundError, TimeoutError, asyncio.TimeoutError) as e:
+            raise BackendUnavailableError(f"codex CLI unreachable: {e}") from e
+
+        if rc != 0:
+            detail = stderr.decode(errors="replace").strip() or "codex exec failed"
+            raise BackendUnavailableError(f"codex exec rc={rc}: {detail[:500]}")
+
+        content = stdout.decode(errors="replace").strip()
+        return BackendResponse(
+            content=content,
+            finish_reason="stop",
+            usage=TokenUsage(),
+            model=model,
+            backend=self.name,
+            raw={"stdout": content},
+        )
+
+    async def stream(
+        self,
+        messages: list[Message],
+        *,
+        model: str,
+        temperature: float = 1.0,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        # `codex exec` is one-shot; true token streaming would need a different
+        # codex subcommand. For now we deliver the full response as one chunk.
+        resp = await self.complete(
+            messages, model=model, temperature=temperature, max_tokens=max_tokens
+        )
+        yield resp.content
+
+    async def health_check(self) -> bool:
+        try:
+            rc, _, _ = await self._run(self._binary, "--version")
+        except (FileNotFoundError, OSError):
+            return False
+        return rc == 0
+
+    def capabilities(self, model: str) -> BackendCapabilities:
+        return BackendCapabilities(
+            supports_streaming=False,
+            supports_tool_use=True,
+            supports_vision=False,
+            supports_system_prompt=True,
+            max_context_tokens=128_000,
+            is_local=False,
+            # Codex rides the user's own OpenAI subscription/API key — no
+            # pricing owned by this adapter.
+            cost_per_1k_input_tokens=0.0,
+            cost_per_1k_output_tokens=0.0,
+        )
+
+
+registry.register("codex-cli", CodexCLIBackend)

--- a/maxwell_daemon/backends/continue_cli.py
+++ b/maxwell_daemon/backends/continue_cli.py
@@ -1,0 +1,149 @@
+"""Continue CLI backend — shells out to Continue.dev's `cn` binary.
+
+Continue.dev ships a `cn` binary (newer 2025) that wraps a local
+``.continue/config.yaml`` + assistant model. We invoke it one-shot via
+``cn ask "<prompt>"`` and surface the stdout verbatim as the response.
+
+The ``model`` argument to :meth:`complete` is ignored: Continue picks
+its model from its own config. We record whatever the CLI reports (or
+the caller's value as a fallback) in :attr:`BackendResponse.model`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
+
+from maxwell_daemon.backends.base import (
+    BackendCapabilities,
+    BackendResponse,
+    BackendUnavailableError,
+    ILLMBackend,
+    Message,
+    MessageRole,
+    TokenUsage,
+)
+from maxwell_daemon.backends.registry import registry
+
+__all__ = ["ContinueCLIBackend"]
+
+RunnerFn = Callable[..., Awaitable[tuple[int, bytes, bytes]]]
+
+
+async def _default_runner(
+    *argv: str, cwd: str | None = None, stdin: bytes | None = None
+) -> tuple[int, bytes, bytes]:
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        cwd=cwd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    return proc.returncode or 0, stdout, stderr
+
+
+class ContinueCLIBackend(ILLMBackend):
+    name = "continue-cli"
+
+    def __init__(
+        self,
+        *,
+        runner: RunnerFn | None = None,
+        binary: str = "cn",
+        assistant: str | None = None,
+        timeout: float = 180.0,
+    ) -> None:
+        self._run = runner or _default_runner
+        self._binary = binary
+        self._assistant = assistant
+        self._timeout = timeout
+
+    def _format_prompt(self, messages: list[Message]) -> str:
+        system_parts: list[str] = []
+        user_parts: list[str] = []
+        for m in messages:
+            if m.role is MessageRole.SYSTEM:
+                system_parts.append(m.content)
+            else:
+                user_parts.append(m.content)
+        # `cn ask` is one-shot: concatenate system prefix then user turns.
+        head = "\n\n".join(system_parts).strip()
+        body = "\n\n".join(user_parts).strip()
+        return f"{head}\n\n{body}" if head else body
+
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        model: str,
+        temperature: float = 1.0,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> BackendResponse:
+        prompt = self._format_prompt(messages)
+        argv: list[str] = [self._binary, "ask", prompt]
+        if self._assistant:
+            argv.extend(["--assistant", self._assistant])
+        try:
+            rc, stdout, stderr = await asyncio.wait_for(self._run(*argv), timeout=self._timeout)
+        except (FileNotFoundError, asyncio.TimeoutError) as e:
+            raise BackendUnavailableError(f"cn CLI unreachable: {e}") from e
+        if rc != 0:
+            detail = stderr.decode(errors="replace").strip() or "cn ask failed"
+            raise BackendUnavailableError(f"cn ask rc={rc}: {detail[:500]}")
+
+        # Continue picks the model from its own config; we record what the
+        # caller requested since the CLI doesn't emit a machine-readable
+        # model field in plain-text output.
+        content = stdout.decode(errors="replace")
+        return BackendResponse(
+            content=content,
+            finish_reason="stop",
+            usage=TokenUsage(),
+            model=model,
+            backend=self.name,
+            raw={"stdout": content},
+        )
+
+    async def stream(
+        self,
+        messages: list[Message],
+        *,
+        model: str,
+        temperature: float = 1.0,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        # One-shot: delegate to complete() and yield once.
+        resp = await self.complete(
+            messages, model=model, temperature=temperature, max_tokens=max_tokens
+        )
+        yield resp.content
+
+    async def health_check(self) -> bool:
+        try:
+            rc, _, _ = await self._run(self._binary, "--version")
+        except (FileNotFoundError, OSError):
+            return False
+        return rc == 0
+
+    def capabilities(self, model: str) -> BackendCapabilities:
+        # Continue manages tool use internally; we can't pass function
+        # schemas through `cn ask`.
+        return BackendCapabilities(
+            supports_streaming=False,
+            supports_tool_use=False,
+            supports_vision=False,
+            supports_system_prompt=True,
+            max_context_tokens=128_000,
+            is_local=False,
+            cost_per_1k_input_tokens=0.0,
+            cost_per_1k_output_tokens=0.0,
+        )
+
+
+registry.register("continue-cli", ContinueCLIBackend)

--- a/maxwell_daemon/backends/registry.py
+++ b/maxwell_daemon/backends/registry.py
@@ -15,7 +15,16 @@ from maxwell_daemon.backends.base import BackendError, ILLMBackend
 
 log = logging.getLogger(__name__)
 
-_BUILTIN_BACKENDS = ("claude", "openai", "azure", "ollama", "claude_code", "agent_loop")
+_BUILTIN_BACKENDS = (
+    "claude",
+    "openai",
+    "azure",
+    "ollama",
+    "claude_code",
+    "codex_cli",
+    "continue_cli",
+    "agent_loop",
+)
 
 
 class BackendRegistry:

--- a/tests/unit/test_backend_codex_cli.py
+++ b/tests/unit/test_backend_codex_cli.py
@@ -1,0 +1,260 @@
+"""Codex CLI backend — shells out to `codex exec` for headless one-shot usage.
+
+The OpenAI `codex` CLI is a Rust binary; we never call it for real from tests
+and inject a fake runner to capture argv / stdin instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from maxwell_daemon.backends import Message, MessageRole
+from maxwell_daemon.backends.base import BackendUnavailableError
+from maxwell_daemon.backends.codex_cli import CodexCLIBackend
+
+
+class _Runner:
+    """Records argv + stdin and returns a pre-programmed response."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self.stdins: list[bytes | None] = []
+        self.cwds: list[str | None] = []
+        self._stdout: bytes = b""
+        self._stderr: bytes = b""
+        self._rc: int = 0
+
+    def respond(self, *, rc: int = 0, stdout: bytes | str = b"", stderr: bytes | str = b"") -> None:
+        self._rc = rc
+        self._stdout = stdout.encode() if isinstance(stdout, str) else stdout
+        self._stderr = stderr.encode() if isinstance(stderr, str) else stderr
+
+    async def __call__(
+        self, *argv: str, cwd: str | None = None, stdin: bytes | None = None
+    ) -> tuple[int, bytes, bytes]:
+        self.calls.append(argv)
+        self.stdins.append(stdin)
+        self.cwds.append(cwd)
+        return self._rc, self._stdout, self._stderr
+
+
+# ---------------------------------------------------------------- construction
+
+
+class TestConstruction:
+    def test_defaults_binary_and_approval(self) -> None:
+        backend = CodexCLIBackend(runner=_Runner())
+        assert backend._binary == "codex"
+        assert backend._approval == "suggest"
+        assert backend._profile is None
+
+
+# ---------------------------------------------------------------- complete()
+
+
+class TestComplete:
+    def test_argv_contains_exec_approval_and_model(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout="hello")
+        backend = CodexCLIBackend(runner=r)
+        asyncio.run(
+            backend.complete(
+                [Message(role=MessageRole.USER, content="ping")],
+                model="gpt-5-codex",
+            )
+        )
+        argv = list(r.calls[-1])
+        assert argv[0] == "codex"
+        assert argv[1] == "exec"
+        assert "--approval" in argv
+        assert argv[argv.index("--approval") + 1] == "suggest"
+        assert "--model" in argv
+        assert argv[argv.index("--model") + 1] == "gpt-5-codex"
+        # Profile not set → flag absent.
+        assert "--profile" not in argv
+
+    def test_prompt_piped_via_stdin(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout="ok")
+        backend = CodexCLIBackend(runner=r)
+        asyncio.run(
+            backend.complete(
+                [
+                    Message(role=MessageRole.SYSTEM, content="be terse"),
+                    Message(role=MessageRole.USER, content="say hi"),
+                ],
+                model="gpt-5-codex",
+            )
+        )
+        piped = r.stdins[-1]
+        assert piped is not None
+        text = piped.decode()
+        # System block before user block, joined by blank lines.
+        assert "be terse" in text
+        assert "say hi" in text
+        assert text.index("be terse") < text.index("say hi")
+
+    def test_full_auto_approval_forwarded(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout="x")
+        backend = CodexCLIBackend(runner=r, approval="full-auto")
+        asyncio.run(
+            backend.complete(
+                [Message(role=MessageRole.USER, content="go")],
+                model="gpt-5-codex",
+            )
+        )
+        argv = list(r.calls[-1])
+        assert argv[argv.index("--approval") + 1] == "full-auto"
+
+    def test_profile_flag_added_when_set(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout="x")
+        backend = CodexCLIBackend(runner=r, profile="team")
+        asyncio.run(
+            backend.complete(
+                [Message(role=MessageRole.USER, content="go")],
+                model="gpt-5-codex",
+            )
+        )
+        argv = list(r.calls[-1])
+        assert "--profile" in argv
+        assert argv[argv.index("--profile") + 1] == "team"
+
+    def test_stdout_returned_as_content(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout="codex says hi\n")
+        backend = CodexCLIBackend(runner=r)
+        resp = asyncio.run(
+            backend.complete(
+                [Message(role=MessageRole.USER, content="hi")],
+                model="gpt-5-codex",
+            )
+        )
+        assert resp.content == "codex says hi"
+        assert resp.backend == "codex-cli"
+        assert resp.model == "gpt-5-codex"
+
+    def test_nonzero_rc_raises_with_truncated_stderr(self) -> None:
+        r = _Runner()
+        # 2000-char stderr should be truncated to 500 in the error message.
+        r.respond(rc=2, stderr="q" * 2000)
+        backend = CodexCLIBackend(runner=r)
+        with pytest.raises(BackendUnavailableError) as ei:
+            asyncio.run(
+                backend.complete(
+                    [Message(role=MessageRole.USER, content="hi")],
+                    model="gpt-5-codex",
+                )
+            )
+        msg = str(ei.value)
+        assert "rc=2" in msg
+        # Only the first 500 q's survive the slice — the other 1500 are dropped.
+        assert "q" * 500 in msg
+        assert "q" * 501 not in msg
+
+    def test_missing_binary_raises_unavailable(self) -> None:
+        async def runner(*a: Any, **kw: Any) -> tuple[int, bytes, bytes]:
+            raise FileNotFoundError("codex")
+
+        backend = CodexCLIBackend(runner=runner)
+        with pytest.raises(BackendUnavailableError):
+            asyncio.run(
+                backend.complete(
+                    [Message(role=MessageRole.USER, content="hi")],
+                    model="gpt-5-codex",
+                )
+            )
+
+    def test_timeout_raises_unavailable(self) -> None:
+        async def runner(*a: Any, **kw: Any) -> tuple[int, bytes, bytes]:
+            raise TimeoutError("too slow")
+
+        backend = CodexCLIBackend(runner=runner)
+        with pytest.raises(BackendUnavailableError):
+            asyncio.run(
+                backend.complete(
+                    [Message(role=MessageRole.USER, content="hi")],
+                    model="gpt-5-codex",
+                )
+            )
+
+    def test_empty_prompt_raises(self) -> None:
+        r = _Runner()
+        backend = CodexCLIBackend(runner=r)
+        with pytest.raises(BackendUnavailableError):
+            asyncio.run(backend.complete([], model="gpt-5-codex"))
+
+
+# ---------------------------------------------------------------- stream()
+
+
+class TestStream:
+    def test_yields_once_with_complete_content(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout="streamed once")
+        backend = CodexCLIBackend(runner=r)
+
+        async def collect() -> list[str]:
+            chunks: list[str] = []
+            async for c in backend.stream(
+                [Message(role=MessageRole.USER, content="hi")],
+                model="gpt-5-codex",
+            ):
+                chunks.append(c)
+            return chunks
+
+        chunks = asyncio.run(collect())
+        assert chunks == ["streamed once"]
+
+
+# ---------------------------------------------------------------- health_check
+
+
+class TestHealthCheck:
+    def test_returns_true_when_version_exits_zero(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout="codex 0.5.0\n")
+        backend = CodexCLIBackend(runner=r)
+        assert asyncio.run(backend.health_check()) is True
+        # health_check runs `codex --version`.
+        assert r.calls[-1] == ("codex", "--version")
+
+    def test_returns_false_on_file_not_found(self) -> None:
+        async def runner(*a: Any, **kw: Any) -> tuple[int, bytes, bytes]:
+            raise FileNotFoundError("codex")
+
+        backend = CodexCLIBackend(runner=runner)
+        assert asyncio.run(backend.health_check()) is False
+
+
+# ---------------------------------------------------------------- capabilities
+
+
+class TestCapabilities:
+    def test_non_local_with_tool_use_and_zero_cost(self) -> None:
+        backend = CodexCLIBackend(runner=_Runner())
+        caps = backend.capabilities("gpt-5-codex")
+        assert caps.is_local is False
+        assert caps.supports_tool_use is True
+        assert caps.supports_streaming is False
+        assert caps.supports_vision is False
+        assert caps.supports_system_prompt is True
+        assert caps.max_context_tokens == 128_000
+        assert caps.cost_per_1k_input_tokens == 0.0
+        assert caps.cost_per_1k_output_tokens == 0.0
+
+
+# ---------------------------------------------------------------- registry
+
+
+class TestRegistry:
+    def test_registered_under_codex_cli(self) -> None:
+        # Import side-effect registers the backend.
+        import maxwell_daemon.backends.codex_cli  # noqa: F401
+        from maxwell_daemon.backends.registry import registry
+
+        assert "codex-cli" in registry.available()

--- a/tests/unit/test_backend_continue_cli.py
+++ b/tests/unit/test_backend_continue_cli.py
@@ -1,0 +1,204 @@
+"""Continue CLI backend — shells out to `cn ask <prompt>` for the Continue.dev CLI."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from maxwell_daemon.backends import Message, MessageRole
+from maxwell_daemon.backends.base import BackendUnavailableError
+from maxwell_daemon.backends.continue_cli import ContinueCLIBackend
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self._stdout: bytes = b""
+        self._stderr: bytes = b""
+        self._rc: int = 0
+
+    def respond(self, *, rc: int = 0, stdout: bytes | str = b"", stderr: bytes | str = b"") -> None:
+        self._rc = rc
+        self._stdout = stdout.encode() if isinstance(stdout, str) else stdout
+        self._stderr = stderr.encode() if isinstance(stderr, str) else stderr
+
+    async def __call__(
+        self, *argv: str, cwd: str | None = None, stdin: bytes | None = None
+    ) -> tuple[int, bytes, bytes]:
+        self.calls.append(argv)
+        return self._rc, self._stdout, self._stderr
+
+
+class TestDefaults:
+    def test_default_binary_is_cn(self) -> None:
+        backend = ContinueCLIBackend()
+        assert backend._binary == "cn"
+
+
+class TestComplete:
+    def test_shells_to_cn_ask_with_prompt(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout=b"the reply")
+        backend = ContinueCLIBackend(runner=r)
+        resp = asyncio.run(
+            backend.complete(
+                [Message(role=MessageRole.USER, content="say hi")],
+                model="auto",
+            )
+        )
+        argv = r.calls[-1]
+        assert argv[0] == "cn"
+        assert argv[1] == "ask"
+        assert argv[2] == "say hi"
+        assert resp.content == "the reply"
+        assert resp.backend == "continue-cli"
+
+    def test_assistant_flag_is_passed_through(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout=b"ok")
+        backend = ContinueCLIBackend(runner=r, assistant="team-assistant")
+        asyncio.run(
+            backend.complete(
+                [Message(role=MessageRole.USER, content="hi")],
+                model="auto",
+            )
+        )
+        argv = r.calls[-1]
+        assert "--assistant" in argv
+        idx = argv.index("--assistant")
+        assert argv[idx + 1] == "team-assistant"
+
+    def test_assistant_absent_when_not_configured(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout=b"ok")
+        backend = ContinueCLIBackend(runner=r)
+        asyncio.run(
+            backend.complete(
+                [Message(role=MessageRole.USER, content="hi")],
+                model="auto",
+            )
+        )
+        argv = r.calls[-1]
+        assert "--assistant" not in argv
+
+    def test_system_message_prepended_to_user_message(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout=b"ok")
+        backend = ContinueCLIBackend(runner=r)
+        asyncio.run(
+            backend.complete(
+                [
+                    Message(role=MessageRole.SYSTEM, content="be terse"),
+                    Message(role=MessageRole.SYSTEM, content="no emojis"),
+                    Message(role=MessageRole.USER, content="say hi"),
+                ],
+                model="auto",
+            )
+        )
+        argv = r.calls[-1]
+        # The prompt should contain both system prefix pieces and the user turn.
+        prompt = argv[2]
+        assert "be terse" in prompt
+        assert "no emojis" in prompt
+        assert "say hi" in prompt
+        # System parts come before user parts.
+        assert prompt.index("be terse") < prompt.index("say hi")
+        assert prompt.index("no emojis") < prompt.index("say hi")
+
+    def test_stdout_returned_as_response_content(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout="hello from continue\n")
+        backend = ContinueCLIBackend(runner=r)
+        resp = asyncio.run(
+            backend.complete(
+                [Message(role=MessageRole.USER, content="hi")],
+                model="auto",
+            )
+        )
+        assert "hello from continue" in resp.content
+
+    def test_error_exit_raises_with_truncated_stderr(self) -> None:
+        r = _Runner()
+        long_err = "x" * 1000
+        r.respond(rc=2, stderr=long_err)
+        backend = ContinueCLIBackend(runner=r)
+        with pytest.raises(BackendUnavailableError) as exc_info:
+            asyncio.run(
+                backend.complete(
+                    [Message(role=MessageRole.USER, content="hi")],
+                    model="auto",
+                )
+            )
+        # Stderr should be truncated to ~500 chars.
+        assert len(str(exc_info.value)) < 700
+        assert "rc=2" in str(exc_info.value)
+
+    def test_missing_binary_wrapped_as_unavailable(self) -> None:
+        async def runner(*a: Any, **kw: Any) -> tuple[int, bytes, bytes]:
+            raise FileNotFoundError("cn")
+
+        backend = ContinueCLIBackend(runner=runner)
+        with pytest.raises(BackendUnavailableError) as exc_info:
+            asyncio.run(
+                backend.complete(
+                    [Message(role=MessageRole.USER, content="hi")],
+                    model="auto",
+                )
+            )
+        assert "cn CLI unreachable" in str(exc_info.value)
+
+
+class TestStream:
+    def test_stream_yields_complete_content_once(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout=b"streamed reply")
+        backend = ContinueCLIBackend(runner=r)
+
+        async def collect() -> list[str]:
+            chunks: list[str] = []
+            async for chunk in backend.stream(
+                [Message(role=MessageRole.USER, content="hi")],
+                model="auto",
+            ):
+                chunks.append(chunk)
+            return chunks
+
+        chunks = asyncio.run(collect())
+        assert chunks == ["streamed reply"]
+
+
+class TestHealthCheck:
+    def test_healthy_when_rc_zero(self) -> None:
+        r = _Runner()
+        r.respond(rc=0, stdout="cn 1.0.0\n")
+        backend = ContinueCLIBackend(runner=r)
+        assert asyncio.run(backend.health_check()) is True
+
+    def test_unhealthy_when_binary_missing(self) -> None:
+        async def runner(*a: Any, **kw: Any) -> tuple[int, bytes, bytes]:
+            raise FileNotFoundError("cn")
+
+        backend = ContinueCLIBackend(runner=runner)
+        assert asyncio.run(backend.health_check()) is False
+
+
+class TestCapabilities:
+    def test_no_tool_use_and_zero_cost(self) -> None:
+        backend = ContinueCLIBackend(runner=_Runner())
+        caps = backend.capabilities("auto")
+        assert caps.supports_tool_use is False
+        assert caps.supports_streaming is False
+        assert caps.supports_system_prompt is True
+        assert caps.cost_per_1k_input_tokens == 0.0
+        assert caps.cost_per_1k_output_tokens == 0.0
+        assert caps.max_context_tokens == 128_000
+        assert caps.is_local is False
+
+
+class TestRegistry:
+    def test_continue_cli_is_registered(self) -> None:
+        from maxwell_daemon.backends.registry import registry
+
+        assert "continue-cli" in registry.available()


### PR DESCRIPTION
Two new `ILLMBackend` adapters. Codex CLI (OpenAI's Rust binary with approval tiers + profile switching, prompt via stdin) and Continue CLI (`cn ask` wrapper with optional `--assistant`). Both added to the `_BUILTIN_BACKENDS` autoload tuple so `registry.available()` surfaces them.

28 new tests (all green). `mypy --strict` + `ruff` clean. Zero real subprocess calls in tests — injected runners throughout.

Maxwell-Daemon now supports **six** backend adapters: Anthropic API, Anthropic CLI, OpenAI API, Ollama, Azure OpenAI, Codex CLI, Continue CLI (plus the multi-turn loop variants for Anthropic + Ollama).

🤖 Generated with [Claude Code](https://claude.com/claude-code)