### PR TITLE
feat(director): Vision-to-tasks decomposition + diff + issue materialisation (#103)

### DIFF
--- a/maxwell_daemon/director/__init__.py
+++ b/maxwell_daemon/director/__init__.py
@@ -1,0 +1,27 @@
+"""Vision-to-tasks Director.
+
+A Director takes a one-paragraph *vision* and produces a validated Epic →
+Story → Task plan, which can then be materialised as GitHub issues or diffed
+against a previous plan for reconciliation.
+
+The LLM call is pluggable: the Director only knows about a ``DecomposerFn``
+coroutine, so the same orchestration works with any backend.
+"""
+
+from maxwell_daemon.director.decomposer import DecomposerFn, Director
+from maxwell_daemon.director.issue_adapter import CreateIssueFn, materialise_plan
+from maxwell_daemon.director.reconciler import PlanDiff, diff_plans
+from maxwell_daemon.director.types import Decomposition, Epic, Story, Task
+
+__all__ = [
+    "CreateIssueFn",
+    "DecomposerFn",
+    "Decomposition",
+    "Director",
+    "Epic",
+    "PlanDiff",
+    "Story",
+    "Task",
+    "diff_plans",
+    "materialise_plan",
+]

--- a/maxwell_daemon/director/decomposer.py
+++ b/maxwell_daemon/director/decomposer.py
@@ -1,0 +1,39 @@
+"""Director — run a vision through an injected decomposer and validate the plan.
+
+The actual LLM call lives inside the caller-supplied ``DecomposerFn`` coroutine
+so this module stays provider-agnostic and trivially testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from maxwell_daemon.contracts import require
+from maxwell_daemon.director.types import Decomposition
+
+__all__ = ["DecomposerFn", "Director"]
+
+
+DecomposerFn = Callable[[str], Awaitable[Decomposition]]
+
+
+class Director:
+    """Orchestrates a single vision → plan run."""
+
+    __slots__ = ("_decomposer",)
+
+    def __init__(self, *, decomposer: DecomposerFn) -> None:
+        self._decomposer = decomposer
+
+    async def plan(self, vision: str) -> Decomposition:
+        """Run the decomposer, validate the result, and return it.
+
+        :param vision: Non-empty free-text goal. Whitespace-only strings are
+            rejected as a precondition.
+        :raises PreconditionError: If the vision is empty/whitespace, or if the
+            returned :class:`Decomposition` fails structural validation.
+        """
+        require(bool(vision and vision.strip()), "vision must be non-empty")
+        result = await self._decomposer(vision)
+        result.validate()
+        return result

--- a/maxwell_daemon/director/issue_adapter.py
+++ b/maxwell_daemon/director/issue_adapter.py
@@ -1,0 +1,155 @@
+"""Materialise a Decomposition as GitHub issues.
+
+The adapter is deliberately decoupled from :class:`GitHubClient`: callers pass
+in a ``create_issue`` coroutine that matches :class:`GitHubClient.create_issue`'s
+kwargs. That keeps the module unit-testable with no subprocess or network.
+
+Issues are created in topological order:
+
+* Every Epic (so stories can reference parent issue numbers).
+* Every Story (so tasks can reference their parent).
+* Every Task in a dependency-respecting order (so ``Depends on #N`` refers to
+  issues that already exist).
+
+Bodies include the entity's own description plus cross-references to related
+issue numbers (``Part of #N``, ``Depends on #M, #O``) so GitHub renders back-
+links automatically.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from maxwell_daemon.director.types import Decomposition, Epic, Story, Task
+
+__all__ = ["CreateIssueFn", "materialise_plan"]
+
+
+#: Signature compatible with :meth:`GitHubClient.create_issue` but returning
+#: the issue number directly. The adapter only needs the number for building
+#: cross-references; callers can wrap ``GitHubClient`` trivially.
+CreateIssueFn = Callable[..., Awaitable[int]]
+
+
+async def materialise_plan(
+    decomposition: Decomposition,
+    *,
+    repo: str,
+    create_issue: CreateIssueFn,
+    label_prefix: str = "director",
+) -> dict[str, int]:
+    """Create one GitHub issue per Epic, Story, and Task in ``decomposition``.
+
+    :returns: Mapping from each entity's slug id to its created issue number.
+    """
+    mapping: dict[str, int] = {}
+
+    for epic in decomposition.epics:
+        mapping[epic.id] = await _create(
+            create_issue,
+            repo,
+            title=epic.title,
+            body=_epic_body(epic),
+            labels=[f"{label_prefix}:epic"],
+        )
+
+    for story in decomposition.stories:
+        mapping[story.id] = await _create(
+            create_issue,
+            repo,
+            title=story.title,
+            body=_story_body(story, mapping),
+            labels=[f"{label_prefix}:story"],
+        )
+
+    for task in _tasks_in_topo_order(decomposition.tasks):
+        mapping[task.id] = await _create(
+            create_issue,
+            repo,
+            title=task.title,
+            body=_task_body(task, mapping),
+            labels=[f"{label_prefix}:task"],
+        )
+
+    return mapping
+
+
+async def _create(
+    create_issue: CreateIssueFn,
+    repo: str,
+    *,
+    title: str,
+    body: str,
+    labels: list[str],
+) -> int:
+    result: Any = await create_issue(repo, title=title, body=body, labels=labels)
+    return int(result)
+
+
+def _epic_body(epic: Epic) -> str:
+    return epic.description
+
+
+def _story_body(story: Story, mapping: dict[str, int]) -> str:
+    lines = [story.description]
+    if story.acceptance_criteria:
+        lines.append("")
+        lines.append("## Acceptance criteria")
+        lines.extend(f"- {item}" for item in story.acceptance_criteria)
+    epic_number = mapping.get(story.epic_id)
+    if epic_number is not None:
+        lines.append("")
+        lines.append(f"Part of #{epic_number}")
+    return "\n".join(lines)
+
+
+def _task_body(task: Task, mapping: dict[str, int]) -> str:
+    lines = [task.description]
+    story_number = mapping.get(task.story_id)
+    if story_number is not None:
+        lines.append("")
+        lines.append(f"Part of #{story_number}")
+    if task.depends_on:
+        dep_numbers = [mapping[dep] for dep in task.depends_on if dep in mapping]
+        if dep_numbers:
+            rendered = ", ".join(f"#{n}" for n in dep_numbers)
+            lines.append(f"Depends on {rendered}")
+    return "\n".join(lines)
+
+
+def _tasks_in_topo_order(tasks: tuple[Task, ...]) -> list[Task]:
+    """Return tasks ordered so every task appears after its dependencies.
+
+    Uses Kahn's algorithm (iterative BFS over in-degrees) for stability and
+    because validation already guarantees no cycles by the time this runs.
+    Tasks without declared dependencies keep their original relative order,
+    which matches how a decomposer usually emits them.
+    """
+    by_id: dict[str, Task] = {t.id: t for t in tasks}
+    in_degree: dict[str, int] = {t.id: 0 for t in tasks}
+    dependents: dict[str, list[str]] = {t.id: [] for t in tasks}
+    for t in tasks:
+        for dep in t.depends_on:
+            if dep in by_id:
+                in_degree[t.id] += 1
+                dependents[dep].append(t.id)
+
+    # Preserve input order among ready tasks.
+    ready: list[str] = [t.id for t in tasks if in_degree[t.id] == 0]
+    ordered: list[Task] = []
+    while ready:
+        tid = ready.pop(0)
+        ordered.append(by_id[tid])
+        for child in dependents[tid]:
+            in_degree[child] -= 1
+            if in_degree[child] == 0:
+                ready.append(child)
+
+    # If a cycle sneaks through (shouldn't, because validate() ran), fall
+    # back to appending unvisited tasks in input order so we never silently
+    # drop work.
+    if len(ordered) != len(tasks):
+        seen = {t.id for t in ordered}
+        ordered.extend(t for t in tasks if t.id not in seen)
+    return ordered

--- a/maxwell_daemon/director/reconciler.py
+++ b/maxwell_daemon/director/reconciler.py
@@ -1,0 +1,58 @@
+"""Reconcile a new Decomposition against an existing one.
+
+Pure set-diff by entity id per level. Edits to an entity's title or description
+(same id, different fields) intentionally don't show up in the diff — keeping
+"updated" separate is left for a future PR.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from maxwell_daemon.director.types import Decomposition, Epic, Story, Task
+
+__all__ = ["PlanDiff", "diff_plans"]
+
+
+@dataclass(slots=True, frozen=True)
+class PlanDiff:
+    """Structured diff between two plans, split by entity level."""
+
+    added_epics: tuple[Epic, ...]
+    removed_epics: tuple[str, ...]
+    added_stories: tuple[Story, ...]
+    removed_stories: tuple[str, ...]
+    added_tasks: tuple[Task, ...]
+    removed_tasks: tuple[str, ...]
+
+
+def diff_plans(old: Decomposition, new: Decomposition) -> PlanDiff:
+    """Return the per-level set-diff between ``old`` and ``new``.
+
+    An entity is "added" if its id exists in ``new`` but not in ``old``, and
+    "removed" if its id exists in ``old`` but not in ``new``. Shared ids with
+    mutated fields are treated as "unchanged" here and are not reported.
+    """
+    old_epic_ids = {e.id for e in old.epics}
+    new_epic_ids = {e.id for e in new.epics}
+    added_epics = tuple(e for e in new.epics if e.id not in old_epic_ids)
+    removed_epics = tuple(e.id for e in old.epics if e.id not in new_epic_ids)
+
+    old_story_ids = {s.id for s in old.stories}
+    new_story_ids = {s.id for s in new.stories}
+    added_stories = tuple(s for s in new.stories if s.id not in old_story_ids)
+    removed_stories = tuple(s.id for s in old.stories if s.id not in new_story_ids)
+
+    old_task_ids = {t.id for t in old.tasks}
+    new_task_ids = {t.id for t in new.tasks}
+    added_tasks = tuple(t for t in new.tasks if t.id not in old_task_ids)
+    removed_tasks = tuple(t.id for t in old.tasks if t.id not in new_task_ids)
+
+    return PlanDiff(
+        added_epics=added_epics,
+        removed_epics=removed_epics,
+        added_stories=added_stories,
+        removed_stories=removed_stories,
+        added_tasks=added_tasks,
+        removed_tasks=removed_tasks,
+    )

--- a/maxwell_daemon/director/types.py
+++ b/maxwell_daemon/director/types.py
@@ -1,0 +1,160 @@
+"""Director data types — Epic, Story, Task, and the Decomposition that binds them.
+
+Every type is a frozen dataclass so a plan produced by the Director can be
+safely shared between the reconciler, the issue adapter, and any downstream
+cache without defensive copying. ``Decomposition.validate()`` enforces the
+structural invariants that the rest of the pipeline assumes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from maxwell_daemon.contracts import require
+
+__all__ = ["Decomposition", "Epic", "Story", "Task"]
+
+
+@dataclass(slots=True, frozen=True)
+class Epic:
+    """A top-level objective. Multiple stories serve an epic."""
+
+    id: str
+    title: str
+    description: str
+
+
+@dataclass(slots=True, frozen=True)
+class Story:
+    """A user-visible outcome that lives under an Epic."""
+
+    id: str
+    epic_id: str
+    title: str
+    description: str
+    acceptance_criteria: tuple[str, ...]
+
+
+@dataclass(slots=True, frozen=True)
+class Task:
+    """A concrete unit of implementation work under a Story."""
+
+    id: str
+    story_id: str
+    title: str
+    description: str
+    depends_on: tuple[str, ...] = field(default=())
+
+
+@dataclass(slots=True, frozen=True)
+class Decomposition:
+    """The output of a single Director run."""
+
+    vision: str
+    epics: tuple[Epic, ...]
+    stories: tuple[Story, ...]
+    tasks: tuple[Task, ...]
+
+    def stories_for_epic(self, epic_id: str) -> tuple[Story, ...]:
+        """Return every story whose ``epic_id`` matches, preserving order."""
+        return tuple(s for s in self.stories if s.epic_id == epic_id)
+
+    def tasks_for_story(self, story_id: str) -> tuple[Task, ...]:
+        """Return every task whose ``story_id`` matches, preserving order."""
+        return tuple(t for t in self.tasks if t.story_id == story_id)
+
+    def validate(self) -> None:
+        """Verify structural invariants; raise :class:`PreconditionError` on failure.
+
+        Checks, in order:
+
+        1. Unique ids within each level (Epic, Story, Task).
+        2. Every story's ``epic_id`` refers to a known epic.
+        3. Every task's ``story_id`` refers to a known story.
+        4. Every task ``depends_on`` entry references a known task.
+        5. The task dependency graph is acyclic (iterative DFS with a
+           three-colour marking, so we detect self-loops and longer cycles
+           without recursion limits).
+        """
+        _check_unique_ids("epic", tuple(e.id for e in self.epics))
+        _check_unique_ids("story", tuple(s.id for s in self.stories))
+        _check_unique_ids("task", tuple(t.id for t in self.tasks))
+
+        epic_ids = {e.id for e in self.epics}
+        for s in self.stories:
+            require(
+                s.epic_id in epic_ids,
+                f"orphan story {s.id!r}: unknown epic_id {s.epic_id!r}",
+            )
+
+        story_ids = {s.id for s in self.stories}
+        for t in self.tasks:
+            require(
+                t.story_id in story_ids,
+                f"orphan task {t.id!r}: unknown story_id {t.story_id!r}",
+            )
+
+        task_ids = {t.id for t in self.tasks}
+        for t in self.tasks:
+            for dep in t.depends_on:
+                require(
+                    dep in task_ids,
+                    f"task {t.id!r} depends on unknown task id {dep!r}",
+                )
+
+        _check_no_cycles(self.tasks)
+
+
+def _check_unique_ids(level: str, ids: tuple[str, ...]) -> None:
+    seen: set[str] = set()
+    for id_ in ids:
+        require(id_ not in seen, f"duplicate {level} id {id_!r}")
+        seen.add(id_)
+
+
+# Colouring constants for iterative DFS cycle detection.
+_WHITE = 0  # unvisited
+_GREY = 1  # on the current DFS stack
+_BLACK = 2  # fully explored
+
+
+def _check_no_cycles(tasks: tuple[Task, ...]) -> None:
+    """Detect cycles in the task ``depends_on`` graph via iterative DFS.
+
+    Standard three-colour algorithm:
+
+    * ``WHITE`` — not yet visited.
+    * ``GREY`` — in the current traversal stack; encountering a grey node
+      means we've found a back-edge → cycle.
+    * ``BLACK`` — fully explored, safe to skip.
+
+    Iterative rather than recursive so pathological plans can't blow the
+    Python stack. A self-loop (task depending on itself) is caught on the
+    first edge visit because the node is already ``GREY``.
+    """
+    graph: dict[str, tuple[str, ...]] = {t.id: t.depends_on for t in tasks}
+    colour: dict[str, int] = dict.fromkeys(graph, _WHITE)
+
+    for start in graph:
+        if colour[start] != _WHITE:
+            continue
+        # Each frame: (node, iterator over its outgoing edges).
+        stack: list[tuple[str, list[str]]] = [(start, list(graph[start]))]
+        colour[start] = _GREY
+        while stack:
+            node, pending = stack[-1]
+            if not pending:
+                colour[node] = _BLACK
+                stack.pop()
+                continue
+            nxt = pending.pop()
+            # Missing-target edges are caught earlier in validate(); treat
+            # a miss here defensively as "no cycle through unknown node".
+            if nxt not in colour:
+                continue
+            state = colour[nxt]
+            if state == _GREY:
+                require(False, f"task dependency cycle detected at {nxt!r}")
+            if state == _WHITE:
+                colour[nxt] = _GREY
+                stack.append((nxt, list(graph[nxt])))

--- a/tests/unit/test_director_issue_adapter.py
+++ b/tests/unit/test_director_issue_adapter.py
@@ -1,0 +1,175 @@
+"""issue_adapter — materialise a Decomposition as GitHub issues.
+
+The adapter delegates creation to an injected ``create_issue`` coroutine so
+these tests never touch the network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from maxwell_daemon.director.issue_adapter import materialise_plan
+from maxwell_daemon.director.types import Decomposition, Epic, Story, Task
+
+
+class _FakeGh:
+    """Records every create_issue call in order and hands out issue numbers."""
+
+    def __init__(self, start: int = 100) -> None:
+        self._next = start
+        self.calls: list[dict[str, object]] = []
+
+    async def create(
+        self,
+        repo: str,
+        *,
+        title: str,
+        body: str,
+        labels: Sequence[str],
+    ) -> int:
+        number = self._next
+        self._next += 1
+        self.calls.append(
+            {
+                "repo": repo,
+                "title": title,
+                "body": body,
+                "labels": list(labels),
+                "number": number,
+            },
+        )
+        return number
+
+
+def _simple_plan() -> Decomposition:
+    e = Epic(id="e1", title="Epic 1", description="epic desc")
+    s = Story(
+        id="s1",
+        epic_id="e1",
+        title="Story 1",
+        description="story desc",
+        acceptance_criteria=("does X", "does Y"),
+    )
+    t1 = Task(id="t1", story_id="s1", title="Task 1", description="t1 desc")
+    t2 = Task(
+        id="t2",
+        story_id="s1",
+        title="Task 2",
+        description="t2 desc",
+        depends_on=("t1",),
+    )
+    return Decomposition(vision="v", epics=(e,), stories=(s,), tasks=(t1, t2))
+
+
+class TestMaterialisePlan:
+    async def test_creates_one_issue_per_entity(self) -> None:
+        gh = _FakeGh()
+        plan = _simple_plan()
+        mapping = await materialise_plan(plan, repo="o/r", create_issue=gh.create)
+        # 1 epic + 1 story + 2 tasks = 4
+        assert len(gh.calls) == 4
+        assert set(mapping) == {"e1", "s1", "t1", "t2"}
+
+    async def test_labels_include_director_level_tag(self) -> None:
+        gh = _FakeGh()
+        plan = _simple_plan()
+        await materialise_plan(plan, repo="o/r", create_issue=gh.create)
+        # order: epic, story, tasks (topologically)
+        labels_by_index = [call["labels"] for call in gh.calls]
+        assert "director:epic" in labels_by_index[0]  # type: ignore[operator]
+        assert "director:story" in labels_by_index[1]  # type: ignore[operator]
+        assert "director:task" in labels_by_index[2]  # type: ignore[operator]
+        assert "director:task" in labels_by_index[3]  # type: ignore[operator]
+
+    async def test_custom_label_prefix(self) -> None:
+        gh = _FakeGh()
+        plan = _simple_plan()
+        await materialise_plan(
+            plan,
+            repo="o/r",
+            create_issue=gh.create,
+            label_prefix="plan",
+        )
+        assert "plan:epic" in gh.calls[0]["labels"]  # type: ignore[operator]
+        assert "plan:story" in gh.calls[1]["labels"]  # type: ignore[operator]
+        assert "plan:task" in gh.calls[2]["labels"]  # type: ignore[operator]
+
+    async def test_story_body_contains_part_of_epic_reference(self) -> None:
+        gh = _FakeGh(start=200)
+        plan = _simple_plan()
+        mapping = await materialise_plan(plan, repo="o/r", create_issue=gh.create)
+        epic_number = mapping["e1"]
+        story_body = gh.calls[1]["body"]
+        assert isinstance(story_body, str)
+        assert f"Part of #{epic_number}" in story_body
+
+    async def test_task_body_contains_part_of_story_and_depends_on(self) -> None:
+        gh = _FakeGh(start=500)
+        plan = _simple_plan()
+        mapping = await materialise_plan(plan, repo="o/r", create_issue=gh.create)
+        story_number = mapping["s1"]
+        t1_number = mapping["t1"]
+        # Task 2 depends on Task 1.
+        t2_body = gh.calls[3]["body"]
+        assert isinstance(t2_body, str)
+        assert f"Part of #{story_number}" in t2_body
+        assert f"Depends on #{t1_number}" in t2_body
+
+    async def test_task_with_multiple_deps_renders_comma_list(self) -> None:
+        e = Epic(id="e1", title="E", description="d")
+        s = Story(
+            id="s1",
+            epic_id="e1",
+            title="S",
+            description="d",
+            acceptance_criteria=("ok",),
+        )
+        t1 = Task(id="t1", story_id="s1", title="T1", description="d")
+        t2 = Task(id="t2", story_id="s1", title="T2", description="d")
+        t3 = Task(
+            id="t3",
+            story_id="s1",
+            title="T3",
+            description="d",
+            depends_on=("t1", "t2"),
+        )
+        plan = Decomposition(vision="v", epics=(e,), stories=(s,), tasks=(t1, t2, t3))
+        gh = _FakeGh(start=10)
+        mapping = await materialise_plan(plan, repo="o/r", create_issue=gh.create)
+        # Last call is t3.
+        t3_body = gh.calls[-1]["body"]
+        assert isinstance(t3_body, str)
+        n1, n2 = mapping["t1"], mapping["t2"]
+        assert f"Depends on #{n1}, #{n2}" in t3_body
+
+    async def test_returns_slug_to_number_map(self) -> None:
+        gh = _FakeGh(start=42)
+        plan = _simple_plan()
+        mapping = await materialise_plan(plan, repo="o/r", create_issue=gh.create)
+        assert mapping["e1"] == 42
+        assert mapping["s1"] == 43
+        assert mapping["t1"] == 44
+        assert mapping["t2"] == 45
+
+    async def test_empty_decomposition_creates_zero_issues(self) -> None:
+        gh = _FakeGh()
+        plan = Decomposition(vision="v", epics=(), stories=(), tasks=())
+        mapping = await materialise_plan(plan, repo="o/r", create_issue=gh.create)
+        assert mapping == {}
+        assert gh.calls == []
+
+    async def test_create_issue_errors_propagate(self) -> None:
+        async def broken(
+            repo: str,
+            *,
+            title: str,
+            body: str,
+            labels: Sequence[str],
+        ) -> int:
+            raise RuntimeError("gh exploded")
+
+        plan = _simple_plan()
+        with pytest.raises(RuntimeError, match="gh exploded"):
+            await materialise_plan(plan, repo="o/r", create_issue=broken)

--- a/tests/unit/test_director_plan.py
+++ b/tests/unit/test_director_plan.py
@@ -1,0 +1,99 @@
+"""Director — orchestrates an injected decomposer and validates its output."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from maxwell_daemon.contracts import PreconditionError
+from maxwell_daemon.director.decomposer import Director
+from maxwell_daemon.director.types import Decomposition, Epic, Story, Task
+
+
+def _valid_plan(vision: str = "ship auth") -> Decomposition:
+    return Decomposition(
+        vision=vision,
+        epics=(Epic(id="e1", title="E", description="d"),),
+        stories=(
+            Story(
+                id="s1",
+                epic_id="e1",
+                title="S",
+                description="d",
+                acceptance_criteria=("ok",),
+            ),
+        ),
+        tasks=(Task(id="t1", story_id="s1", title="T", description="d"),),
+    )
+
+
+class TestDirectorPlan:
+    async def test_empty_vision_raises_precondition(self) -> None:
+        async def fake(vision: str) -> Decomposition:
+            return _valid_plan()
+
+        d = Director(decomposer=fake)
+        with pytest.raises(PreconditionError):
+            await d.plan("")
+
+    async def test_whitespace_only_vision_raises(self) -> None:
+        async def fake(vision: str) -> Decomposition:
+            return _valid_plan()
+
+        d = Director(decomposer=fake)
+        with pytest.raises(PreconditionError):
+            await d.plan("   \n\t  ")
+
+    async def test_forwards_vision_to_decomposer(self) -> None:
+        seen: list[str] = []
+
+        async def fake(vision: str) -> Decomposition:
+            seen.append(vision)
+            return _valid_plan(vision=vision)
+
+        d = Director(decomposer=fake)
+        await d.plan("harden CI")
+        assert seen == ["harden CI"]
+
+    async def test_returns_decomposer_result(self) -> None:
+        plan = _valid_plan()
+
+        async def fake(vision: str) -> Decomposition:
+            return plan
+
+        d = Director(decomposer=fake)
+        got = await d.plan("a vision")
+        assert got is plan
+
+    async def test_propagates_validation_errors(self) -> None:
+        bad = Decomposition(
+            vision="v",
+            epics=(Epic(id="e1", title="", description=""),),
+            stories=(
+                Story(
+                    id="s1",
+                    epic_id="ghost",  # orphan: no such epic
+                    title="",
+                    description="",
+                    acceptance_criteria=(),
+                ),
+            ),
+            tasks=(),
+        )
+
+        async def fake(vision: str) -> Decomposition:
+            return bad
+
+        d = Director(decomposer=fake)
+        with pytest.raises(PreconditionError):
+            await d.plan("anything")
+
+    async def test_result_is_frozen(self) -> None:
+        async def fake(vision: str) -> Decomposition:
+            return _valid_plan()
+
+        d = Director(decomposer=fake)
+        result = await d.plan("v")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            result.vision = "changed"  # type: ignore[misc]

--- a/tests/unit/test_director_reconciler.py
+++ b/tests/unit/test_director_reconciler.py
@@ -1,0 +1,128 @@
+"""Reconciler — set-diff between two Decompositions by entity id."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from maxwell_daemon.director.reconciler import PlanDiff, diff_plans
+from maxwell_daemon.director.types import Decomposition, Epic, Story, Task
+
+
+def _epic(eid: str, title: str = "E") -> Epic:
+    return Epic(id=eid, title=title, description="d")
+
+
+def _story(sid: str, epic_id: str = "e1", title: str = "S") -> Story:
+    return Story(
+        id=sid,
+        epic_id=epic_id,
+        title=title,
+        description="d",
+        acceptance_criteria=("ok",),
+    )
+
+
+def _task(tid: str, story_id: str = "s1", title: str = "T") -> Task:
+    return Task(id=tid, story_id=story_id, title=title, description="d")
+
+
+def _plan(
+    epics: tuple[Epic, ...] = (),
+    stories: tuple[Story, ...] = (),
+    tasks: tuple[Task, ...] = (),
+) -> Decomposition:
+    return Decomposition(vision="v", epics=epics, stories=stories, tasks=tasks)
+
+
+class TestDiffPlans:
+    def test_empty_vs_empty_is_empty_diff(self) -> None:
+        d = diff_plans(_plan(), _plan())
+        assert d == PlanDiff(
+            added_epics=(),
+            removed_epics=(),
+            added_stories=(),
+            removed_stories=(),
+            added_tasks=(),
+            removed_tasks=(),
+        )
+
+    def test_adds_new_epics(self) -> None:
+        old = _plan()
+        new = _plan(epics=(_epic("e1"), _epic("e2")))
+        d = diff_plans(old, new)
+        assert {e.id for e in d.added_epics} == {"e1", "e2"}
+        assert d.removed_epics == ()
+
+    def test_removes_deleted_epics(self) -> None:
+        old = _plan(epics=(_epic("e1"), _epic("e2")))
+        new = _plan(epics=(_epic("e1"),))
+        d = diff_plans(old, new)
+        assert d.added_epics == ()
+        assert d.removed_epics == ("e2",)
+
+    def test_story_level_diff(self) -> None:
+        old = _plan(
+            epics=(_epic("e1"),),
+            stories=(_story("s1"), _story("s2")),
+        )
+        new = _plan(
+            epics=(_epic("e1"),),
+            stories=(_story("s2"), _story("s3")),
+        )
+        d = diff_plans(old, new)
+        assert {s.id for s in d.added_stories} == {"s3"}
+        assert d.removed_stories == ("s1",)
+
+    def test_task_level_diff(self) -> None:
+        old = _plan(
+            epics=(_epic("e1"),),
+            stories=(_story("s1"),),
+            tasks=(_task("t1"), _task("t2")),
+        )
+        new = _plan(
+            epics=(_epic("e1"),),
+            stories=(_story("s1"),),
+            tasks=(_task("t2"), _task("t3")),
+        )
+        d = diff_plans(old, new)
+        assert {t.id for t in d.added_tasks} == {"t3"}
+        assert d.removed_tasks == ("t1",)
+
+    def test_same_id_different_title_is_not_in_diff(self) -> None:
+        """Changed titles are intentionally out-of-scope for now.
+
+        The same id in both plans must NOT appear as added+removed.
+        """
+        old = _plan(epics=(_epic("e1", title="Old"),))
+        new = _plan(epics=(_epic("e1", title="New"),))
+        d = diff_plans(old, new)
+        assert d.added_epics == ()
+        assert d.removed_epics == ()
+
+    def test_same_id_different_title_at_all_levels(self) -> None:
+        old = _plan(
+            epics=(_epic("e1", title="OldE"),),
+            stories=(_story("s1", title="OldS"),),
+            tasks=(_task("t1", title="OldT"),),
+        )
+        new = _plan(
+            epics=(_epic("e1", title="NewE"),),
+            stories=(_story("s1", title="NewS"),),
+            tasks=(_task("t1", title="NewT"),),
+        )
+        d = diff_plans(old, new)
+        assert d == PlanDiff(
+            added_epics=(),
+            removed_epics=(),
+            added_stories=(),
+            removed_stories=(),
+            added_tasks=(),
+            removed_tasks=(),
+        )
+
+    def test_plan_diff_is_frozen(self) -> None:
+        d = diff_plans(_plan(), _plan())
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            d.added_epics = (_epic("x"),)  # type: ignore[misc]

--- a/tests/unit/test_director_types.py
+++ b/tests/unit/test_director_types.py
@@ -1,0 +1,183 @@
+"""Director data types — Epic / Story / Task / Decomposition invariants.
+
+Validates:
+* Dataclasses are frozen (immutable) so a plan can be safely shared.
+* Derived accessors filter correctly by parent id.
+* ``Decomposition.validate()`` enforces structural consistency: unique ids per
+  level, no orphan stories/tasks, task dependencies reference real tasks, and
+  the task dependency graph is acyclic.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from maxwell_daemon.contracts import PreconditionError
+from maxwell_daemon.director.types import Decomposition, Epic, Story, Task
+
+
+def _epic(eid: str = "e1", title: str = "E1") -> Epic:
+    return Epic(id=eid, title=title, description="desc")
+
+
+def _story(sid: str = "s1", epic_id: str = "e1") -> Story:
+    return Story(
+        id=sid,
+        epic_id=epic_id,
+        title=f"Story {sid}",
+        description="desc",
+        acceptance_criteria=("done",),
+    )
+
+
+def _task(
+    tid: str = "t1",
+    story_id: str = "s1",
+    depends_on: tuple[str, ...] = (),
+) -> Task:
+    return Task(
+        id=tid,
+        story_id=story_id,
+        title=f"Task {tid}",
+        description="desc",
+        depends_on=depends_on,
+    )
+
+
+class TestFrozen:
+    def test_epic_is_frozen(self) -> None:
+        e = _epic()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            e.title = "changed"  # type: ignore[misc]
+
+    def test_story_is_frozen(self) -> None:
+        s = _story()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            s.title = "changed"  # type: ignore[misc]
+
+    def test_task_is_frozen(self) -> None:
+        t = _task()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            t.title = "changed"  # type: ignore[misc]
+
+    def test_decomposition_is_frozen(self) -> None:
+        d = Decomposition(vision="v", epics=(), stories=(), tasks=())
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            d.vision = "changed"  # type: ignore[misc]
+
+
+class TestDerivedAccessors:
+    def test_stories_for_epic_filters_by_epic_id(self) -> None:
+        e1, e2 = _epic("e1"), _epic("e2")
+        s1 = _story("s1", "e1")
+        s2 = _story("s2", "e2")
+        s3 = _story("s3", "e1")
+        d = Decomposition(vision="v", epics=(e1, e2), stories=(s1, s2, s3), tasks=())
+        assert d.stories_for_epic("e1") == (s1, s3)
+        assert d.stories_for_epic("e2") == (s2,)
+        assert d.stories_for_epic("missing") == ()
+
+    def test_tasks_for_story_filters_by_story_id(self) -> None:
+        e = _epic()
+        s1, s2 = _story("s1"), _story("s2")
+        t1 = _task("t1", "s1")
+        t2 = _task("t2", "s2")
+        t3 = _task("t3", "s1")
+        d = Decomposition(vision="v", epics=(e,), stories=(s1, s2), tasks=(t1, t2, t3))
+        assert d.tasks_for_story("s1") == (t1, t3)
+        assert d.tasks_for_story("s2") == (t2,)
+        assert d.tasks_for_story("missing") == ()
+
+
+class TestValidate:
+    def test_happy_path_no_errors(self) -> None:
+        e = _epic()
+        s = _story()
+        t1 = _task("t1", "s1")
+        t2 = _task("t2", "s1", depends_on=("t1",))
+        d = Decomposition(vision="v", epics=(e,), stories=(s,), tasks=(t1, t2))
+        d.validate()  # no raise
+
+    def test_duplicate_epic_id_raises(self) -> None:
+        d = Decomposition(
+            vision="v",
+            epics=(_epic("e1"), _epic("e1")),
+            stories=(),
+            tasks=(),
+        )
+        with pytest.raises(PreconditionError, match="duplicate"):
+            d.validate()
+
+    def test_duplicate_story_id_raises(self) -> None:
+        e = _epic()
+        d = Decomposition(
+            vision="v",
+            epics=(e,),
+            stories=(_story("s1"), _story("s1")),
+            tasks=(),
+        )
+        with pytest.raises(PreconditionError, match="duplicate"):
+            d.validate()
+
+    def test_duplicate_task_id_raises(self) -> None:
+        e = _epic()
+        s = _story()
+        d = Decomposition(
+            vision="v",
+            epics=(e,),
+            stories=(s,),
+            tasks=(_task("t1"), _task("t1")),
+        )
+        with pytest.raises(PreconditionError, match="duplicate"):
+            d.validate()
+
+    def test_orphan_story_raises(self) -> None:
+        d = Decomposition(
+            vision="v",
+            epics=(_epic("e1"),),
+            stories=(_story("s1", epic_id="nope"),),
+            tasks=(),
+        )
+        with pytest.raises(PreconditionError, match="orphan"):
+            d.validate()
+
+    def test_orphan_task_raises(self) -> None:
+        d = Decomposition(
+            vision="v",
+            epics=(_epic(),),
+            stories=(_story(),),
+            tasks=(_task("t1", story_id="nope"),),
+        )
+        with pytest.raises(PreconditionError, match="orphan"):
+            d.validate()
+
+    def test_task_depends_on_unknown_id_raises(self) -> None:
+        e = _epic()
+        s = _story()
+        d = Decomposition(
+            vision="v",
+            epics=(e,),
+            stories=(s,),
+            tasks=(_task("t1", depends_on=("ghost",)),),
+        )
+        with pytest.raises(PreconditionError, match="unknown"):
+            d.validate()
+
+    def test_task_dependency_cycle_raises(self) -> None:
+        e = _epic()
+        s = _story()
+        t1 = _task("t1", depends_on=("t2",))
+        t2 = _task("t2", depends_on=("t1",))
+        d = Decomposition(vision="v", epics=(e,), stories=(s,), tasks=(t1, t2))
+        with pytest.raises(PreconditionError, match="cycle"):
+            d.validate()
+
+    def test_task_self_cycle_raises(self) -> None:
+        e = _epic()
+        s = _story()
+        t = _task("t1", depends_on=("t1",))
+        d = Decomposition(vision="v", epics=(e,), stories=(s,), tasks=(t,))
+        with pytest.raises(PreconditionError, match="cycle"):
+            d.validate()


### PR DESCRIPTION
User writes a vision paragraph; Director decomposes it into Epic → Story → Task with a dependency graph; issue adapter materialises the plan as GitHub issues. Re-running against an edited vision produces a `PlanDiff` so only new entities get fresh issues.

Five modules (~450 LOC total):
- **types.py** — frozen `Epic` / `Story` / `Task` / `Decomposition` / `validate()` (catches duplicate IDs, orphan children, unknown-dep refs, task cycles via iterative 3-colour DFS — stack-safe for pathological graphs).
- **decomposer.py** — `Director` wraps an injected `DecomposerFn`; the LLM call lives in the callable, not the Director. DbC: empty vision → `PreconditionError`.
- **reconciler.py** — `diff_plans(old, new) -> PlanDiff`. Set-diff by ID; title-change doesn't appear in diff.
- **issue_adapter.py** — `materialise_plan` creates issues in topological order (Kahn's); labels `director:epic|story|task`; body renders `Part of #N` / `Depends on #M, #O`; returns slug → issue_number map.

**38 new tests.** `ruff` + `mypy --strict` clean.

**Follow-up:** `maxwell-daemon vision '<goal>'` CLI + LLM prompt template that produces a valid `Decomposition` JSON — orthogonal to this structural PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)