### PR TITLE
feat(fleet): multi-machine task dispatch (dispatcher + remote client) (#104)

### DIFF
--- a/maxwell_daemon/fleet/__init__.py
+++ b/maxwell_daemon/fleet/__init__.py
@@ -1,0 +1,42 @@
+"""Multi-machine task dispatch.
+
+This package splits the problem in two on purpose:
+
+* :mod:`.dispatcher` is pure: given a fleet snapshot and a task list, produce a
+  :class:`DispatchPlan`. No I/O, no asyncio — every edge case is a table test.
+* :mod:`.client` is the async HTTP adapter that talks to remote daemons. The
+  underlying HTTP call is injected so unit tests never touch sockets.
+
+The separation means policy changes (scoring, tie-breaking) land in one module,
+transport changes (httpx → something else) land in the other.
+"""
+
+from __future__ import annotations
+
+from maxwell_daemon.fleet.client import (
+    HTTPClientProtocol,
+    RemoteDaemonClient,
+    RemoteDaemonError,
+    RemoteTaskResult,
+)
+from maxwell_daemon.fleet.dispatcher import (
+    Assignment,
+    DispatchPlan,
+    FleetDispatcher,
+    MachineState,
+    TaskRequirement,
+    score_machine,
+)
+
+__all__ = [
+    "Assignment",
+    "DispatchPlan",
+    "FleetDispatcher",
+    "HTTPClientProtocol",
+    "MachineState",
+    "RemoteDaemonClient",
+    "RemoteDaemonError",
+    "RemoteTaskResult",
+    "TaskRequirement",
+    "score_machine",
+]

--- a/maxwell_daemon/fleet/client.py
+++ b/maxwell_daemon/fleet/client.py
@@ -1,0 +1,217 @@
+"""Async HTTP client for dispatching tasks to remote daemon instances.
+
+Transport is injected via :class:`HTTPClientProtocol` so tests can hand in a
+recorder and never touch a real socket. Production code instantiates the
+adapter with an :class:`httpx.AsyncClient`.
+
+Two endpoints matter for now:
+
+* ``POST /api/v1/tasks``  — submit a task for execution
+* ``GET  /api/v1/health`` — liveness probe used by :meth:`refresh_all`
+
+All methods translate transport-level failures (connection refused, timeouts)
+into a single :class:`RemoteDaemonError` so callers don't have to know which
+HTTP library we're using underneath.
+
+See GitHub issue #104.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from maxwell_daemon.fleet.dispatcher import MachineState
+
+__all__ = [
+    "HTTPClientProtocol",
+    "HTTPResponseProtocol",
+    "RemoteDaemonClient",
+    "RemoteDaemonError",
+    "RemoteTaskResult",
+]
+
+
+_TASKS_PATH = "/api/v1/tasks"
+_HEALTH_PATH = "/api/v1/health"
+
+
+class RemoteDaemonError(RuntimeError):
+    """Raised when a remote daemon call fails or times out at the transport layer."""
+
+
+@dataclass(slots=True, frozen=True)
+class RemoteTaskResult:
+    """Outcome of a submit_task call."""
+
+    task_id: str
+    machine_name: str
+    status: str  # "submitted" | "error"
+    detail: str = ""
+
+
+@runtime_checkable
+class HTTPResponseProtocol(Protocol):
+    """Shape of an HTTP response our client consumes.
+
+    Matches httpx.Response closely enough that a real httpx client satisfies it
+    without adaptation.
+    """
+
+    status_code: int
+
+    def json(self) -> Any: ...
+
+
+@runtime_checkable
+class HTTPClientProtocol(Protocol):
+    """Minimal async HTTP client surface the adapter needs."""
+
+    async def post(
+        self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+    ) -> HTTPResponseProtocol: ...
+
+    async def get(self, url: str, *, headers: dict[str, str]) -> HTTPResponseProtocol: ...
+
+
+class RemoteDaemonClient:
+    """Async HTTP client for dispatching tasks to remote daemon instances.
+
+    The ``http_client`` is injected. Pass ``None`` to use a fresh
+    :class:`httpx.AsyncClient` with the configured timeout.
+    """
+
+    def __init__(
+        self,
+        *,
+        http_client: HTTPClientProtocol | None = None,
+        auth_token: str | None = None,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self._http = http_client if http_client is not None else _make_default_http(timeout_seconds)
+        self._auth_token = auth_token
+        self._timeout_seconds = timeout_seconds
+
+    # ------------------------------------------------------------------ headers
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._auth_token:
+            headers["Authorization"] = f"Bearer {self._auth_token}"
+        return headers
+
+    # ------------------------------------------------------------------ URLs
+    @staticmethod
+    def _base_url(machine: MachineState) -> str:
+        return f"http://{machine.host}:{machine.port}"
+
+    # ------------------------------------------------------------------ submit
+    async def submit_task(
+        self,
+        machine: MachineState,
+        *,
+        task_payload: dict[str, Any],
+    ) -> RemoteTaskResult:
+        """POST the task payload; translate HTTP status into a typed result."""
+        url = f"{self._base_url(machine)}{_TASKS_PATH}"
+        task_id = str(task_payload.get("task_id", ""))
+        try:
+            response = await self._http.post(url, json=task_payload, headers=self._headers())
+        except Exception as exc:  # transport-level failure
+            raise RemoteDaemonError(
+                f"submit_task to {machine.name} ({url}) failed: {exc!r}"
+            ) from exc
+
+        if 200 <= response.status_code < 300:
+            return RemoteTaskResult(
+                task_id=task_id,
+                machine_name=machine.name,
+                status="submitted",
+            )
+
+        return RemoteTaskResult(
+            task_id=task_id,
+            machine_name=machine.name,
+            status="error",
+            detail=_extract_error_detail(response),
+        )
+
+    # ------------------------------------------------------------------ health
+    async def health_check(self, machine: MachineState) -> bool:
+        """Liveness probe. Returns True iff the daemon answers 200."""
+        url = f"{self._base_url(machine)}{_HEALTH_PATH}"
+        try:
+            response = await self._http.get(url, headers=self._headers())
+        except Exception:
+            return False
+        return response.status_code == 200
+
+    async def refresh_all(self, machines: tuple[MachineState, ...]) -> tuple[MachineState, ...]:
+        """Probe every machine in parallel, return snapshots with ``healthy`` updated.
+
+        One machine's failure never affects the probe of another — each task
+        catches its own exceptions. Other fields (host, port, capacity, tags,
+        active_tasks) pass through untouched.
+        """
+        if not machines:
+            return ()
+        results = await asyncio.gather(
+            *(self.health_check(m) for m in machines),
+            return_exceptions=False,
+        )
+        return tuple(
+            MachineState(
+                name=m.name,
+                host=m.host,
+                port=m.port,
+                capacity=m.capacity,
+                tags=m.tags,
+                active_tasks=m.active_tasks,
+                healthy=healthy,
+            )
+            for m, healthy in zip(machines, results, strict=True)
+        )
+
+
+def _extract_error_detail(response: HTTPResponseProtocol) -> str:
+    """Pull a useful error message out of an HTTP error response.
+
+    We try JSON first, fall back to ``.text`` (if present), and finally to just
+    the status code so callers always have something non-empty to surface.
+    """
+    status = response.status_code
+    try:
+        body = response.json()
+        if isinstance(body, dict):
+            for key in ("error", "detail", "message"):
+                if body.get(key):
+                    return f"HTTP {status}: {body[key]}"
+        return f"HTTP {status}: {body!r}"
+    except Exception:
+        text = getattr(response, "text", "") or ""
+        if text:
+            return f"HTTP {status}: {text}"
+        return f"HTTP {status}"
+
+
+def _make_default_http(timeout_seconds: float) -> HTTPClientProtocol:
+    """Create an httpx AsyncClient wrapped to match our protocol.
+
+    Imported lazily so unit tests can run without httpx being functional in the
+    test environment (they always inject a fake).
+    """
+    import httpx
+
+    class _HttpxAdapter:
+        def __init__(self, timeout: float) -> None:
+            self._client = httpx.AsyncClient(timeout=timeout)
+
+        async def post(
+            self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+        ) -> HTTPResponseProtocol:
+            return await self._client.post(url, json=json, headers=headers)
+
+        async def get(self, url: str, *, headers: dict[str, str]) -> HTTPResponseProtocol:
+            return await self._client.get(url, headers=headers)
+
+    return _HttpxAdapter(timeout_seconds)

--- a/maxwell_daemon/fleet/dispatcher.py
+++ b/maxwell_daemon/fleet/dispatcher.py
@@ -1,0 +1,171 @@
+"""Pure routing policy: tasks -> machines.
+
+The dispatcher is deliberately side-effect-free. Given an immutable snapshot
+of the fleet (:class:`MachineState`) plus a list of :class:`TaskRequirement`,
+it returns a :class:`DispatchPlan` describing which tasks go where and which
+couldn't be placed. No asyncio, no I/O, no global state.
+
+Scoring is intentionally simple: ``available_slots * 10 + #preferred_tags_matched``.
+The factor of 10 keeps "more capacity" dominant over "nice-to-have tags" while
+still letting preferred tags break ties between machines with equal slots.
+Greedy placement picks the highest-scoring (machine, task) pair at each step
+— after picking, the machine's remaining capacity drops by one and scores are
+recomputed so the next pick reflects current load.
+
+See GitHub issue #104 for context.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from maxwell_daemon.contracts import require
+
+__all__ = [
+    "Assignment",
+    "DispatchPlan",
+    "FleetDispatcher",
+    "MachineState",
+    "TaskRequirement",
+    "score_machine",
+]
+
+
+# Weight applied to each free slot when scoring. Large enough that capacity
+# dominates preferred-tag matches, so two equally-preferred machines are
+# separated by load rather than tag count.
+_SLOT_WEIGHT = 10
+
+
+@dataclass(slots=True, frozen=True)
+class MachineState:
+    """Immutable snapshot of a machine's current load and capabilities."""
+
+    name: str
+    host: str
+    port: int
+    capacity: int
+    tags: tuple[str, ...]
+    active_tasks: int = 0
+    healthy: bool = True
+
+    @property
+    def available_slots(self) -> int:
+        """Free slots right now. Unhealthy machines report zero regardless of load."""
+        if not self.healthy:
+            return 0
+        return max(0, self.capacity - self.active_tasks)
+
+
+@dataclass(slots=True, frozen=True)
+class TaskRequirement:
+    """What a task needs (required tags) and prefers (preferred tags).
+
+    Required tags act as a hard filter — a machine that lacks any is excluded.
+    Preferred tags only influence scoring.
+    """
+
+    task_id: str
+    required_tags: frozenset[str] = frozenset()
+    preferred_tags: frozenset[str] = frozenset()
+
+
+@dataclass(slots=True, frozen=True)
+class Assignment:
+    """One task -> one machine binding."""
+
+    task_id: str
+    machine_name: str
+
+
+@dataclass(slots=True, frozen=True)
+class DispatchPlan:
+    """Result of :meth:`FleetDispatcher.plan`.
+
+    ``assignments`` is ordered by placement: the first entry was the highest
+    scoring (machine, task) pair at the moment it was picked.
+    """
+
+    assignments: tuple[Assignment, ...]
+    unassigned: tuple[str, ...]
+
+
+def score_machine(machine: MachineState, task: TaskRequirement) -> int | None:
+    """Score a (machine, task) pair.
+
+    Returns:
+        ``None`` when the machine cannot run the task (unhealthy, full, or
+        missing any required tag). Otherwise an integer where higher is better.
+    """
+    if not machine.healthy:
+        return None
+    if machine.available_slots <= 0:
+        return None
+    machine_tags = set(machine.tags)
+    if not task.required_tags.issubset(machine_tags):
+        return None
+    preferred_hits = len(task.preferred_tags & machine_tags)
+    return machine.available_slots * _SLOT_WEIGHT + preferred_hits
+
+
+class FleetDispatcher:
+    """Pure logic — produce a :class:`DispatchPlan` from a fleet snapshot.
+
+    Algorithm: repeatedly find the highest-scoring (machine, task) pair across
+    all currently-schedulable pairs. Assign it, decrement that machine's
+    available capacity, remove the task from the pool, repeat until nothing is
+    schedulable. Any task we never placed goes into ``unassigned``.
+
+    Tie-breaking (when two candidate pairs have identical scores): we pick the
+    lowest task id first, then the lowest machine name. Stable and deterministic
+    — important for reproducible planning in tests.
+    """
+
+    def plan(
+        self,
+        machines: tuple[MachineState, ...],
+        tasks: tuple[TaskRequirement, ...],
+    ) -> DispatchPlan:
+        # Machines mutate (their active_tasks grows) as we assign. Work on a
+        # mutable dict keyed by name so we can swap in updated snapshots.
+        live: dict[str, MachineState] = {m.name: m for m in machines}
+        remaining: list[TaskRequirement] = list(tasks)
+        assignments: list[Assignment] = []
+
+        while remaining:
+            best: tuple[int, str, str, TaskRequirement, MachineState] | None = None
+            # Iterate in a deterministic order so ties resolve the same way
+            # every run. We sort by (-score, task_id, machine_name) at the end.
+            for task in remaining:
+                for machine in live.values():
+                    score = score_machine(machine, task)
+                    if score is None:
+                        continue
+                    candidate = (score, task.task_id, machine.name, task, machine)
+                    if best is None:
+                        best = candidate
+                        continue
+                    # Higher score wins; on equal score prefer lower task id,
+                    # then lower machine name (lexicographic, stable).
+                    if (score > best[0]) or (
+                        score == best[0] and (task.task_id, machine.name) < (best[1], best[2])
+                    ):
+                        best = candidate
+
+            if best is None:
+                break  # nothing schedulable — the rest go unassigned
+
+            _score, task_id, machine_name, task, machine = best
+            require(
+                machine.available_slots > 0,
+                "scored machine must have at least one available slot",
+            )
+            assignments.append(Assignment(task_id=task_id, machine_name=machine_name))
+            # "Consume" a slot by incrementing active_tasks on the live copy.
+            live[machine_name] = replace(machine, active_tasks=machine.active_tasks + 1)
+            remaining.remove(task)
+
+        return DispatchPlan(
+            assignments=tuple(assignments),
+            unassigned=tuple(t.task_id for t in remaining),
+        )

--- a/tests/unit/test_fleet_dispatcher.py
+++ b/tests/unit/test_fleet_dispatcher.py
@@ -1,0 +1,254 @@
+"""Unit tests for maxwell_daemon.fleet.dispatcher — pure task-to-machine routing.
+
+The dispatcher is deliberately side-effect-free: given a snapshot of machines
+and a list of task requirements, it returns a DispatchPlan. No I/O, no asyncio,
+no network. That makes scoring decisions trivial to verify and lets the
+higher-level workflow mock any policy change we throw at it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from maxwell_daemon.fleet.dispatcher import (
+    Assignment,
+    DispatchPlan,
+    FleetDispatcher,
+    MachineState,
+    TaskRequirement,
+    score_machine,
+)
+
+
+def _machine(
+    name: str = "m1",
+    *,
+    host: str = "host.example",
+    port: int = 50051,
+    capacity: int = 2,
+    tags: tuple[str, ...] = (),
+    active_tasks: int = 0,
+    healthy: bool = True,
+) -> MachineState:
+    return MachineState(
+        name=name,
+        host=host,
+        port=port,
+        capacity=capacity,
+        tags=tags,
+        active_tasks=active_tasks,
+        healthy=healthy,
+    )
+
+
+def _task(
+    task_id: str = "t1",
+    *,
+    required: tuple[str, ...] = (),
+    preferred: tuple[str, ...] = (),
+) -> TaskRequirement:
+    return TaskRequirement(
+        task_id=task_id,
+        required_tags=frozenset(required),
+        preferred_tags=frozenset(preferred),
+    )
+
+
+class TestMachineStateAvailableSlots:
+    def test_available_slots_zero_when_unhealthy(self) -> None:
+        m = _machine(capacity=4, active_tasks=0, healthy=False)
+        assert m.available_slots == 0
+
+    def test_available_slots_zero_when_full(self) -> None:
+        m = _machine(capacity=2, active_tasks=2)
+        assert m.available_slots == 0
+
+    def test_available_slots_never_negative(self) -> None:
+        """If active_tasks somehow exceeds capacity, clamp to 0 rather than lie."""
+        m = _machine(capacity=2, active_tasks=5)
+        assert m.available_slots == 0
+
+    def test_available_slots_correct_when_partial(self) -> None:
+        m = _machine(capacity=4, active_tasks=1)
+        assert m.available_slots == 3
+
+    def test_available_slots_equals_capacity_when_idle(self) -> None:
+        m = _machine(capacity=3, active_tasks=0)
+        assert m.available_slots == 3
+
+
+class TestScoreMachine:
+    def test_none_when_unhealthy(self) -> None:
+        m = _machine(healthy=False)
+        assert score_machine(m, _task()) is None
+
+    def test_none_when_full(self) -> None:
+        m = _machine(capacity=2, active_tasks=2)
+        assert score_machine(m, _task()) is None
+
+    def test_none_when_required_tag_missing(self) -> None:
+        m = _machine(tags=("linux",))
+        assert score_machine(m, _task(required=("gpu",))) is None
+
+    def test_none_when_some_required_tag_missing(self) -> None:
+        m = _machine(tags=("linux",))
+        assert score_machine(m, _task(required=("linux", "gpu"))) is None
+
+    def test_int_returned_when_all_required_tags_present(self) -> None:
+        m = _machine(capacity=2, tags=("linux", "gpu"))
+        result = score_machine(m, _task(required=("linux",)))
+        assert isinstance(result, int)
+
+    def test_higher_score_for_more_available_slots(self) -> None:
+        low = _machine("a", capacity=1)
+        high = _machine("b", capacity=8)
+        task = _task()
+        low_score = score_machine(low, task)
+        high_score = score_machine(high, task)
+        assert low_score is not None and high_score is not None
+        assert high_score > low_score
+
+    def test_higher_score_for_more_preferred_tags(self) -> None:
+        plain = _machine("plain", capacity=2, tags=())
+        tagged = _machine("tagged", capacity=2, tags=("fast", "ssd"))
+        task = _task(preferred=("fast", "ssd"))
+        plain_score = score_machine(plain, task)
+        tagged_score = score_machine(tagged, task)
+        assert plain_score is not None and tagged_score is not None
+        assert tagged_score > plain_score
+
+    def test_preferred_tag_missing_does_not_exclude(self) -> None:
+        m = _machine(tags=())
+        assert score_machine(m, _task(preferred=("fast",))) is not None
+
+
+class TestDispatcherBasics:
+    def test_empty_machines_all_unassigned(self) -> None:
+        plan = FleetDispatcher().plan((), (_task("t1"), _task("t2")))
+        assert plan.assignments == ()
+        assert set(plan.unassigned) == {"t1", "t2"}
+
+    def test_empty_tasks_empty_plan(self) -> None:
+        plan = FleetDispatcher().plan((_machine(),), ())
+        assert plan.assignments == ()
+        assert plan.unassigned == ()
+
+    def test_single_task_single_assignment(self) -> None:
+        m = _machine("m1", capacity=2)
+        plan = FleetDispatcher().plan((m,), (_task("t1"),))
+        assert plan.assignments == (Assignment(task_id="t1", machine_name="m1"),)
+        assert plan.unassigned == ()
+
+    def test_single_task_best_machine_wins(self) -> None:
+        small = _machine("small", capacity=1)
+        big = _machine("big", capacity=8)
+        plan = FleetDispatcher().plan((small, big), (_task("t1"),))
+        assert plan.assignments == (Assignment(task_id="t1", machine_name="big"),)
+
+
+class TestDispatcherCapacity:
+    def test_tasks_exceeding_capacity_overflow(self) -> None:
+        m = _machine("m1", capacity=2)
+        tasks = tuple(_task(f"t{i}") for i in range(5))
+        plan = FleetDispatcher().plan((m,), tasks)
+        assert len(plan.assignments) == 2
+        assert len(plan.unassigned) == 3
+        assigned_ids = {a.task_id for a in plan.assignments}
+        unassigned_ids = set(plan.unassigned)
+        assert assigned_ids.isdisjoint(unassigned_ids)
+        assert assigned_ids | unassigned_ids == {f"t{i}" for i in range(5)}
+
+    def test_capacity_respected_across_machines(self) -> None:
+        a = _machine("a", capacity=2)
+        b = _machine("b", capacity=3)
+        tasks = tuple(_task(f"t{i}") for i in range(10))
+        plan = FleetDispatcher().plan((a, b), tasks)
+
+        counts: dict[str, int] = {}
+        for assignment in plan.assignments:
+            counts[assignment.machine_name] = counts.get(assignment.machine_name, 0) + 1
+        assert counts.get("a", 0) <= 2
+        assert counts.get("b", 0) <= 3
+        assert len(plan.assignments) == 5
+        assert len(plan.unassigned) == 5
+
+    def test_active_tasks_reduce_available_capacity(self) -> None:
+        m = _machine("m1", capacity=4, active_tasks=3)
+        tasks = (_task("t1"), _task("t2"), _task("t3"))
+        plan = FleetDispatcher().plan((m,), tasks)
+        assert len(plan.assignments) == 1
+        assert len(plan.unassigned) == 2
+
+
+class TestDispatcherFiltering:
+    def test_required_tags_filter_excludes_machines(self) -> None:
+        cpu_only = _machine("cpu", capacity=4, tags=("cpu",))
+        gpu = _machine("gpu", capacity=1, tags=("cpu", "gpu"))
+        plan = FleetDispatcher().plan(
+            (cpu_only, gpu),
+            (_task("t1", required=("gpu",)),),
+        )
+        assert plan.assignments == (Assignment(task_id="t1", machine_name="gpu"),)
+
+    def test_no_machine_satisfies_required_tags(self) -> None:
+        m = _machine("m1", capacity=4, tags=("linux",))
+        plan = FleetDispatcher().plan((m,), (_task("t1", required=("darwin",)),))
+        assert plan.assignments == ()
+        assert plan.unassigned == ("t1",)
+
+    def test_unhealthy_machine_skipped(self) -> None:
+        dead = _machine("dead", capacity=8, healthy=False)
+        alive = _machine("alive", capacity=1)
+        plan = FleetDispatcher().plan((dead, alive), (_task("t1"),))
+        assert plan.assignments == (Assignment(task_id="t1", machine_name="alive"),)
+
+
+class TestDispatcherTieBreaking:
+    def test_preferred_tags_break_ties(self) -> None:
+        plain = _machine("plain", capacity=2, tags=())
+        fast = _machine("fast", capacity=2, tags=("fast",))
+        plan = FleetDispatcher().plan(
+            (plain, fast),
+            (_task("t1", preferred=("fast",)),),
+        )
+        assert plan.assignments == (Assignment(task_id="t1", machine_name="fast"),)
+
+    def test_greedy_placement_highest_score_first(self) -> None:
+        """When two tasks compete, the higher-scoring pair is picked first.
+
+        Task t_gpu prefers ``gpu``; task t_any has no preference. The gpu machine
+        scores higher for t_gpu (slots + preferred match) than the cpu machine
+        does for either task. Greedy should place (t_gpu, gpu) first, then
+        t_any lands on cpu.
+        """
+        cpu = _machine("cpu", capacity=1, tags=("cpu",))
+        gpu = _machine("gpu", capacity=1, tags=("cpu", "gpu"))
+        t_gpu = _task("t_gpu", preferred=("gpu",))
+        t_any = _task("t_any")
+        plan = FleetDispatcher().plan((cpu, gpu), (t_gpu, t_any))
+        by_task = {a.task_id: a.machine_name for a in plan.assignments}
+        assert by_task == {"t_gpu": "gpu", "t_any": "cpu"}
+
+
+class TestFrozenDataclasses:
+    def test_machine_state_frozen(self) -> None:
+        m = _machine()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            m.active_tasks = 99  # type: ignore[misc]
+
+    def test_task_requirement_frozen(self) -> None:
+        t = _task()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            t.task_id = "other"  # type: ignore[misc]
+
+    def test_assignment_frozen(self) -> None:
+        a = Assignment(task_id="t1", machine_name="m1")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            a.task_id = "t2"  # type: ignore[misc]
+
+    def test_dispatch_plan_frozen(self) -> None:
+        plan = DispatchPlan(assignments=(), unassigned=())
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            plan.unassigned = ("x",)  # type: ignore[misc]

--- a/tests/unit/test_fleet_remote_client.py
+++ b/tests/unit/test_fleet_remote_client.py
@@ -1,0 +1,322 @@
+"""Unit tests for maxwell_daemon.fleet.client — async HTTP client for remote daemons.
+
+Follows the injected-runner pattern: tests pass a recording fake HTTP client so
+no sockets are opened. The production code uses httpx; the test fakes emulate
+just enough of httpx's response surface (`status_code`, `.json()`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from maxwell_daemon.fleet.client import (
+    RemoteDaemonClient,
+    RemoteDaemonError,
+    RemoteTaskResult,
+)
+from maxwell_daemon.fleet.dispatcher import MachineState
+
+
+def _machine(name: str = "m1", host: str = "host.example", port: int = 50051) -> MachineState:
+    return MachineState(
+        name=name,
+        host=host,
+        port=port,
+        capacity=2,
+        tags=(),
+        active_tasks=0,
+        healthy=True,
+    )
+
+
+@dataclass
+class FakeResponse:
+    status_code: int
+    _body: dict[str, Any] = field(default_factory=dict)
+    _text: str = ""
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+    @property
+    def text(self) -> str:
+        return self._text or str(self._body)
+
+
+@dataclass
+class RecordedPost:
+    url: str
+    json: dict[str, Any]
+    headers: dict[str, str]
+
+
+@dataclass
+class RecordedGet:
+    url: str
+    headers: dict[str, str]
+
+
+class FakeHTTPClient:
+    """Records calls and returns canned responses keyed by URL + method."""
+
+    def __init__(
+        self,
+        *,
+        post_responses: dict[str, FakeResponse] | None = None,
+        get_responses: dict[str, FakeResponse] | None = None,
+        post_exceptions: dict[str, Exception] | None = None,
+        get_exceptions: dict[str, Exception] | None = None,
+    ) -> None:
+        self._post_responses = post_responses or {}
+        self._get_responses = get_responses or {}
+        self._post_exceptions = post_exceptions or {}
+        self._get_exceptions = get_exceptions or {}
+        self.posts: list[RecordedPost] = []
+        self.gets: list[RecordedGet] = []
+
+    async def post(
+        self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+    ) -> FakeResponse:
+        self.posts.append(RecordedPost(url=url, json=json, headers=dict(headers)))
+        if url in self._post_exceptions:
+            raise self._post_exceptions[url]
+        return self._post_responses.get(url, FakeResponse(status_code=200, _body={"ok": True}))
+
+    async def get(self, url: str, *, headers: dict[str, str]) -> FakeResponse:
+        self.gets.append(RecordedGet(url=url, headers=dict(headers)))
+        if url in self._get_exceptions:
+            raise self._get_exceptions[url]
+        return self._get_responses.get(url, FakeResponse(status_code=200, _body={"ok": True}))
+
+
+class TestSubmitTaskRequestShape:
+    async def test_posts_to_correct_url(self) -> None:
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http)
+        await client.submit_task(
+            _machine(host="runner-a", port=50099),
+            task_payload={"task_id": "t1"},
+        )
+        assert len(http.posts) == 1
+        assert http.posts[0].url == "http://runner-a:50099/api/v1/tasks"
+
+    async def test_sends_json_body(self) -> None:
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http)
+        payload = {"task_id": "t1", "repo": "acme/foo"}
+        await client.submit_task(_machine(), task_payload=payload)
+        assert http.posts[0].json == payload
+
+    async def test_no_auth_header_when_token_unset(self) -> None:
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http)
+        await client.submit_task(_machine(), task_payload={})
+        assert "Authorization" not in http.posts[0].headers
+
+    async def test_bearer_header_when_token_set(self) -> None:
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http, auth_token="s3cret")
+        await client.submit_task(_machine(), task_payload={})
+        assert http.posts[0].headers["Authorization"] == "Bearer s3cret"
+
+
+class TestSubmitTaskResponse:
+    @pytest.mark.parametrize("status", [200, 201, 202])
+    async def test_success_statuses_return_submitted(self, status: int) -> None:
+        url = "http://host.example:50051/api/v1/tasks"
+        http = FakeHTTPClient(
+            post_responses={url: FakeResponse(status_code=status, _body={"accepted": True})}
+        )
+        client = RemoteDaemonClient(http_client=http)
+        result = await client.submit_task(_machine(), task_payload={"task_id": "t1"})
+        assert isinstance(result, RemoteTaskResult)
+        assert result.status == "submitted"
+        assert result.task_id == "t1"
+        assert result.machine_name == "m1"
+
+    @pytest.mark.parametrize("status", [400, 403, 404, 500, 503])
+    async def test_error_statuses_return_error_with_detail(self, status: int) -> None:
+        url = "http://host.example:50051/api/v1/tasks"
+        http = FakeHTTPClient(
+            post_responses={
+                url: FakeResponse(status_code=status, _body={"error": "nope"}, _text="nope"),
+            }
+        )
+        client = RemoteDaemonClient(http_client=http)
+        result = await client.submit_task(_machine(), task_payload={"task_id": "t1"})
+        assert result.status == "error"
+        assert result.task_id == "t1"
+        assert result.machine_name == "m1"
+        assert result.detail  # non-empty detail on error
+        assert str(status) in result.detail or "nope" in result.detail
+
+    async def test_task_id_missing_from_payload_still_returns_result(self) -> None:
+        """If the caller forgets ``task_id``, the result should still carry an id
+        (we fall back to empty string rather than crashing)."""
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http)
+        result = await client.submit_task(_machine(), task_payload={})
+        assert isinstance(result, RemoteTaskResult)
+        assert result.status == "submitted"
+
+
+class TestSubmitTaskTransport:
+    async def test_transport_failure_raises_remote_daemon_error(self) -> None:
+        url = "http://host.example:50051/api/v1/tasks"
+        http = FakeHTTPClient(
+            post_exceptions={url: ConnectionRefusedError("nope")},
+        )
+        client = RemoteDaemonClient(http_client=http)
+        with pytest.raises(RemoteDaemonError):
+            await client.submit_task(_machine(), task_payload={"task_id": "t1"})
+
+    async def test_timeout_raises_remote_daemon_error(self) -> None:
+        url = "http://host.example:50051/api/v1/tasks"
+        http = FakeHTTPClient(
+            post_exceptions={url: TimeoutError("slow")},
+        )
+        client = RemoteDaemonClient(http_client=http)
+        with pytest.raises(RemoteDaemonError):
+            await client.submit_task(_machine(), task_payload={"task_id": "t1"})
+
+
+class TestHealthCheck:
+    async def test_returns_true_on_200(self) -> None:
+        url = "http://host.example:50051/api/v1/health"
+        http = FakeHTTPClient(get_responses={url: FakeResponse(status_code=200)})
+        client = RemoteDaemonClient(http_client=http)
+        assert await client.health_check(_machine()) is True
+
+    @pytest.mark.parametrize("status", [201, 301, 400, 500, 503])
+    async def test_returns_false_on_non_200(self, status: int) -> None:
+        url = "http://host.example:50051/api/v1/health"
+        http = FakeHTTPClient(get_responses={url: FakeResponse(status_code=status)})
+        client = RemoteDaemonClient(http_client=http)
+        assert await client.health_check(_machine()) is False
+
+    async def test_returns_false_on_transport_exception(self) -> None:
+        url = "http://host.example:50051/api/v1/health"
+        http = FakeHTTPClient(get_exceptions={url: ConnectionRefusedError("nope")})
+        client = RemoteDaemonClient(http_client=http)
+        assert await client.health_check(_machine()) is False
+
+    async def test_sends_auth_header_when_configured(self) -> None:
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http, auth_token="t0k")
+        await client.health_check(_machine())
+        assert http.gets[0].headers["Authorization"] == "Bearer t0k"
+
+
+class TestRefreshAll:
+    async def test_returns_same_number_of_machines(self) -> None:
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http)
+        machines = (
+            _machine("a", host="ha"),
+            _machine("b", host="hb"),
+            _machine("c", host="hc"),
+        )
+        result = await client.refresh_all(machines)
+        assert len(result) == 3
+
+    async def test_updates_healthy_flag(self) -> None:
+        http = FakeHTTPClient(
+            get_responses={
+                "http://ha:50051/api/v1/health": FakeResponse(status_code=200),
+                "http://hb:50051/api/v1/health": FakeResponse(status_code=500),
+            }
+        )
+        client = RemoteDaemonClient(http_client=http)
+        machines = (_machine("a", host="ha"), _machine("b", host="hb"))
+        result = await client.refresh_all(machines)
+        by_name = {m.name: m for m in result}
+        assert by_name["a"].healthy is True
+        assert by_name["b"].healthy is False
+
+    async def test_preserves_other_fields(self) -> None:
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http)
+        original = MachineState(
+            name="a",
+            host="ha",
+            port=9000,
+            capacity=5,
+            tags=("gpu", "linux"),
+            active_tasks=3,
+            healthy=False,
+        )
+        result = await client.refresh_all((original,))
+        updated = result[0]
+        assert updated.name == "a"
+        assert updated.host == "ha"
+        assert updated.port == 9000
+        assert updated.capacity == 5
+        assert updated.tags == ("gpu", "linux")
+        assert updated.active_tasks == 3
+
+    async def test_one_failing_machine_does_not_affect_others(self) -> None:
+        http = FakeHTTPClient(
+            get_responses={
+                "http://ha:50051/api/v1/health": FakeResponse(status_code=200),
+                "http://hc:50051/api/v1/health": FakeResponse(status_code=200),
+            },
+            get_exceptions={
+                "http://hb:50051/api/v1/health": ConnectionRefusedError("nope"),
+            },
+        )
+        client = RemoteDaemonClient(http_client=http)
+        machines = (
+            _machine("a", host="ha"),
+            _machine("b", host="hb"),
+            _machine("c", host="hc"),
+        )
+        result = await client.refresh_all(machines)
+        by_name = {m.name: m.healthy for m in result}
+        assert by_name == {"a": True, "b": False, "c": True}
+
+    async def test_probes_run_in_parallel(self) -> None:
+        """Parallel probes: if we measure concurrency, N probes with delay D
+        should complete in roughly D, not N*D."""
+
+        class SlowHTTP:
+            def __init__(self) -> None:
+                self.active = 0
+                self.max_active = 0
+
+            async def post(
+                self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+            ) -> FakeResponse:
+                raise AssertionError("post not used in refresh_all")
+
+            async def get(self, url: str, *, headers: dict[str, str]) -> FakeResponse:
+                self.active += 1
+                self.max_active = max(self.max_active, self.active)
+                try:
+                    await asyncio.sleep(0.05)
+                    return FakeResponse(status_code=200)
+                finally:
+                    self.active -= 1
+
+        http = SlowHTTP()
+        client = RemoteDaemonClient(http_client=http)
+        machines = tuple(_machine(f"m{i}", host=f"h{i}") for i in range(5))
+        await client.refresh_all(machines)
+        assert http.max_active >= 2, "probes should run concurrently"
+
+    async def test_empty_input_returns_empty(self) -> None:
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http)
+        assert await client.refresh_all(()) == ()
+
+
+class TestRemoteTaskResultFrozen:
+    async def test_remote_task_result_frozen(self) -> None:
+        import dataclasses as dc
+
+        r = RemoteTaskResult(task_id="t1", machine_name="m1", status="submitted")
+        with pytest.raises(dc.FrozenInstanceError):
+            r.status = "error"  # type: ignore[misc]


