### PR TITLE
feat: recipes + multi-format diff editing (#98, #101)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,8 @@ jobs:
       - name: Bandit (static analysis)
         run: python -m bandit -r maxwell_daemon -c pyproject.toml
       - name: pip-audit (dependency vulnerabilities)
-        run: python -m pip_audit --desc --strict || true  # report but don't fail until we triage
+        continue-on-error: true  # report but don't fail until we triage
+        run: python -m pip_audit --desc --strict
 
   build:
     name: Build distribution

--- a/maxwell_daemon/editing/__init__.py
+++ b/maxwell_daemon/editing/__init__.py
@@ -1,0 +1,5 @@
+"""File-editing primitives: diff-format parsers and patch application.
+
+Separate from ``tools/`` because these modules are about *interpreting
+model output*, not about exposing a runtime tool to the agent.
+"""

--- a/maxwell_daemon/editing/diff_formats.py
+++ b/maxwell_daemon/editing/diff_formats.py
@@ -1,0 +1,378 @@
+"""Multi-format diff parser for model-produced file edits.
+
+Aider's insight: no single diff format is reliably produced by every
+model. Instead of fighting the model, we let it pick whichever format
+it's best at and parse all of them. :func:`parse_any` tries each format
+in a caller-supplied order; on total failure it surfaces every format's
+rejection reason so the dispatch layer can log *why* none matched.
+
+Three formats are supported:
+
+* ``udiff`` — unified diff (``diff --git`` + ``@@`` hunks).
+* ``search_replace`` — Aider-style ``<<<<<<< SEARCH`` / ``=======`` /
+  ``>>>>>>> REPLACE`` blocks with a ``file: path`` preamble.
+* ``whole_file`` — entire-file blocks between ``--- path ---`` /
+  ``--- end ---`` delimiters; safest for small-file regeneration.
+
+The parsers produce a uniform :class:`FileEdit` value so downstream apply
+logic doesn't care which format the model used.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+__all__ = [
+    "DiffFormat",
+    "DiffParseError",
+    "FileEdit",
+    "parse_any",
+    "parse_search_replace",
+    "parse_udiff",
+    "parse_whole_file",
+]
+
+
+class DiffFormat(str, Enum):
+    """Which diff convention produced a :class:`FileEdit`."""
+
+    UDIFF = "udiff"
+    SEARCH_REPLACE = "search_replace"
+    WHOLE_FILE = "whole_file"
+
+
+class DiffParseError(ValueError):
+    """Raised when text doesn't parse as the requested (or any) diff format."""
+
+
+EditKind = Literal["modify", "create", "delete"]
+
+
+@dataclass(slots=True, frozen=True)
+class FileEdit:
+    """One file change extracted from model output.
+
+    ``content`` meaning depends on ``kind`` and ``format``:
+
+    * ``modify`` + ``UDIFF`` → the hunk text (including ``@@`` headers).
+    * ``modify`` + ``SEARCH_REPLACE`` → the raw SEARCH/REPLACE block.
+    * ``modify`` + ``WHOLE_FILE`` → the full new file contents.
+    * ``create`` → new file contents (for ``WHOLE_FILE``) or hunk (for ``UDIFF``).
+    * ``delete`` → empty string.
+    """
+
+    path: str
+    kind: EditKind
+    content: str
+    format: DiffFormat
+
+
+# ── Unified diff ────────────────────────────────────────────────────────────
+
+_GIT_HEADER_RE = re.compile(r"^diff --git a/(?P<a>\S+) b/(?P<b>\S+)\s*$")
+_MINUS_RE = re.compile(r"^--- (?P<path>.+?)\s*$")
+_PLUS_RE = re.compile(r"^\+\+\+ (?P<path>.+?)\s*$")
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@")
+
+
+def parse_udiff(text: str) -> tuple[FileEdit, ...]:
+    """Parse unified-diff text into :class:`FileEdit` entries (one per file).
+
+    Accepts ``/dev/null`` on either side to signal create/delete. Raises
+    :class:`DiffParseError` for empty input, missing file headers, or any
+    hunk header that doesn't match ``@@ -a,b +c,d @@``.
+    """
+    if not text.strip():
+        raise DiffParseError("udiff: empty input")
+
+    lines = text.splitlines()
+    # Pre-scan: confirm at least one `diff --git` section exists.
+    if not any(_GIT_HEADER_RE.match(line) for line in lines):
+        raise DiffParseError("udiff: no 'diff --git' header found")
+
+    edits: list[FileEdit] = []
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        if not _GIT_HEADER_RE.match(lines[i]):
+            i += 1
+            continue
+
+        # Collect this file's section: from this `diff --git` up to the
+        # next one (or EOF).
+        section_start = i
+        i += 1
+        while i < n and not _GIT_HEADER_RE.match(lines[i]):
+            i += 1
+        section = lines[section_start:i]
+
+        edits.append(_parse_udiff_section(section))
+
+    if not edits:
+        raise DiffParseError("udiff: no valid diff sections parsed")
+    return tuple(edits)
+
+
+def _parse_udiff_section(section: list[str]) -> FileEdit:
+    if not section:
+        raise DiffParseError("udiff: empty section")
+
+    minus_path: str | None = None
+    plus_path: str | None = None
+    hunk_start_idx: int | None = None
+
+    for idx, line in enumerate(section):
+        if (m := _MINUS_RE.match(line)) is not None:
+            minus_path = m.group("path").strip()
+            continue
+        if (m := _PLUS_RE.match(line)) is not None:
+            plus_path = m.group("path").strip()
+            continue
+        if line.startswith("@@"):
+            if not _HUNK_RE.match(line):
+                raise DiffParseError(f"udiff: malformed hunk header {line!r}")
+            hunk_start_idx = idx
+            break
+
+    if minus_path is None or plus_path is None:
+        raise DiffParseError("udiff: missing '---' or '+++' file header")
+    if hunk_start_idx is None:
+        raise DiffParseError("udiff: no hunk found in section")
+
+    # Validate every additional `@@` line is a proper hunk header.
+    for line in section[hunk_start_idx + 1 :]:
+        if line.startswith("@@") and not _HUNK_RE.match(line):
+            raise DiffParseError(f"udiff: malformed hunk header {line!r}")
+
+    path, kind = _resolve_udiff_path(minus_path, plus_path)
+    content = "\n".join(section[hunk_start_idx:]) + "\n"
+    return FileEdit(path=path, kind=kind, content=content, format=DiffFormat.UDIFF)
+
+
+def _resolve_udiff_path(minus: str, plus: str) -> tuple[str, EditKind]:
+    if minus == "/dev/null":
+        return _strip_b_prefix(plus), "create"
+    if plus == "/dev/null":
+        return _strip_a_prefix(minus), "delete"
+    return _strip_b_prefix(plus), "modify"
+
+
+def _strip_a_prefix(path: str) -> str:
+    return path[2:] if path.startswith("a/") else path
+
+
+def _strip_b_prefix(path: str) -> str:
+    return path[2:] if path.startswith("b/") else path
+
+
+# ── SEARCH / REPLACE ────────────────────────────────────────────────────────
+
+_SR_FILE_RE = re.compile(r"^file:\s*(?P<path>\S.*?)\s*$")
+_SR_SEARCH_MARKER = "<<<<<<< SEARCH"
+_SR_SEPARATOR = "======="
+_SR_REPLACE_MARKER = ">>>>>>> REPLACE"
+
+
+def parse_search_replace(text: str) -> tuple[FileEdit, ...]:
+    """Parse Aider-style SEARCH/REPLACE blocks with ``file:`` preambles.
+
+    Each block must be of the form::
+
+        file: path/to/x.py
+        <<<<<<< SEARCH
+        old lines
+        =======
+        new lines
+        >>>>>>> REPLACE
+
+    Raises :class:`DiffParseError` for missing preamble, missing separator,
+    or missing REPLACE marker.
+    """
+    lines = text.splitlines()
+    edits: list[FileEdit] = []
+    i = 0
+    n = len(lines)
+    saw_any_marker = False
+
+    while i < n:
+        line = lines[i]
+        if line.strip() == _SR_SEARCH_MARKER:
+            saw_any_marker = True
+            # Walk backwards to find the most recent ``file:`` preamble.
+            path = _find_preceding_file_preamble(lines, i)
+            if path is None:
+                raise DiffParseError(
+                    "search_replace: missing 'file: <path>' preamble before SEARCH marker"
+                )
+
+            search_lines: list[str] = []
+            j = i + 1
+            separator_idx: int | None = None
+            while j < n:
+                if lines[j].strip() == _SR_SEPARATOR:
+                    separator_idx = j
+                    break
+                if lines[j].strip() == _SR_REPLACE_MARKER:
+                    # Hit REPLACE before separator => malformed.
+                    break
+                search_lines.append(lines[j])
+                j += 1
+            if separator_idx is None:
+                raise DiffParseError(
+                    "search_replace: missing '=======' separator between SEARCH and REPLACE"
+                )
+
+            replace_lines: list[str] = []
+            k = separator_idx + 1
+            replace_idx: int | None = None
+            while k < n:
+                if lines[k].strip() == _SR_REPLACE_MARKER:
+                    replace_idx = k
+                    break
+                replace_lines.append(lines[k])
+                k += 1
+            if replace_idx is None:
+                raise DiffParseError("search_replace: missing '>>>>>>> REPLACE' closing marker")
+
+            block = (
+                f"{_SR_SEARCH_MARKER}\n"
+                + "\n".join(search_lines)
+                + f"\n{_SR_SEPARATOR}\n"
+                + "\n".join(replace_lines)
+                + f"\n{_SR_REPLACE_MARKER}\n"
+            )
+            edits.append(
+                FileEdit(
+                    path=path,
+                    kind="modify",
+                    content=block,
+                    format=DiffFormat.SEARCH_REPLACE,
+                )
+            )
+            i = replace_idx + 1
+            continue
+        i += 1
+
+    if not saw_any_marker:
+        raise DiffParseError("search_replace: no '<<<<<<< SEARCH' marker found")
+    if not edits:
+        raise DiffParseError("search_replace: no complete blocks parsed")
+    return tuple(edits)
+
+
+def _find_preceding_file_preamble(lines: list[str], search_idx: int) -> str | None:
+    # Look backwards up to (but not past) any previous SEARCH marker.
+    for j in range(search_idx - 1, -1, -1):
+        stripped = lines[j].strip()
+        if stripped == _SR_REPLACE_MARKER:
+            break
+        if not stripped:
+            continue
+        if (m := _SR_FILE_RE.match(lines[j])) is not None:
+            return m.group("path")
+        # Any other non-blank line without a file preamble invalidates the
+        # scan — a preamble must be the nearest non-blank line above SEARCH.
+        return None
+    return None
+
+
+# ── Whole file ──────────────────────────────────────────────────────────────
+
+_WF_HEADER_RE = re.compile(r"^---\s+(?P<path>\S.*?)\s+---\s*$")
+_WF_END = "--- end ---"
+
+
+def parse_whole_file(text: str) -> tuple[FileEdit, ...]:
+    """Parse whole-file blocks delimited by ``--- path ---`` / ``--- end ---``.
+
+    Raises :class:`DiffParseError` if no header is found, or if any header
+    lacks its matching ``--- end ---`` closer.
+    """
+    lines = text.splitlines()
+    edits: list[FileEdit] = []
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        line = lines[i]
+        if line.strip() == _WF_END:
+            # Stray end marker — treat as malformed.
+            raise DiffParseError("whole_file: '--- end ---' without matching header")
+        m = _WF_HEADER_RE.match(line)
+        if m is None:
+            i += 1
+            continue
+        path = m.group("path")
+        body: list[str] = []
+        j = i + 1
+        end_idx: int | None = None
+        while j < n:
+            if lines[j].strip() == _WF_END:
+                end_idx = j
+                break
+            if _WF_HEADER_RE.match(lines[j]):
+                # New header before close => previous block missing end.
+                break
+            body.append(lines[j])
+            j += 1
+        if end_idx is None:
+            raise DiffParseError(f"whole_file: missing '--- end ---' closer for {path!r}")
+        content = "\n".join(body)
+        if body:
+            content += "\n"
+        edits.append(
+            FileEdit(
+                path=path,
+                kind="modify",
+                content=content,
+                format=DiffFormat.WHOLE_FILE,
+            )
+        )
+        i = end_idx + 1
+
+    if not edits:
+        raise DiffParseError("whole_file: no '--- path ---' headers found")
+    return tuple(edits)
+
+
+# ── Multi-format fallback ───────────────────────────────────────────────────
+
+
+_PARSERS: dict[DiffFormat, object] = {
+    DiffFormat.UDIFF: parse_udiff,
+    DiffFormat.SEARCH_REPLACE: parse_search_replace,
+    DiffFormat.WHOLE_FILE: parse_whole_file,
+}
+
+
+def parse_any(
+    text: str,
+    *,
+    prefer: tuple[DiffFormat, ...] = (
+        DiffFormat.UDIFF,
+        DiffFormat.SEARCH_REPLACE,
+        DiffFormat.WHOLE_FILE,
+    ),
+) -> tuple[FileEdit, ...]:
+    """Try each format in ``prefer`` order; return the first non-empty result.
+
+    On total failure, raises :class:`DiffParseError` whose message lists
+    every attempted format and its rejection reason — critical telemetry
+    when a model's output format drifts.
+    """
+    failures: list[str] = []
+    for fmt in prefer:
+        parser = _PARSERS[fmt]
+        try:
+            edits = parser(text)  # type: ignore[operator]
+        except DiffParseError as e:
+            failures.append(f"{fmt.value}: {e}")
+            continue
+        if edits:
+            return edits  # type: ignore[no-any-return]
+        failures.append(f"{fmt.value}: returned no edits")
+    raise DiffParseError("parse_any: no format matched — " + "; ".join(failures))

--- a/maxwell_daemon/recipes.py
+++ b/maxwell_daemon/recipes.py
@@ -1,0 +1,317 @@
+"""Goose-style YAML recipes — named, shareable agent workflows.
+
+A *recipe* bundles:
+
+* an instruction prompt (the system/user text sent to the model),
+* a declared parameter list (typed, with required/default/description),
+* a tool allow/deny list (what the agent may call during this workflow),
+* routing hints (``requires``: preferred model tier, max turns, budget).
+
+Recipes live in ``.maxwell/recipes/*.yaml``. The loader is lenient at the
+*directory* level (one broken file doesn't kill a sweep) but strict at the
+*file* level (bad schema → :class:`RecipeLoadError` so the authoring tool
+can surface the problem).
+
+DbC: the parser is pure (bytes in, value out). ``bind_parameters`` is the
+precondition gate for every invocation — it refuses unknown, mistyped, or
+missing-required inputs via :class:`PreconditionError` so downstream steps
+can assume clean, fully-populated parameter dicts.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from maxwell_daemon.contracts import require
+
+__all__ = [
+    "Recipe",
+    "RecipeLoadError",
+    "RecipeParameter",
+    "RecipeRequires",
+    "RecipeTools",
+    "bind_parameters",
+    "load_recipe",
+    "load_recipe_directory",
+    "render_instructions",
+]
+
+_LOG = logging.getLogger(__name__)
+
+_SUPPORTED_VERSIONS: frozenset[int] = frozenset({1})
+_PARAM_TYPES: frozenset[str] = frozenset({"string", "integer", "number", "boolean"})
+ParamType = Literal["string", "integer", "number", "boolean"]
+
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}")
+
+
+class RecipeLoadError(ValueError):
+    """Raised when a recipe YAML file doesn't parse into a valid :class:`Recipe`."""
+
+
+@dataclass(slots=True, frozen=True)
+class RecipeParameter:
+    """One declared parameter for a recipe."""
+
+    name: str
+    type: ParamType
+    description: str
+    required: bool = False
+    default: Any = None
+
+
+@dataclass(slots=True, frozen=True)
+class RecipeTools:
+    """Tool allow/deny list. Empty ``allow`` means allow-any; ``deny`` always applied."""
+
+    allow: tuple[str, ...] = ()
+    deny: tuple[str, ...] = ()
+
+
+@dataclass(slots=True, frozen=True)
+class RecipeRequires:
+    """Routing hints for the dispatch layer — not enforced by the recipe itself."""
+
+    model_tier: str | None = None
+    max_turns: int | None = None
+    budget_per_story_usd: float | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class Recipe:
+    """A parsed YAML recipe — one named agent workflow."""
+
+    name: str
+    description: str
+    version: int
+    instructions: str
+    parameters: tuple[RecipeParameter, ...]
+    tools: RecipeTools
+    requires: RecipeRequires
+    source: Path
+
+
+# ── Loaders ─────────────────────────────────────────────────────────────────
+
+
+def load_recipe(path: Path) -> Recipe:
+    """Parse one YAML recipe file into a :class:`Recipe`.
+
+    Raises :class:`RecipeLoadError` on missing required fields, unknown
+    parameter types, unsupported schema versions, or malformed tools lists.
+    """
+    try:
+        raw: Any = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as e:
+        raise RecipeLoadError(f"{path}: invalid YAML: {e}") from e
+
+    if not isinstance(raw, dict):
+        raise RecipeLoadError(f"{path}: top-level must be a mapping")
+
+    name = raw.get("name")
+    if not isinstance(name, str) or not name:
+        raise RecipeLoadError(f"{path}: missing or empty 'name'")
+
+    description = raw.get("description")
+    if not isinstance(description, str) or not description:
+        raise RecipeLoadError(f"{path}: missing or empty 'description'")
+
+    version_raw = raw.get("version", 1)
+    if not isinstance(version_raw, int) or isinstance(version_raw, bool):
+        raise RecipeLoadError(f"{path}: 'version' must be an integer")
+    if version_raw not in _SUPPORTED_VERSIONS:
+        raise RecipeLoadError(
+            f"{path}: unsupported 'version' {version_raw!r} "
+            f"(supported: {sorted(_SUPPORTED_VERSIONS)})"
+        )
+
+    instructions = raw.get("instructions")
+    if not isinstance(instructions, str) or not instructions.strip():
+        raise RecipeLoadError(f"{path}: missing or empty 'instructions'")
+
+    parameters = _parse_parameters(path, raw.get("parameters"))
+    tools = _parse_tools(path, raw.get("tools"))
+    requires = _parse_requires(path, raw.get("requires"))
+
+    return Recipe(
+        name=name,
+        description=description,
+        version=version_raw,
+        instructions=instructions,
+        parameters=parameters,
+        tools=tools,
+        requires=requires,
+        source=path,
+    )
+
+
+def load_recipe_directory(directory: Path) -> tuple[Recipe, ...]:
+    """Load every ``*.yaml`` / ``*.yml`` recipe under ``directory`` (non-recursive).
+
+    Missing directory → empty tuple. Files that fail to parse are skipped
+    with a WARNING-level log entry (no exception) so one bad recipe never
+    kills the whole sweep.
+    """
+    if not directory.is_dir():
+        return ()
+    out: list[Recipe] = []
+    for path in sorted(directory.iterdir()):
+        if not path.is_file() or path.suffix not in {".yaml", ".yml"}:
+            continue
+        try:
+            out.append(load_recipe(path))
+        except RecipeLoadError as e:
+            _LOG.warning("skipping malformed recipe %s: %s", path, e)
+            continue
+    return tuple(out)
+
+
+def _parse_parameters(path: Path, raw: Any) -> tuple[RecipeParameter, ...]:
+    if raw is None:
+        return ()
+    if not isinstance(raw, dict):
+        raise RecipeLoadError(f"{path}: 'parameters' must be a mapping")
+    out: list[RecipeParameter] = []
+    for name, spec in raw.items():
+        if not isinstance(name, str):
+            raise RecipeLoadError(f"{path}: parameter names must be strings")
+        if not isinstance(spec, dict):
+            raise RecipeLoadError(f"{path}: parameter {name!r} must be a mapping")
+        ptype = spec.get("type")
+        if ptype not in _PARAM_TYPES:
+            raise RecipeLoadError(
+                f"{path}: parameter {name!r} has unknown 'type' {ptype!r} "
+                f"(expected one of {sorted(_PARAM_TYPES)})"
+            )
+        description = spec.get("description", "")
+        if not isinstance(description, str):
+            raise RecipeLoadError(f"{path}: parameter {name!r} 'description' must be a string")
+        required = spec.get("required", False)
+        if not isinstance(required, bool):
+            raise RecipeLoadError(f"{path}: parameter {name!r} 'required' must be a boolean")
+        default = spec.get("default")
+        out.append(
+            RecipeParameter(
+                name=name,
+                type=ptype,
+                description=description,
+                required=required,
+                default=default,
+            )
+        )
+    return tuple(out)
+
+
+def _parse_tools(path: Path, raw: Any) -> RecipeTools:
+    if raw is None:
+        return RecipeTools()
+    if not isinstance(raw, dict):
+        raise RecipeLoadError(f"{path}: 'tools' must be a mapping")
+    allow = raw.get("allow", [])
+    deny = raw.get("deny", [])
+    if not isinstance(allow, list) or not all(isinstance(x, str) for x in allow):
+        raise RecipeLoadError(f"{path}: 'tools.allow' must be a list of strings")
+    if not isinstance(deny, list) or not all(isinstance(x, str) for x in deny):
+        raise RecipeLoadError(f"{path}: 'tools.deny' must be a list of strings")
+    return RecipeTools(allow=tuple(allow), deny=tuple(deny))
+
+
+def _parse_requires(path: Path, raw: Any) -> RecipeRequires:
+    if raw is None:
+        return RecipeRequires()
+    if not isinstance(raw, dict):
+        raise RecipeLoadError(f"{path}: 'requires' must be a mapping")
+    model_tier = raw.get("model_tier")
+    if model_tier is not None and not isinstance(model_tier, str):
+        raise RecipeLoadError(f"{path}: 'requires.model_tier' must be a string")
+    max_turns = raw.get("max_turns")
+    if max_turns is not None and (not isinstance(max_turns, int) or isinstance(max_turns, bool)):
+        raise RecipeLoadError(f"{path}: 'requires.max_turns' must be an integer")
+    budget = raw.get("budget_per_story_usd")
+    if budget is not None and (isinstance(budget, bool) or not isinstance(budget, (int, float))):
+        # bool is a subclass of int in Python — we don't want ``True`` to
+        # silently become 1.0, so check bool first.
+        raise RecipeLoadError(f"{path}: 'requires.budget_per_story_usd' must be a number")
+    return RecipeRequires(
+        model_tier=model_tier,
+        max_turns=max_turns,
+        budget_per_story_usd=float(budget) if budget is not None else None,
+    )
+
+
+# ── Parameter binding & templating ──────────────────────────────────────────
+
+
+def bind_parameters(recipe: Recipe, *, supplied: dict[str, Any]) -> dict[str, Any]:
+    """Resolve concrete values for every declared parameter.
+
+    * Missing required param → :class:`PreconditionError`.
+    * Type mismatch (e.g. int where string declared) → :class:`PreconditionError`.
+    * Unknown supplied name → :class:`PreconditionError` (never silently ignored).
+    * Missing optional → fill from ``default`` if present, else omit.
+
+    Returns the fully-resolved parameter dict ready for instruction templating.
+    """
+    declared = {p.name: p for p in recipe.parameters}
+
+    extra = set(supplied) - set(declared)
+    require(
+        not extra,
+        f"recipe {recipe.name!r}: extra supplied parameter(s) {sorted(extra)!r} "
+        f"not declared in the recipe",
+    )
+
+    resolved: dict[str, Any] = {}
+    for name, spec in declared.items():
+        if name in supplied:
+            value = supplied[name]
+            require(
+                _type_matches(value, spec.type),
+                f"recipe {recipe.name!r}: parameter {name!r} expected type "
+                f"{spec.type!r}, got {type(value).__name__}",
+            )
+            resolved[name] = value
+        elif spec.required:
+            require(
+                False,
+                f"recipe {recipe.name!r}: required parameter {name!r} not supplied",
+            )
+        elif spec.default is not None:
+            resolved[name] = spec.default
+    return resolved
+
+
+def _type_matches(value: Any, declared: ParamType) -> bool:
+    """Strict-ish type check. ``bool`` never satisfies ``integer`` or ``number``."""
+    if declared == "string":
+        return isinstance(value, str)
+    if declared == "boolean":
+        return isinstance(value, bool)
+    if declared == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if declared == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return False
+
+
+def render_instructions(recipe: Recipe, bound: dict[str, Any]) -> str:
+    """Substitute ``{{name}}`` placeholders in ``recipe.instructions``.
+
+    Values are stringified with ``str(...)``. Placeholders whose name isn't
+    in ``bound`` stay literal so the author can spot unresolved templates
+    in their workflow output.
+    """
+
+    def _sub(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name in bound:
+            return str(bound[name])
+        return match.group(0)
+
+    return _PLACEHOLDER_RE.sub(_sub, recipe.instructions)

--- a/tests/unit/test_diff_formats.py
+++ b/tests/unit/test_diff_formats.py
@@ -1,0 +1,328 @@
+"""Tests for the LLM diff-format parsers.
+
+The agent loop asks the model for file edits in one of three formats,
+picks whichever the model is most reliable at. The parser tries each
+format until one succeeds, so a flaky model answer doesn't wedge the
+edit step. See ``maxwell_daemon/editing/diff_formats.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from textwrap import dedent
+
+import pytest
+
+from maxwell_daemon.editing.diff_formats import (
+    DiffFormat,
+    DiffParseError,
+    FileEdit,
+    parse_any,
+    parse_search_replace,
+    parse_udiff,
+    parse_whole_file,
+)
+
+# ── Shape ────────────────────────────────────────────────────────────────────
+
+
+class TestFileEdit:
+    def test_frozen(self) -> None:
+        e = FileEdit(path="x.py", kind="modify", content="", format=DiffFormat.UDIFF)
+        with pytest.raises(FrozenInstanceError):
+            e.path = "y.py"  # type: ignore[misc]
+
+
+# ── parse_udiff ──────────────────────────────────────────────────────────────
+
+
+class TestParseUdiff:
+    def test_single_file_single_hunk(self) -> None:
+        text = dedent(
+            """\
+            diff --git a/foo.py b/foo.py
+            --- a/foo.py
+            +++ b/foo.py
+            @@ -1,3 +1,3 @@
+             line1
+            -old
+            +new
+             line3
+            """
+        )
+        edits = parse_udiff(text)
+        assert len(edits) == 1
+        assert edits[0].path == "foo.py"
+        assert edits[0].kind == "modify"
+        assert edits[0].format is DiffFormat.UDIFF
+        assert "-old" in edits[0].content
+        assert "+new" in edits[0].content
+
+    def test_two_files_multiple_hunks(self) -> None:
+        text = dedent(
+            """\
+            diff --git a/foo.py b/foo.py
+            --- a/foo.py
+            +++ b/foo.py
+            @@ -1,2 +1,2 @@
+            -a
+            +A
+             b
+            @@ -10,2 +10,2 @@
+            -x
+            +X
+             y
+            diff --git a/bar.py b/bar.py
+            --- a/bar.py
+            +++ b/bar.py
+            @@ -1,1 +1,1 @@
+            -old
+            +new
+            """
+        )
+        edits = parse_udiff(text)
+        assert [e.path for e in edits] == ["foo.py", "bar.py"]
+        # First file should contain both hunk headers (each has opening + closing @@).
+        assert edits[0].content.count("@@ -1,2 +1,2 @@") == 1
+        assert edits[0].content.count("@@ -10,2 +10,2 @@") == 1
+
+    def test_create_new_file(self) -> None:
+        text = dedent(
+            """\
+            diff --git a/new.py b/new.py
+            --- /dev/null
+            +++ b/new.py
+            @@ -0,0 +1,2 @@
+            +hello
+            +world
+            """
+        )
+        edits = parse_udiff(text)
+        assert len(edits) == 1
+        assert edits[0].path == "new.py"
+        assert edits[0].kind == "create"
+
+    def test_delete_file(self) -> None:
+        text = dedent(
+            """\
+            diff --git a/gone.py b/gone.py
+            --- a/gone.py
+            +++ /dev/null
+            @@ -1,2 +0,0 @@
+            -hello
+            -world
+            """
+        )
+        edits = parse_udiff(text)
+        assert len(edits) == 1
+        assert edits[0].path == "gone.py"
+        assert edits[0].kind == "delete"
+
+    def test_malformed_hunk_header_rejected(self) -> None:
+        text = dedent(
+            """\
+            diff --git a/foo.py b/foo.py
+            --- a/foo.py
+            +++ b/foo.py
+            @@ not a real header @@
+            -old
+            +new
+            """
+        )
+        with pytest.raises(DiffParseError, match="hunk"):
+            parse_udiff(text)
+
+    def test_empty_text_rejected(self) -> None:
+        with pytest.raises(DiffParseError):
+            parse_udiff("")
+
+
+# ── parse_search_replace ─────────────────────────────────────────────────────
+
+
+class TestParseSearchReplace:
+    def test_single_block(self) -> None:
+        text = dedent(
+            """\
+            file: foo.py
+            <<<<<<< SEARCH
+            old text
+            =======
+            new text
+            >>>>>>> REPLACE
+            """
+        )
+        edits = parse_search_replace(text)
+        assert len(edits) == 1
+        e = edits[0]
+        assert e.path == "foo.py"
+        assert e.kind == "modify"
+        assert e.format is DiffFormat.SEARCH_REPLACE
+        assert "old text" in e.content
+        assert "new text" in e.content
+
+    def test_multiple_blocks_different_files(self) -> None:
+        text = dedent(
+            """\
+            file: foo.py
+            <<<<<<< SEARCH
+            a
+            =======
+            A
+            >>>>>>> REPLACE
+
+            file: bar.py
+            <<<<<<< SEARCH
+            b
+            =======
+            B
+            >>>>>>> REPLACE
+            """
+        )
+        edits = parse_search_replace(text)
+        assert [e.path for e in edits] == ["foo.py", "bar.py"]
+
+    def test_missing_separator_rejected(self) -> None:
+        text = dedent(
+            """\
+            file: foo.py
+            <<<<<<< SEARCH
+            old
+            new
+            >>>>>>> REPLACE
+            """
+        )
+        with pytest.raises(DiffParseError, match="separator"):
+            parse_search_replace(text)
+
+    def test_missing_replace_marker_rejected(self) -> None:
+        text = dedent(
+            """\
+            file: foo.py
+            <<<<<<< SEARCH
+            old
+            =======
+            new
+            """
+        )
+        with pytest.raises(DiffParseError, match="REPLACE"):
+            parse_search_replace(text)
+
+    def test_missing_file_preamble_rejected(self) -> None:
+        text = dedent(
+            """\
+            <<<<<<< SEARCH
+            old
+            =======
+            new
+            >>>>>>> REPLACE
+            """
+        )
+        with pytest.raises(DiffParseError, match="file"):
+            parse_search_replace(text)
+
+
+# ── parse_whole_file ─────────────────────────────────────────────────────────
+
+
+class TestParseWholeFile:
+    def test_single_file(self) -> None:
+        text = dedent(
+            """\
+            --- foo.py ---
+            print("hello")
+            x = 1
+            --- end ---
+            """
+        )
+        edits = parse_whole_file(text)
+        assert len(edits) == 1
+        e = edits[0]
+        assert e.path == "foo.py"
+        assert e.kind == "modify"
+        assert e.format is DiffFormat.WHOLE_FILE
+        assert 'print("hello")' in e.content
+        assert "x = 1" in e.content
+
+    def test_multiple_files(self) -> None:
+        text = dedent(
+            """\
+            --- foo.py ---
+            a = 1
+            --- end ---
+
+            --- bar/baz.py ---
+            b = 2
+            --- end ---
+            """
+        )
+        edits = parse_whole_file(text)
+        assert [e.path for e in edits] == ["foo.py", "bar/baz.py"]
+
+    def test_missing_end_rejected(self) -> None:
+        text = dedent(
+            """\
+            --- foo.py ---
+            print("hello")
+            """
+        )
+        with pytest.raises(DiffParseError, match="end"):
+            parse_whole_file(text)
+
+
+# ── parse_any ────────────────────────────────────────────────────────────────
+
+
+class TestParseAny:
+    def test_picks_first_working_format(self) -> None:
+        text = dedent(
+            """\
+            diff --git a/foo.py b/foo.py
+            --- a/foo.py
+            +++ b/foo.py
+            @@ -1,1 +1,1 @@
+            -old
+            +new
+            """
+        )
+        edits = parse_any(text)
+        assert len(edits) == 1
+        assert edits[0].format is DiffFormat.UDIFF
+
+    def test_falls_through_to_next_format(self) -> None:
+        text = dedent(
+            """\
+            file: foo.py
+            <<<<<<< SEARCH
+            old
+            =======
+            new
+            >>>>>>> REPLACE
+            """
+        )
+        edits = parse_any(text)
+        assert len(edits) == 1
+        assert edits[0].format is DiffFormat.SEARCH_REPLACE
+
+    def test_custom_prefer_order_respected(self) -> None:
+        # The text is valid whole_file but also happens to be valid udiff?
+        # No — whole-file markers don't look like udiff, so udiff would fail.
+        # We confirm prefer order is respected by asking for WHOLE_FILE first.
+        text = dedent(
+            """\
+            --- foo.py ---
+            a = 1
+            --- end ---
+            """
+        )
+        edits = parse_any(text, prefer=(DiffFormat.WHOLE_FILE,))
+        assert len(edits) == 1
+        assert edits[0].format is DiffFormat.WHOLE_FILE
+
+    def test_all_fail_includes_each_reason(self) -> None:
+        with pytest.raises(DiffParseError) as excinfo:
+            parse_any("this is not any diff format at all")
+        msg = str(excinfo.value)
+        assert "udiff" in msg
+        assert "search_replace" in msg
+        assert "whole_file" in msg

--- a/tests/unit/test_recipes.py
+++ b/tests/unit/test_recipes.py
@@ -1,0 +1,369 @@
+"""Tests for Goose-style YAML recipes.
+
+Recipes bundle an instruction prompt, a tool allow/deny list, declared
+parameters, and routing hints — a named, shareable agent workflow. See
+``maxwell_daemon/recipes.py`` for the schema and loader.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from maxwell_daemon.contracts import PreconditionError
+from maxwell_daemon.recipes import (
+    Recipe,
+    RecipeLoadError,
+    RecipeParameter,
+    RecipeRequires,
+    RecipeTools,
+    bind_parameters,
+    load_recipe,
+    load_recipe_directory,
+    render_instructions,
+)
+
+
+def _write_recipe(tmp_path: Path, body: str, name: str = "fix-flaky-test.yaml") -> Path:
+    path = tmp_path / name
+    path.write_text(dedent(body).lstrip())
+    return path
+
+
+_FULL_RECIPE = """
+    name: fix-flaky-test
+    description: Investigate a flaky test and either fix it or mark xfail.
+    version: 1
+    instructions: |
+      You are investigating a flaky test. Follow the procedure.
+    parameters:
+      test_path:
+        type: string
+        description: Path to the flaky test file
+        required: true
+      max_runs:
+        type: integer
+        default: 10
+        description: How many times to run the test
+    tools:
+      allow: [read_file, run_bash, glob_files, grep_files]
+      deny: [write_file, edit_file]
+    requires:
+      model_tier: complex
+      max_turns: 40
+"""
+
+
+# ── Shape ────────────────────────────────────────────────────────────────────
+
+
+class TestShapes:
+    def test_recipe_frozen(self, tmp_path: Path) -> None:
+        r = Recipe(
+            name="x",
+            description="y",
+            version=1,
+            instructions="go",
+            parameters=(),
+            tools=RecipeTools(),
+            requires=RecipeRequires(),
+            source=tmp_path / "x.yaml",
+        )
+        with pytest.raises(FrozenInstanceError):
+            r.name = "z"  # type: ignore[misc]
+
+    def test_recipe_parameter_frozen(self) -> None:
+        p = RecipeParameter(name="x", type="string", description="d")
+        with pytest.raises(FrozenInstanceError):
+            p.name = "y"  # type: ignore[misc]
+
+    def test_recipe_tools_frozen(self) -> None:
+        t = RecipeTools()
+        with pytest.raises(FrozenInstanceError):
+            t.allow = ("x",)  # type: ignore[misc]
+
+    def test_recipe_requires_frozen(self) -> None:
+        rq = RecipeRequires()
+        with pytest.raises(FrozenInstanceError):
+            rq.model_tier = "x"  # type: ignore[misc]
+
+
+# ── load_recipe ─────────────────────────────────────────────────────────────
+
+
+class TestLoadRecipe:
+    def test_happy_path(self, tmp_path: Path) -> None:
+        path = _write_recipe(tmp_path, _FULL_RECIPE)
+        r = load_recipe(path)
+        assert r.name == "fix-flaky-test"
+        assert r.description.startswith("Investigate")
+        assert r.version == 1
+        assert "investigating a flaky test" in r.instructions
+        assert len(r.parameters) == 2
+        names = {p.name for p in r.parameters}
+        assert names == {"test_path", "max_runs"}
+        test_path_param = next(p for p in r.parameters if p.name == "test_path")
+        assert test_path_param.type == "string"
+        assert test_path_param.required is True
+        max_runs_param = next(p for p in r.parameters if p.name == "max_runs")
+        assert max_runs_param.type == "integer"
+        assert max_runs_param.default == 10
+        assert max_runs_param.required is False
+        assert r.tools.allow == ("read_file", "run_bash", "glob_files", "grep_files")
+        assert r.tools.deny == ("write_file", "edit_file")
+        assert r.requires.model_tier == "complex"
+        assert r.requires.max_turns == 40
+        assert r.source == path
+
+    def test_missing_name_rejected(self, tmp_path: Path) -> None:
+        path = _write_recipe(
+            tmp_path,
+            """
+            description: x
+            version: 1
+            instructions: go
+            """,
+        )
+        with pytest.raises(RecipeLoadError, match="name"):
+            load_recipe(path)
+
+    def test_missing_description_rejected(self, tmp_path: Path) -> None:
+        path = _write_recipe(
+            tmp_path,
+            """
+            name: x
+            version: 1
+            instructions: go
+            """,
+        )
+        with pytest.raises(RecipeLoadError, match="description"):
+            load_recipe(path)
+
+    def test_missing_instructions_rejected(self, tmp_path: Path) -> None:
+        path = _write_recipe(
+            tmp_path,
+            """
+            name: x
+            description: d
+            version: 1
+            """,
+        )
+        with pytest.raises(RecipeLoadError, match="instructions"):
+            load_recipe(path)
+
+    def test_unknown_parameter_type_rejected(self, tmp_path: Path) -> None:
+        path = _write_recipe(
+            tmp_path,
+            """
+            name: x
+            description: d
+            version: 1
+            instructions: go
+            parameters:
+              p1:
+                type: uuid
+                description: d
+            """,
+        )
+        with pytest.raises(RecipeLoadError, match="type"):
+            load_recipe(path)
+
+    def test_unsupported_version_rejected(self, tmp_path: Path) -> None:
+        path = _write_recipe(
+            tmp_path,
+            """
+            name: x
+            description: d
+            version: 99
+            instructions: go
+            """,
+        )
+        with pytest.raises(RecipeLoadError, match="version"):
+            load_recipe(path)
+
+    def test_non_mapping_top_level_rejected(self, tmp_path: Path) -> None:
+        path = _write_recipe(tmp_path, "- just a list\n- of things\n")
+        with pytest.raises(RecipeLoadError):
+            load_recipe(path)
+
+    def test_bad_tools_structure_rejected(self, tmp_path: Path) -> None:
+        path = _write_recipe(
+            tmp_path,
+            """
+            name: x
+            description: d
+            version: 1
+            instructions: go
+            tools:
+              allow: "not a list"
+            """,
+        )
+        with pytest.raises(RecipeLoadError, match="tools"):
+            load_recipe(path)
+
+
+# ── load_recipe_directory ────────────────────────────────────────────────────
+
+
+class TestLoadRecipeDirectory:
+    def test_returns_empty_for_missing_dir(self, tmp_path: Path) -> None:
+        assert load_recipe_directory(tmp_path / "nope") == ()
+
+    def test_loads_yaml_and_yml(self, tmp_path: Path) -> None:
+        _write_recipe(tmp_path, _FULL_RECIPE, name="a.yaml")
+        _write_recipe(
+            tmp_path,
+            """
+            name: other
+            description: d
+            version: 1
+            instructions: go
+            """,
+            name="b.yml",
+        )
+        recipes = load_recipe_directory(tmp_path)
+        assert sorted(r.name for r in recipes) == ["fix-flaky-test", "other"]
+
+    def test_skips_malformed(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        _write_recipe(tmp_path, _FULL_RECIPE, name="good.yaml")
+        _write_recipe(tmp_path, "not: [valid\n", name="bad.yaml")
+        with caplog.at_level(logging.WARNING):
+            recipes = load_recipe_directory(tmp_path)
+        assert [r.name for r in recipes] == ["fix-flaky-test"]
+        assert any("bad.yaml" in rec.message for rec in caplog.records)
+
+    def test_ignores_non_yaml_files(self, tmp_path: Path) -> None:
+        (tmp_path / "readme.md").write_text("not a recipe")
+        _write_recipe(tmp_path, _FULL_RECIPE, name="a.yaml")
+        recipes = load_recipe_directory(tmp_path)
+        assert [r.name for r in recipes] == ["fix-flaky-test"]
+
+
+# ── bind_parameters ──────────────────────────────────────────────────────────
+
+
+def _make_recipe(*params: RecipeParameter, tmp_path: Path | None = None) -> Recipe:
+    return Recipe(
+        name="r",
+        description="d",
+        version=1,
+        instructions="go",
+        parameters=params,
+        tools=RecipeTools(),
+        requires=RecipeRequires(),
+        source=(tmp_path or Path("/tmp")) / "r.yaml",
+    )
+
+
+class TestBindParameters:
+    def test_required_and_optional(self) -> None:
+        r = _make_recipe(
+            RecipeParameter(name="a", type="string", description="", required=True),
+            RecipeParameter(name="b", type="integer", description="", default=5),
+        )
+        bound = bind_parameters(r, supplied={"a": "hello"})
+        assert bound == {"a": "hello", "b": 5}
+
+    def test_missing_required_raises(self) -> None:
+        r = _make_recipe(
+            RecipeParameter(name="a", type="string", description="", required=True),
+        )
+        with pytest.raises(PreconditionError, match="a"):
+            bind_parameters(r, supplied={})
+
+    def test_type_mismatch_raises(self) -> None:
+        r = _make_recipe(
+            RecipeParameter(name="a", type="string", description="", required=True),
+        )
+        with pytest.raises(PreconditionError, match="string"):
+            bind_parameters(r, supplied={"a": 42})
+
+    def test_integer_accepts_int_rejects_bool(self) -> None:
+        # bool is a subtype of int in Python but we don't want `True` to
+        # satisfy an integer parameter silently.
+        r = _make_recipe(
+            RecipeParameter(name="n", type="integer", description="", required=True),
+        )
+        assert bind_parameters(r, supplied={"n": 7}) == {"n": 7}
+        with pytest.raises(PreconditionError):
+            bind_parameters(r, supplied={"n": True})
+
+    def test_default_fills_in_optional(self) -> None:
+        r = _make_recipe(
+            RecipeParameter(name="a", type="string", description="", default="x"),
+        )
+        bound = bind_parameters(r, supplied={})
+        assert bound == {"a": "x"}
+
+    def test_unknown_supplied_param_raises(self) -> None:
+        r = _make_recipe(
+            RecipeParameter(name="a", type="string", description="", required=True),
+        )
+        with pytest.raises(PreconditionError, match="extra"):
+            bind_parameters(r, supplied={"a": "ok", "extra": "nope"})
+
+    def test_number_accepts_int_and_float(self) -> None:
+        r = _make_recipe(
+            RecipeParameter(name="x", type="number", description="", required=True),
+        )
+        assert bind_parameters(r, supplied={"x": 1})["x"] == 1
+        assert bind_parameters(r, supplied={"x": 1.5})["x"] == 1.5
+
+    def test_boolean_param(self) -> None:
+        r = _make_recipe(
+            RecipeParameter(name="flag", type="boolean", description="", required=True),
+        )
+        assert bind_parameters(r, supplied={"flag": True}) == {"flag": True}
+        with pytest.raises(PreconditionError):
+            bind_parameters(r, supplied={"flag": "yes"})
+
+
+# ── render_instructions ─────────────────────────────────────────────────────
+
+
+class TestRenderInstructions:
+    def test_single_placeholder(self) -> None:
+        r = Recipe(
+            name="r",
+            description="d",
+            version=1,
+            instructions="Fix the test at {{test_path}} now.",
+            parameters=(),
+            tools=RecipeTools(),
+            requires=RecipeRequires(),
+            source=Path("/tmp/r.yaml"),
+        )
+        out = render_instructions(r, {"test_path": "tests/unit/test_x.py"})
+        assert out == "Fix the test at tests/unit/test_x.py now."
+
+    def test_missing_placeholder_stays_literal(self) -> None:
+        r = Recipe(
+            name="r",
+            description="d",
+            version=1,
+            instructions="Use {{absent}} and keep it literal.",
+            parameters=(),
+            tools=RecipeTools(),
+            requires=RecipeRequires(),
+            source=Path("/tmp/r.yaml"),
+        )
+        out = render_instructions(r, {})
+        assert "{{absent}}" in out
+
+    def test_multiple_placeholders_non_string_values(self) -> None:
+        r = Recipe(
+            name="r",
+            description="d",
+            version=1,
+            instructions="Run {{path}} {{n}} times; flag={{flag}}.",
+            parameters=(),
+            tools=RecipeTools(),
+            requires=RecipeRequires(),
+            source=Path("/tmp/r.yaml"),
+        )
+        out = render_instructions(r, {"path": "x.py", "n": 10, "flag": True})
+        assert out == "Run x.py 10 times; flag=True."

--- a/tests/unit/test_tool_result_compression.py
+++ b/tests/unit/test_tool_result_compression.py
@@ -83,23 +83,17 @@ class TestHeadTailTruncation:
     def test_head_tail_applied_when_too_long(self) -> None:
         lines = [f"line {i}" for i in range(500)]
         output = "\n".join(lines)
-        compressor = ToolResultCompressor(
-            head_lines=5, tail_lines=5, max_chars=100
-        )
+        compressor = ToolResultCompressor(head_lines=5, tail_lines=5, max_chars=100)
         result = compressor.compress("run_bash", output)
         assert result.strategy == "head_tail"
         # First 5 lines preserved verbatim.
         assert result.content.startswith("line 0\nline 1\nline 2\nline 3\nline 4\n")
         # Last 5 lines preserved verbatim.
-        assert result.content.rstrip().endswith(
-            "line 495\nline 496\nline 497\nline 498\nline 499"
-        )
+        assert result.content.rstrip().endswith("line 495\nline 496\nline 497\nline 498\nline 499")
 
     def test_head_tail_contains_truncation_marker(self) -> None:
         output = "\n".join(f"L{i}" for i in range(200))
-        compressor = ToolResultCompressor(
-            head_lines=3, tail_lines=3, max_chars=20
-        )
+        compressor = ToolResultCompressor(head_lines=3, tail_lines=3, max_chars=20)
         result = compressor.compress("run_bash", output)
         assert "truncated" in result.content
         # Marker should record how many lines vanished: 200 - 3 - 3 = 194.
@@ -107,17 +101,13 @@ class TestHeadTailTruncation:
 
     def test_head_tail_compressed_shorter_than_original(self) -> None:
         output = "\n".join(f"line {i}" for i in range(1000))
-        compressor = ToolResultCompressor(
-            head_lines=10, tail_lines=10, max_chars=50
-        )
+        compressor = ToolResultCompressor(head_lines=10, tail_lines=10, max_chars=50)
         result = compressor.compress("run_bash", output)
         assert len(result.content) < len(output)
 
     def test_unknown_tool_still_head_tail_when_long(self) -> None:
         output = "\n".join(f"line {i}" for i in range(400))
-        compressor = ToolResultCompressor(
-            head_lines=2, tail_lines=2, max_chars=30
-        )
+        compressor = ToolResultCompressor(head_lines=2, tail_lines=2, max_chars=30)
         result = compressor.compress("unknown_tool", output)
         assert result.strategy == "head_tail"
 
@@ -158,9 +148,7 @@ class TestDedup:
         # the strategy must then fall through to head_tail.
         lines = [f"unique_{i}" for i in range(500)]
         output = "\n".join(lines)
-        compressor = ToolResultCompressor(
-            head_lines=3, tail_lines=3, max_chars=50
-        )
+        compressor = ToolResultCompressor(head_lines=3, tail_lines=3, max_chars=50)
         result = compressor.compress("grep_files", output)
         assert result.strategy == "head_tail"
         assert "truncated" in result.content
@@ -169,9 +157,7 @@ class TestDedup:
         # run_bash isn't in the dedup set; duplicate lines are untouched when
         # we go through head_tail.
         output = ("same\n" * 200) + "end\n"
-        compressor = ToolResultCompressor(
-            head_lines=5, tail_lines=5, max_chars=30
-        )
+        compressor = ToolResultCompressor(head_lines=5, tail_lines=5, max_chars=30)
         result = compressor.compress("run_bash", output)
         assert result.strategy == "head_tail"
 
@@ -202,9 +188,7 @@ class TestCompressionResultAccounting:
 
     def test_accounting_on_truncation_compressed_is_smaller(self) -> None:
         output = "\n".join(f"line_{i}" for i in range(1000))
-        compressor = ToolResultCompressor(
-            head_lines=5, tail_lines=5, max_chars=50
-        )
+        compressor = ToolResultCompressor(head_lines=5, tail_lines=5, max_chars=50)
         result = compressor.compress("run_bash", output)
         assert result.compressed_bytes < result.original_bytes
 


### PR DESCRIPTION
Two orthogonal primitives — each small, both shipped together because they share the 'schema-driven LLM-facing primitive' pattern.

### `recipes.py` (#98)
Goose-style YAML: `name`, `description`, `instructions` (with `{{param}}` tokens), `parameters` (typed + required + default), `tools.allow`/`deny`, `requires.model_tier`/`max_turns`/`budget`. Frozen dataclasses. `bind_parameters` enforces DbC (required missing / type mismatch / unknown param all raise `PreconditionError`). Closes Python's `bool <: int` trap explicitly.

### `editing/diff_formats.py` (#101)
Three parsers: `parse_udiff` (unified `diff --git` + `/dev/null` create/delete detection), `parse_search_replace` (SEARCH/======/REPLACE blocks with `file:` preamble walk-back), `parse_whole_file` (`--- path ---` / `--- end ---`). `parse_any` dispatches in preference order and emits each format's rejection reason when all fail — feeds per-model format telemetry.

**46 new tests, all green.** `ruff` + `mypy --strict` clean.

**Follow-ups:** `maxwell-daemon recipe` CLI + wiring `parse_any` into `IssueExecutor`'s diff-application path (re-ask with targeted prompt on parse failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)