### PR TITLE
🎨 Palette: Add ARIA labels for UI accessibility

### DIFF
--- a/maxwell_daemon/api/ui/index.html
+++ b/maxwell_daemon/api/ui/index.html
@@ -21,7 +21,7 @@
       <div class="card-head">
         <h2>Tasks</h2>
         <div class="filters">
-          <select id="status-filter">
+          <select id="status-filter" aria-label="Filter tasks by status">
             <option value="">all</option>
             <option value="queued">queued</option>
             <option value="running">running</option>
@@ -51,7 +51,7 @@
     <section class="card" id="detail-card" hidden>
       <div class="card-head">
         <h2 id="detail-title">Task detail</h2>
-        <button id="detail-close">×</button>
+        <button id="detail-close" aria-label="Close task details" title="Close">×</button>
       </div>
       <dl id="detail-fields"></dl>
       <h3>Output</h3>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the status filter dropdown and the task detail close button. Also added a `title` attribute to the close button for visual tooltip feedback.

🎯 Why: To improve keyboard and screen reader accessibility. Previously, the select element lacked an associated label, and the icon-only close button ("×") was not meaningfully announced by screen readers.

📸 Before/After: The changes are purely structural (accessibility attributes) and do not affect the visual layout, though a tooltip now appears when hovering over the close button.

♿ Accessibility: Ensures that screen reader users can understand the purpose of the status filter dropdown and the close button.

---
*PR created automatically by Jules for task [3499235583839834102](https://jules.google.com/task/3499235583839834102) started by @dieterolson*