### PR TITLE
feat(memory): semantic embeddings for episodic retrieval (#102)

### DIFF
--- a/maxwell_daemon/memory/embeddings.py
+++ b/maxwell_daemon/memory/embeddings.py
@@ -1,0 +1,397 @@
+"""Semantic embedding primitives for episodic memory retrieval.
+
+Today ``EpisodicStore`` ranks past episodes with SQLite FTS5 (keyword BM25).
+FTS is fast and zero-dep, but it misses paraphrases — "fix the parser" and
+"segfault in the tokenizer" don't share surface tokens even though they're
+the same kind of work.
+
+This module delivers the *primitives* needed to bolt semantic retrieval onto
+that keyword baseline:
+
+* :class:`EmbeddingResult` — one embedding plus the content hash it encodes.
+* :class:`EmbeddingProvider` — structural protocol every backend satisfies.
+* :class:`StubEmbeddingProvider` — deterministic, offline provider for tests
+  and air-gapped installs. Not semantically meaningful; swap in a real model
+  for production.
+* :class:`OpenAIEmbeddingProvider` — thin wrapper over OpenAI's
+  ``/v1/embeddings`` endpoint. HTTP client is injected so tests never touch
+  the network (same injected-runner pattern as ``gh/client.py``).
+* :func:`cosine_similarity` / :func:`rerank` — pure-function blending of FTS
+  and embedding scores into a single ordered list of candidates.
+* :class:`EmbeddingCache` — SQLite-backed ``(provider, text_hash) → vector``
+  cache keyed on ``sha256`` so expensive embeddings are paid for exactly once.
+
+The integration into ``EpisodicStore`` / ``MemoryManager`` is deliberately
+separate — this module ships only the building blocks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import sqlite3
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from maxwell_daemon.backends.base import BackendUnavailableError
+from maxwell_daemon.contracts import require
+
+__all__ = [
+    "EmbeddingCache",
+    "EmbeddingProvider",
+    "EmbeddingResult",
+    "OpenAIEmbeddingProvider",
+    "StubEmbeddingProvider",
+    "cosine_similarity",
+    "hash_text",
+    "rerank",
+]
+
+
+_HASH_PREFIX = 16  # hex chars — 64 bits of collision space is plenty for a cache key.
+
+
+def hash_text(text: str) -> str:
+    """sha256 hex prefix used as the cache key for a piece of text.
+
+    Short enough to keep SQLite indices small, wide enough (64 bits) that
+    collisions across a single user's episode corpus are vanishingly rare.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:_HASH_PREFIX]
+
+
+@dataclass(slots=True, frozen=True)
+class EmbeddingResult:
+    """One embedding + the text hash it encodes (for cache key reuse)."""
+
+    text_hash: str
+    vector: tuple[float, ...]
+    dimensions: int
+    provider_name: str
+
+
+@runtime_checkable
+class EmbeddingProvider(Protocol):
+    """Structural — anything with ``name`` + ``dimensions`` + ``embed_batch`` works."""
+
+    name: str
+
+    @property
+    def dimensions(self) -> int: ...
+
+    async def embed_batch(self, texts: tuple[str, ...]) -> tuple[EmbeddingResult, ...]: ...
+
+
+class StubEmbeddingProvider:
+    """Deterministic local provider — tests and air-gapped operation.
+
+    Produces a fixed-dimensional vector whose components are derived from a
+    streaming sha256 of ``text``. Fast, zero cost, no network. *Not*
+    semantically meaningful — callers should swap in ``sentence-transformers``
+    or ``OpenAIEmbeddingProvider`` in prod.
+
+    Determinism makes this provider useful as the default in tests: the same
+    text always yields the same vector across processes, so golden assertions
+    don't churn.
+    """
+
+    name: str = "stub"
+
+    def __init__(self, dimensions: int = 64) -> None:
+        require(
+            dimensions >= 16,
+            f"StubEmbeddingProvider: dimensions must be >= 16, got {dimensions}",
+        )
+        self._dim = dimensions
+
+    @property
+    def dimensions(self) -> int:
+        return self._dim
+
+    async def embed_batch(self, texts: tuple[str, ...]) -> tuple[EmbeddingResult, ...]:
+        return tuple(self._embed_one(t) for t in texts)
+
+    def _embed_one(self, text: str) -> EmbeddingResult:
+        # Stream sha256 blocks until we have enough bytes (4 per float component).
+        needed = self._dim * 4
+        buf = bytearray()
+        seed = text.encode("utf-8")
+        counter = 0
+        while len(buf) < needed:
+            h = hashlib.sha256(seed + counter.to_bytes(4, "big")).digest()
+            buf.extend(h)
+            counter += 1
+
+        # Map each 4-byte chunk to [-1, 1) then L2-normalise so cosine == dot.
+        components: list[float] = []
+        for i in range(self._dim):
+            chunk = int.from_bytes(buf[i * 4 : (i + 1) * 4], "big", signed=False)
+            components.append((chunk / 0xFFFFFFFF) * 2.0 - 1.0)
+
+        norm = math.sqrt(sum(c * c for c in components))
+        if norm > 0:
+            components = [c / norm for c in components]
+
+        return EmbeddingResult(
+            text_hash=hash_text(text),
+            vector=tuple(components),
+            dimensions=self._dim,
+            provider_name=self.name,
+        )
+
+
+class OpenAIEmbeddingProvider:
+    """Wraps OpenAI's ``/v1/embeddings`` endpoint.
+
+    The HTTP client is *injected* (default: ``openai.AsyncOpenAI``) so tests
+    can swap in a stub without mocking the network stack. The injected client
+    only needs an ``embeddings.create(input=..., model=..., dimensions=...)``
+    coroutine returning an object whose ``.data`` is a sequence of objects
+    with an ``.embedding`` list — i.e. the shape the OpenAI SDK already
+    returns. Anything matching that duck-type works.
+    """
+
+    name: str = "openai"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        model: str = "text-embedding-3-small",
+        http_client: Any = None,
+        dimensions_override: int | None = None,
+    ) -> None:
+        if http_client is None:
+            key = api_key or os.environ.get("OPENAI_API_KEY")
+            if not key:
+                raise BackendUnavailableError(
+                    "OpenAIEmbeddingProvider: OPENAI_API_KEY not set and no http_client injected"
+                )
+            # Import lazily so the stub path never pays the openai import cost.
+            import openai
+
+            http_client = openai.AsyncOpenAI(api_key=key)
+
+        self._client = http_client
+        self._model = model
+        self._dimensions_override = dimensions_override
+        # Default dimension for text-embedding-3-small; overridable via
+        # `dimensions_override` (OpenAI supports truncation on this model).
+        self._dim = dimensions_override if dimensions_override is not None else 1536
+
+    @property
+    def dimensions(self) -> int:
+        return self._dim
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def embed_batch(self, texts: tuple[str, ...]) -> tuple[EmbeddingResult, ...]:
+        if not texts:
+            return ()
+
+        kwargs: dict[str, Any] = {"model": self._model, "input": list(texts)}
+        if self._dimensions_override is not None:
+            kwargs["dimensions"] = self._dimensions_override
+
+        response = await self._client.embeddings.create(**kwargs)
+
+        results: list[EmbeddingResult] = []
+        for text, item in zip(texts, response.data, strict=True):
+            vector = tuple(float(x) for x in item.embedding)
+            results.append(
+                EmbeddingResult(
+                    text_hash=hash_text(text),
+                    vector=vector,
+                    dimensions=len(vector),
+                    provider_name=self.name,
+                )
+            )
+        return tuple(results)
+
+
+def cosine_similarity(a: tuple[float, ...], b: tuple[float, ...]) -> float:
+    """Cosine similarity in ``[-1, 1]``. Zero-length vectors → 0.
+
+    Raises ``ValueError`` if the two vectors differ in dimension — that's
+    always a bug, never something the caller wants to silently paper over.
+    """
+    if len(a) != len(b):
+        raise ValueError(f"cosine_similarity: dimension mismatch ({len(a)} vs {len(b)})")
+    if not a:
+        return 0.0
+
+    dot = 0.0
+    norm_a = 0.0
+    norm_b = 0.0
+    for x, y in zip(a, b, strict=True):
+        dot += x * y
+        norm_a += x * x
+        norm_b += y * y
+
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (math.sqrt(norm_a) * math.sqrt(norm_b))
+
+
+def rerank(
+    candidates: tuple[tuple[str, float], ...],
+    *,
+    query_vec: tuple[float, ...],
+    candidate_vecs: tuple[tuple[float, ...], ...],
+    fts_weight: float = 0.3,
+    embedding_weight: float = 0.7,
+) -> tuple[int, ...]:
+    """Return indices into ``candidates`` sorted by hybrid score (descending).
+
+    Hybrid = ``fts_weight * fts_norm + embedding_weight * cosine``, where
+    ``fts_norm`` linearly rescales the candidate FTS scores into ``[0, 1]``
+    (so the two components are on the same footing regardless of BM25's raw
+    magnitude).
+
+    Design-by-contract:
+
+    * ``fts_weight`` and ``embedding_weight`` must be non-negative.
+    * Their sum must be strictly positive — a zero-weight rerank is a no-op
+      disguised as a scoring call, almost always a bug.
+    * ``candidates`` and ``candidate_vecs`` must be the same length.
+    """
+    require(fts_weight >= 0.0, "rerank: fts_weight must be non-negative")
+    require(embedding_weight >= 0.0, "rerank: embedding_weight must be non-negative")
+    require(
+        fts_weight + embedding_weight > 0.0,
+        "rerank: fts_weight + embedding_weight must be > 0",
+    )
+    require(
+        len(candidates) == len(candidate_vecs),
+        "rerank: candidates and candidate_vecs must be the same length",
+    )
+
+    if not candidates:
+        return ()
+
+    fts_scores = [score for _, score in candidates]
+    lo = min(fts_scores)
+    hi = max(fts_scores)
+    span = hi - lo
+    if span > 0.0:  # noqa: SIM108 — keep explanatory comment on the else branch
+        fts_norm = [(s - lo) / span for s in fts_scores]
+    else:
+        # All equal → FTS contributes no ranking signal; zero it so embedding
+        # weight alone decides order (stable on ties).
+        fts_norm = [0.0 for _ in fts_scores]
+
+    scored: list[tuple[float, int]] = []
+    for idx, vec in enumerate(candidate_vecs):
+        cos = cosine_similarity(query_vec, vec)
+        blended = fts_weight * fts_norm[idx] + embedding_weight * cos
+        scored.append((blended, idx))
+
+    # Python's sort is stable — ties preserve the input order so repeated
+    # scores map to ascending indices, which is what tests assert.
+    scored.sort(key=lambda sv: (-sv[0], sv[1]))
+    return tuple(idx for _, idx in scored)
+
+
+_CACHE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS embedding_cache (
+    provider TEXT NOT NULL,
+    text_hash TEXT NOT NULL,
+    vector BLOB NOT NULL,
+    dimensions INTEGER NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (provider, text_hash)
+);
+CREATE INDEX IF NOT EXISTS idx_embedding_cache_created_at
+    ON embedding_cache(created_at);
+"""
+
+
+class EmbeddingCache:
+    """SQLite-backed cache keyed by ``(provider_name, text_hash)``.
+
+    Same connection-per-call pattern as :class:`CostLedger` — callers need
+    only one ``EmbeddingCache`` per process, and the lock serialises writes
+    so WAL-mode readers never see a half-populated row.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self._path = Path(db_path).expanduser()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        with self._connect() as conn:
+            conn.executescript(_CACHE_SCHEMA)
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self._path, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def get(self, *, provider: str, text_hash: str) -> tuple[float, ...] | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT vector, dimensions FROM embedding_cache
+                WHERE provider = ? AND text_hash = ?
+                """,
+                (provider, text_hash),
+            ).fetchone()
+        if row is None:
+            return None
+        return _decode_vector(row["vector"], row["dimensions"])
+
+    def put(self, result: EmbeddingResult) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        blob = _encode_vector(result.vector)
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO embedding_cache
+                    (provider, text_hash, vector, dimensions, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(provider, text_hash) DO UPDATE SET
+                    vector = excluded.vector,
+                    dimensions = excluded.dimensions,
+                    created_at = excluded.created_at
+                """,
+                (
+                    result.provider_name,
+                    result.text_hash,
+                    blob,
+                    result.dimensions,
+                    now,
+                ),
+            )
+
+    def prune_older_than(self, cutoff_ts: datetime) -> int:
+        with self._lock, self._connect() as conn:
+            cursor = conn.execute(
+                "DELETE FROM embedding_cache WHERE created_at < ?",
+                (cutoff_ts.isoformat(),),
+            )
+            return cursor.rowcount or 0
+
+
+def _encode_vector(vector: tuple[float, ...]) -> bytes:
+    # Little-endian float64 — portable and avoids numpy as a dependency.
+    import struct
+
+    return struct.pack(f"<{len(vector)}d", *vector)
+
+
+def _decode_vector(blob: bytes, dimensions: int) -> tuple[float, ...]:
+    import struct
+
+    return tuple(struct.unpack(f"<{dimensions}d", blob))

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -1,0 +1,355 @@
+"""Semantic embedding primitives for episodic memory retrieval."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from maxwell_daemon.backends.base import BackendUnavailableError
+from maxwell_daemon.contracts import PreconditionError
+from maxwell_daemon.memory.embeddings import (
+    EmbeddingCache,
+    EmbeddingResult,
+    OpenAIEmbeddingProvider,
+    StubEmbeddingProvider,
+    cosine_similarity,
+    hash_text,
+    rerank,
+)
+
+
+def _run(coro: Any) -> Any:
+    """Tiny sync bridge so tests don't each need a pytest-asyncio marker."""
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# StubEmbeddingProvider
+# ---------------------------------------------------------------------------
+
+
+class TestStubProvider:
+    def test_rejects_tiny_dimensions(self) -> None:
+        with pytest.raises(PreconditionError):
+            StubEmbeddingProvider(dimensions=8)
+
+    def test_accepts_minimum_dimensions(self) -> None:
+        provider = StubEmbeddingProvider(dimensions=16)
+        assert provider.dimensions == 16
+
+    def test_batch_count_matches_input(self) -> None:
+        provider = StubEmbeddingProvider(dimensions=32)
+        out = _run(provider.embed_batch(("one", "two", "three")))
+        assert len(out) == 3
+
+    def test_each_vector_has_requested_dimensions(self) -> None:
+        provider = StubEmbeddingProvider(dimensions=48)
+        out = _run(provider.embed_batch(("hello",)))
+        assert len(out[0].vector) == 48
+        assert out[0].dimensions == 48
+
+    def test_deterministic_same_text_same_vector(self) -> None:
+        provider = StubEmbeddingProvider(dimensions=32)
+        a = _run(provider.embed_batch(("the parser broke",)))
+        b = _run(provider.embed_batch(("the parser broke",)))
+        assert a[0].vector == b[0].vector
+
+    def test_different_texts_different_vectors(self) -> None:
+        provider = StubEmbeddingProvider(dimensions=32)
+        out = _run(provider.embed_batch(("alpha", "beta")))
+        assert out[0].vector != out[1].vector
+
+    def test_text_hash_is_sha256_prefix(self) -> None:
+        provider = StubEmbeddingProvider(dimensions=32)
+        text = "hash me please"
+        out = _run(provider.embed_batch((text,)))
+        expected = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+        assert out[0].text_hash == expected == hash_text(text)
+
+    def test_empty_batch_returns_empty(self) -> None:
+        provider = StubEmbeddingProvider(dimensions=32)
+        assert _run(provider.embed_batch(())) == ()
+
+    def test_provider_name_stamped(self) -> None:
+        provider = StubEmbeddingProvider(dimensions=32)
+        out = _run(provider.embed_batch(("x",)))
+        assert out[0].provider_name == "stub"
+
+
+# ---------------------------------------------------------------------------
+# OpenAIEmbeddingProvider
+# ---------------------------------------------------------------------------
+
+
+class _FakeEmbeddingItem:
+    def __init__(self, embedding: list[float]) -> None:
+        self.embedding = embedding
+
+
+class _FakeEmbeddingResponse:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self.data = [_FakeEmbeddingItem(v) for v in vectors]
+
+
+class _FakeEmbeddings:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self._vectors = vectors
+        self.create = AsyncMock(return_value=_FakeEmbeddingResponse(vectors))
+
+
+class _FakeClient:
+    def __init__(self, vectors: list[list[float]]) -> None:
+        self.embeddings = _FakeEmbeddings(vectors)
+
+
+class TestOpenAIProvider:
+    def test_pulls_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        # Don't inject — force the constructor to hit the env path. It will
+        # build a real openai.AsyncOpenAI with that key but never call it.
+        provider = OpenAIEmbeddingProvider()
+        assert provider.name == "openai"
+        assert provider.model == "text-embedding-3-small"
+
+    def test_raises_when_no_key_and_no_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with pytest.raises(BackendUnavailableError):
+            OpenAIEmbeddingProvider()
+
+    def test_embed_batch_calls_injected_client(self) -> None:
+        client = _FakeClient([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
+        provider = OpenAIEmbeddingProvider(http_client=client, model="test-model")
+        out = _run(provider.embed_batch(("alpha", "beta")))
+        client.embeddings.create.assert_awaited_once_with(
+            model="test-model", input=["alpha", "beta"]
+        )
+        assert len(out) == 2
+
+    def test_response_parsed_into_embedding_results(self) -> None:
+        client = _FakeClient([[0.5, 0.5, 0.5]])
+        provider = OpenAIEmbeddingProvider(http_client=client)
+        (result,) = _run(provider.embed_batch(("only",)))
+        assert isinstance(result, EmbeddingResult)
+        assert result.vector == (0.5, 0.5, 0.5)
+        assert result.dimensions == 3
+        assert result.provider_name == "openai"
+        assert result.text_hash == hash_text("only")
+
+    def test_dimensions_override_forwarded(self) -> None:
+        client = _FakeClient([[0.0] * 256])
+        provider = OpenAIEmbeddingProvider(http_client=client, dimensions_override=256)
+        _run(provider.embed_batch(("x",)))
+        call_kwargs = client.embeddings.create.await_args.kwargs
+        assert call_kwargs["dimensions"] == 256
+        assert provider.dimensions == 256
+
+    def test_no_dimensions_kwarg_when_not_overridden(self) -> None:
+        client = _FakeClient([[0.0] * 3])
+        provider = OpenAIEmbeddingProvider(http_client=client)
+        _run(provider.embed_batch(("x",)))
+        call_kwargs = client.embeddings.create.await_args.kwargs
+        assert "dimensions" not in call_kwargs
+
+    def test_empty_batch_short_circuits(self) -> None:
+        client = _FakeClient([])
+        provider = OpenAIEmbeddingProvider(http_client=client)
+        assert _run(provider.embed_batch(())) == ()
+        client.embeddings.create.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# cosine_similarity
+# ---------------------------------------------------------------------------
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors(self) -> None:
+        v = (1.0, 2.0, 3.0)
+        assert cosine_similarity(v, v) == pytest.approx(1.0)
+
+    def test_opposite_vectors(self) -> None:
+        a = (1.0, 2.0, 3.0)
+        b = (-1.0, -2.0, -3.0)
+        assert cosine_similarity(a, b) == pytest.approx(-1.0)
+
+    def test_orthogonal_vectors(self) -> None:
+        a = (1.0, 0.0, 0.0)
+        b = (0.0, 1.0, 0.0)
+        assert cosine_similarity(a, b) == pytest.approx(0.0)
+
+    def test_zero_vector_returns_zero_not_nan(self) -> None:
+        zero = (0.0, 0.0, 0.0)
+        some = (1.0, 2.0, 3.0)
+        assert cosine_similarity(zero, some) == 0.0
+        assert cosine_similarity(some, zero) == 0.0
+
+    def test_mismatched_dimensions_raise(self) -> None:
+        with pytest.raises(ValueError):
+            cosine_similarity((1.0, 2.0), (1.0, 2.0, 3.0))
+
+
+# ---------------------------------------------------------------------------
+# rerank
+# ---------------------------------------------------------------------------
+
+
+class TestRerank:
+    def test_stable_index_order_on_ties(self) -> None:
+        candidates = (("a", 0.5), ("b", 0.5), ("c", 0.5))
+        vec = (1.0, 0.0)
+        vecs = ((1.0, 0.0), (1.0, 0.0), (1.0, 0.0))
+        assert rerank(candidates, query_vec=vec, candidate_vecs=vecs) == (0, 1, 2)
+
+    def test_pure_embedding_weight_ignores_fts(self) -> None:
+        # FTS would rank 0 > 1 > 2; embedding similarity should flip it.
+        candidates = (("a", 10.0), ("b", 5.0), ("c", 0.0))
+        query = (1.0, 0.0)
+        vecs = (
+            (-1.0, 0.0),  # cosine = -1
+            (0.0, 1.0),  # cosine = 0
+            (1.0, 0.0),  # cosine = +1
+        )
+        assert rerank(
+            candidates,
+            query_vec=query,
+            candidate_vecs=vecs,
+            fts_weight=0.0,
+            embedding_weight=1.0,
+        ) == (2, 1, 0)
+
+    def test_pure_fts_weight_ignores_embedding(self) -> None:
+        candidates = (("a", 0.1), ("b", 0.9), ("c", 0.5))
+        query = (1.0, 0.0)
+        # All embeddings identical — only FTS decides.
+        vecs = ((1.0, 0.0), (1.0, 0.0), (1.0, 0.0))
+        assert rerank(
+            candidates,
+            query_vec=query,
+            candidate_vecs=vecs,
+            fts_weight=1.0,
+            embedding_weight=0.0,
+        ) == (1, 2, 0)
+
+    def test_zero_weight_sum_rejected(self) -> None:
+        with pytest.raises(PreconditionError):
+            rerank(
+                (("a", 1.0),),
+                query_vec=(1.0,),
+                candidate_vecs=((1.0,),),
+                fts_weight=0.0,
+                embedding_weight=0.0,
+            )
+
+    def test_negative_weight_rejected(self) -> None:
+        with pytest.raises(PreconditionError):
+            rerank(
+                (("a", 1.0),),
+                query_vec=(1.0,),
+                candidate_vecs=((1.0,),),
+                fts_weight=-0.1,
+                embedding_weight=1.0,
+            )
+
+    def test_top_result_has_highest_blended_score(self) -> None:
+        candidates = (("poor-fts-great-emb", 0.0), ("great-fts-poor-emb", 1.0))
+        query = (1.0, 0.0)
+        vecs = (
+            (1.0, 0.0),  # cosine = 1.0
+            (-1.0, 0.0),  # cosine = -1.0
+        )
+        # Embedding weight dominates → index 0 wins.
+        result = rerank(
+            candidates,
+            query_vec=query,
+            candidate_vecs=vecs,
+            fts_weight=0.3,
+            embedding_weight=0.7,
+        )
+        assert result[0] == 0
+
+    def test_empty_candidates_returns_empty(self) -> None:
+        assert rerank((), query_vec=(1.0,), candidate_vecs=()) == ()
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingCache
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingCache:
+    @pytest.fixture
+    def cache(self, tmp_path: Path) -> EmbeddingCache:
+        return EmbeddingCache(tmp_path / "emb.db")
+
+    def _result(
+        self,
+        *,
+        provider: str = "stub",
+        text: str = "hello",
+        vector: tuple[float, ...] = (0.1, 0.2, 0.3),
+    ) -> EmbeddingResult:
+        return EmbeddingResult(
+            text_hash=hash_text(text),
+            vector=vector,
+            dimensions=len(vector),
+            provider_name=provider,
+        )
+
+    def test_miss_returns_none(self, cache: EmbeddingCache) -> None:
+        assert cache.get(provider="stub", text_hash="deadbeefdeadbeef") is None
+
+    def test_roundtrip(self, cache: EmbeddingCache) -> None:
+        result = self._result(vector=(0.1, 0.2, 0.3, 0.4))
+        cache.put(result)
+        got = cache.get(provider="stub", text_hash=result.text_hash)
+        assert got is not None
+        assert len(got) == 4
+        for a, b in zip(got, (0.1, 0.2, 0.3, 0.4), strict=True):
+            assert a == pytest.approx(b)
+
+    def test_providers_isolated(self, cache: EmbeddingCache) -> None:
+        stub = self._result(provider="stub", vector=(1.0, 0.0))
+        openai = EmbeddingResult(
+            text_hash=stub.text_hash,
+            vector=(0.0, 1.0),
+            dimensions=2,
+            provider_name="openai",
+        )
+        cache.put(stub)
+        cache.put(openai)
+        assert cache.get(provider="stub", text_hash=stub.text_hash) == (1.0, 0.0)
+        assert cache.get(provider="openai", text_hash=stub.text_hash) == (0.0, 1.0)
+
+    def test_prune_older_than_removes_and_counts(
+        self, cache: EmbeddingCache, tmp_path: Path
+    ) -> None:
+        # Insert a row with a fabricated old timestamp by writing directly.
+        result = self._result()
+        cache.put(result)
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+        import sqlite3
+
+        conn = sqlite3.connect(tmp_path / "emb.db")
+        conn.execute(
+            "UPDATE embedding_cache SET created_at = ? WHERE text_hash = ?",
+            (old_ts, result.text_hash),
+        )
+        conn.commit()
+        conn.close()
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+        removed = cache.prune_older_than(cutoff)
+        assert removed == 1
+        assert cache.get(provider="stub", text_hash=result.text_hash) is None
+
+    def test_prune_leaves_fresh_rows(self, cache: EmbeddingCache) -> None:
+        cache.put(self._result())
+        cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+        assert cache.prune_older_than(cutoff) == 0


### PR DESCRIPTION
Primitives for semantic search over episodic memory. Two providers (deterministic stub + OpenAI), cosine similarity, hybrid FTS+embedding re-rank, SQLite cache. Integration into `EpisodicStore` is a follow-up — this PR ships the building blocks.

- `StubEmbeddingProvider` — deterministic local: sha256-streamed blocks → L2-normalised unit vectors. Same text, same vector, across processes. Zero deps.
- `OpenAIEmbeddingProvider` — lazy imports `openai.AsyncOpenAI`; duck-typed `http_client` so tests don't touch the network.
- `cosine_similarity` returns 0 (not NaN) on zero vectors; mismatched dims → `ValueError`.
- `rerank(candidates, query_vec, candidate_vecs, fts_weight, embedding_weight)` — DbC rejects negative weights / zero sum.
- `EmbeddingCache` — SQLite, keyed by `(provider, text_hash)`, same per-call connection pattern as `CostLedger`.

**33 new tests, all green.** `ruff` + `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)