### PR DESCRIPTION
Pure routing policy + async HTTP client for remote daemons. Two self-contained modules; no changes to the existing FastAPI app or Daemon class — those integrate via follow-ups using this PR's surface.

### `fleet/dispatcher.py` (171 LOC)
Frozen `MachineState`, `TaskRequirement`, `Assignment`, `DispatchPlan`. `score_machine` returns `None` (cannot run) or `int` (higher = better; `slots * 10 + #preferred_tags_matched`). `FleetDispatcher.plan` is greedy highest-score-first with capacity re-scored after each placement (natural load spreading). Deterministic tie-break: lower task_id, then lower machine_name.

### `fleet/client.py` (217 LOC)
`HTTPClientProtocol` + `HTTPResponseProtocol` typed contracts. `RemoteDaemonClient.submit_task(machine, payload)` → POST /api/v1/tasks with Bearer auth. `health_check` → GET /api/v1/health → bool. `refresh_all` probes every machine in parallel via `asyncio.gather`; one broken machine doesn't strand the rest.

**59 new tests.** `ruff` + `mypy --strict` clean. Zero real sockets — every HTTP call goes through an injected protocol.

**Follow-ups** (noted in issue body): wire POST /api/v1/tasks onto the existing FastAPI app; plug `FleetDispatcher` + `RemoteDaemonClient` into `Daemon.submit_issue` for fleet-aware routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)