### PR TITLE
fix: address 3 of 9 nice-to-have findings from adversarial review (#119)

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -302,7 +302,11 @@ def create_app(
         if payload.dispatch:
             import re
 
-            match = re.search(r"/issues/(\d+)", url)
+            # Anchor to end-of-string so we only match the trailing issue
+            # number that ``gh issue create`` actually returns (one URL per
+            # line), not an ``/issues/NN`` fragment that happens to appear in
+            # the issue body or in a repo slug like ``org/x-issues``.
+            match = re.search(r"/issues/(\d+)/?\s*$", url.strip())
             if match:
                 number = int(match.group(1))
                 task = daemon.submit_issue(

--- a/maxwell_daemon/gh/executor.py
+++ b/maxwell_daemon/gh/executor.py
@@ -15,6 +15,7 @@ Modes:
 from __future__ import annotations
 
 import json
+import os
 import re
 import tempfile
 from dataclasses import dataclass
@@ -353,9 +354,12 @@ class IssueExecutor:
             except TypeError:
                 # Legacy stub without task_id
                 return self._ws.path_for(repo)
+        # Namespace fallback paths by PID so parallel pytest workers
+        # (pytest-xdist) that hit the stub-workspace branch don't clobber
+        # each other's checkouts under a shared /tmp/maxwell-daemon-workspace.
         return (
             Path(tempfile.gettempdir())
-            / "maxwell-daemon-workspace"
+            / f"maxwell-daemon-workspace-{os.getpid()}"
             / repo.split("/", 1)[1]
             / (task_id or "test")
         )

--- a/maxwell_daemon/metrics.py
+++ b/maxwell_daemon/metrics.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI, Response
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, generate_latest
 
 __all__ = [
+    "MAXWELL_FREE_REQUESTS_TOTAL",
     "MAXWELL_REQUESTS_TOTAL",
     "MAXWELL_REQUEST_COST",
     "MAXWELL_REQUEST_DURATION",
@@ -43,6 +44,17 @@ MAXWELL_REQUEST_COST = Counter(
     labelnames=("backend", "model"),
 )
 
+MAXWELL_FREE_REQUESTS_TOTAL = Counter(
+    "maxwell_daemon_free_requests_total",
+    (
+        "Successful requests with zero billed cost "
+        "(e.g. local Ollama or cached provider hits). "
+        "Complements maxwell_daemon_request_cost_usd_total so dashboards can "
+        "distinguish 'never ran' from 'ran many free requests'."
+    ),
+    labelnames=("backend", "model"),
+)
+
 MAXWELL_COST_FORECAST_USD = Gauge(
     "maxwell_daemon_cost_forecast_usd",
     "Linear month-end spend forecast from the cost ledger",
@@ -68,7 +80,10 @@ def record_request(
     """Emit all per-request metrics in one call.
 
     Token and cost metrics are only incremented when status == "success" so that
-    failed/rejected requests don't pollute spend dashboards.
+    failed/rejected requests don't pollute spend dashboards. Zero-cost
+    successes (free-tier Ollama, cached hits) are counted separately via
+    ``MAXWELL_FREE_REQUESTS_TOTAL`` so dashboards can distinguish "never ran"
+    from "ran many free requests".
     """
     MAXWELL_REQUESTS_TOTAL.labels(backend=backend, model=model, status=status).inc()
     if status == "success":
@@ -76,6 +91,8 @@ def record_request(
             MAXWELL_TOKENS_TOTAL.labels(backend=backend, model=model).inc(tokens)
         if cost_usd > 0:
             MAXWELL_REQUEST_COST.labels(backend=backend, model=model).inc(cost_usd)
+        else:
+            MAXWELL_FREE_REQUESTS_TOTAL.labels(backend=backend, model=model).inc()
         if duration_seconds > 0:
             MAXWELL_REQUEST_DURATION.labels(backend=backend, model=model).observe(duration_seconds)
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -6,6 +6,8 @@ from fastapi.testclient import TestClient
 from prometheus_client import CollectorRegistry
 
 from maxwell_daemon.metrics import (
+    MAXWELL_FREE_REQUESTS_TOTAL,
+    MAXWELL_REQUEST_COST,
     MAXWELL_REQUESTS_TOTAL,
     MAXWELL_TOKENS_TOTAL,
     build_registry,
@@ -44,6 +46,41 @@ class TestRecordRequest:
         )
         after = MAXWELL_TOKENS_TOTAL.labels(backend="claude", model="m")._value.get()
         assert after == before + 500
+
+    def test_free_request_increments_free_counter_not_cost(self) -> None:
+        # A zero-cost success (local Ollama, cached hit) should bump the
+        # free-requests counter while leaving the USD cost counter flat.
+        free_before = MAXWELL_FREE_REQUESTS_TOTAL.labels(
+            backend="ollama", model="llama3"
+        )._value.get()
+        cost_before = MAXWELL_REQUEST_COST.labels(backend="ollama", model="llama3")._value.get()
+        record_request(
+            backend="ollama",
+            model="llama3",
+            status="success",
+            tokens=10,
+            cost_usd=0.0,
+            duration_seconds=0.1,
+        )
+        free_after = MAXWELL_FREE_REQUESTS_TOTAL.labels(
+            backend="ollama", model="llama3"
+        )._value.get()
+        cost_after = MAXWELL_REQUEST_COST.labels(backend="ollama", model="llama3")._value.get()
+        assert free_after == free_before + 1
+        assert cost_after == cost_before
+
+    def test_priced_request_does_not_increment_free_counter(self) -> None:
+        free_before = MAXWELL_FREE_REQUESTS_TOTAL.labels(backend="claude", model="m")._value.get()
+        record_request(
+            backend="claude",
+            model="m",
+            status="success",
+            tokens=10,
+            cost_usd=0.02,
+            duration_seconds=0.1,
+        )
+        free_after = MAXWELL_FREE_REQUESTS_TOTAL.labels(backend="claude", model="m")._value.get()
+        assert free_after == free_before
 
     def test_error_status_skips_token_and_cost(self) -> None:
         # Error path still bumps the request counter but not tokens/cost.


### PR DESCRIPTION
## Summary
Partial fix for #119 — addresses 3 of the 9 nice-to-have findings from the adversarial review. Each was chosen as a <30-minute, self-contained polish item.

### Addressed (3/9)
- **#29 — Tempfile fallback in executor.** `_workspace_path` fallback is now namespaced by PID (`maxwell-daemon-workspace-{pid}/...`) so parallel pytest workers (xdist) exercising the stub-workspace branch can't collide on a shared `/tmp` directory.
- **#30 — Issue URL regex too greedy.** `create_issue` dispatch now uses an end-of-string-anchored regex (`/issues/(\d+)/?\s*$`) so an `/issues/NN` fragment in an issue body or a repo slug like `org/x-issues` can't be mistaken for the actual number returned by `gh issue create`.
- **#31 — Cost counter drops 0.0 samples.** New `maxwell_daemon_free_requests_total{backend,model}` counter tracks zero-cost successes (local Ollama, cached hits). Dashboards can now distinguish "never ran" from "ran many free requests" instead of silently dropping the free-tier samples.

### Remaining (6/9, tracked in #119)
- #28 SQLite connection-per-write (memory/episodic.py) — needs pooling design.
- #32 Webhook URL regex (same class as #30, different call site) — worth doing after #30 lands.
- #33 `Daemon.stop(drain=True)` cancellation window — needs `asyncio.shield` around the commit/PR-push tail; touches concurrency contracts.
- #34 Test flakes from shared `/tmp` — will be mostly mitigated once #29 lands here; remainder is a `tmp_path` fixture sweep.
- #35 Recipe/spec `version` migration story — design discussion, not a code change.

(Original list numbers 28–35 = 8 items; the issue title says "9 findings"; the 9th appears to be the implicit "bundle these into a single polish milestone" action item. No change is implied.)

## Test plan
- [x] `ruff check .` — clean
- [x] `ruff format --check` — clean for touched files (one unrelated pre-existing `tests/bdd/test_login.py` left alone)
- [x] `mypy` — clean for touched files
- [x] `pytest tests/unit/test_metrics.py` — 8 passed (2 new tests for free-counter split)
- [x] Full `pytest tests/unit` delta: +2 passing, 0 new failures (179 pre-existing failures unchanged from main)

spec-exempt: polish-only; no user-visible behavior change beyond the new metric and a tightened regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
