### PR TITLE
feat(ui): implement 7-view dashboard (issue #6)

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -416,6 +416,73 @@ def create_app(
             for i in issues
         ]
 
+    @app.get("/api/v1/fleet", dependencies=[Depends(auth)])
+    async def fleet_overview() -> dict[str, Any]:
+        """Return fleet manifest data merged with live task counts per repo."""
+        import os
+
+        import yaml
+
+        candidates = [
+            os.environ.get("MAXWELL_FLEET_CONFIG") or "",
+            "./fleet.yaml",
+            str(_Path.home() / ".maxwell-daemon" / "fleet.yaml"),
+        ]
+        raw: dict[str, Any] = {}
+        for path in candidates:
+            if path:
+                p = _Path(path)
+                if p.is_file():
+                    with p.open() as fh:
+                        raw = yaml.safe_load(fh) or {}
+                    break
+
+        fleet_section: dict[str, Any] = raw.get("fleet", {})
+        repos_raw: list[dict[str, Any]] = raw.get("repos", [])
+
+        default_slots: int = fleet_section.get("default_slots", 2)
+        default_budget: float = fleet_section.get("default_budget_per_story", 0.50)
+        default_branch: str = fleet_section.get("default_pr_target_branch", "staging")
+        default_labels: list[str] = fleet_section.get("default_watch_labels", [])
+
+        tasks = list(daemon.state().tasks.values())
+        active_by_repo: dict[str, int] = {}
+        cost_by_repo: dict[str, float] = {}
+        for t in tasks:
+            repo_name = (t.issue_repo or "").split("/")[-1] or t.repo or ""
+            if not repo_name:
+                continue
+            if t.status.value in ("queued", "running"):
+                active_by_repo[repo_name] = active_by_repo.get(repo_name, 0) + 1
+            cost_by_repo[repo_name] = cost_by_repo.get(repo_name, 0.0) + t.cost_usd
+
+        repos: list[dict[str, Any]] = []
+        for r in repos_raw:
+            name: str = r.get("name", "")
+            org: str = r.get("org", "")
+            repos.append(
+                {
+                    "name": name,
+                    "org": org,
+                    "github_url": f"https://github.com/{org}/{name}" if org and name else None,
+                    "slots": r.get("slots", default_slots),
+                    "budget_per_story": r.get("budget_per_story", default_budget),
+                    "pr_target_branch": r.get("pr_target_branch", default_branch),
+                    "watch_labels": r.get("watch_labels", default_labels),
+                    "active_tasks": active_by_repo.get(name, 0),
+                    "total_cost_usd": round(cost_by_repo.get(name, 0.0), 6),
+                }
+            )
+
+        return {
+            "fleet": {
+                "name": fleet_section.get("name", ""),
+                "auto_promote_staging": fleet_section.get("auto_promote_staging", False),
+                "discovery_interval_seconds": fleet_section.get("discovery_interval_seconds", 300),
+            },
+            "repos": repos,
+        }
+
     @app.get("/api/v1/cost", dependencies=[Depends(auth)])
     async def cost_summary() -> CostSummary:
         now = datetime.now(timezone.utc)

--- a/maxwell_daemon/api/ui/app.js
+++ b/maxwell_daemon/api/ui/app.js
@@ -10,7 +10,55 @@ const state = {
   tasks: new Map(),           // id -> task object
   selected: null,             // currently-shown task id
   testOutput: new Map(),      // task id -> accumulated text
+  monitorLines: [],           // raw event lines (capped at 500)
+  debugEvents: [],            // raw JSON events for debug view (capped at 200)
+  currentView: "tasks",       // active tab
 };
+
+// ---- helpers ---------------------------------------------------------------
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  }[c]));
+}
+
+function fmtUsd(n) { return `$${(n || 0).toFixed(4)}`; }
+function fmtUsdShort(n) { return `$${(n || 0).toFixed(2)}`; }
+
+function fmtTs(iso) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, { dateStyle: "short", timeStyle: "medium" });
+}
+
+function fmtTsShort(iso) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, { timeStyle: "short" });
+}
+
+// ---- tab navigation --------------------------------------------------------
+
+function switchView(name) {
+  state.currentView = name;
+  document.querySelectorAll(".tab").forEach((btn) => {
+    const active = btn.dataset.view === name;
+    btn.classList.toggle("active", active);
+    btn.setAttribute("aria-selected", String(active));
+  });
+  document.querySelectorAll(".view").forEach((el) => {
+    const active = el.id === `view-${name}`;
+    el.hidden = !active;
+    el.classList.toggle("active", active);
+  });
+
+  // Lazy-load view data
+  if (name === "fleet") fetchFleet().catch(console.error);
+  if (name === "cost") fetchCostDetail().catch(console.error);
+  if (name === "history") renderHistory();
+  if (name === "repos") fetchFleet().catch(console.error);  // repos uses same data
+}
 
 // ---- data fetching ---------------------------------------------------------
 
@@ -25,6 +73,8 @@ async function fetchTasks() {
   state.tasks.clear();
   for (const t of list) state.tasks.set(t.id, t);
   renderTasks();
+  if (state.currentView === "history") renderHistory();
+  if (state.currentView === "cost") renderCostTasks();
 }
 
 async function fetchBackends() {
@@ -45,7 +95,147 @@ async function fetchCost() {
   if (!r.ok) return;
   const body = await r.json();
   const el = document.getElementById("cost-summary");
-  el.textContent = `MTD $${body.month_to_date_usd.toFixed(2)}`;
+  el.textContent = `MTD ${fmtUsdShort(body.month_to_date_usd)}`;
+  return body;
+}
+
+async function fetchCostDetail() {
+  const body = await fetchCost();
+  if (!body) return;
+
+  const detailEl = document.getElementById("cost-summary-detail");
+  const byBackend = body.by_backend || {};
+  const total = body.month_to_date_usd || 0;
+  const taskCount = [...state.tasks.values()].length;
+  const avgCost = taskCount > 0
+    ? [...state.tasks.values()].reduce((s, t) => s + (t.cost_usd || 0), 0) / taskCount
+    : 0;
+
+  detailEl.innerHTML = `
+    <div class="cost-stat">
+      <span class="value">${fmtUsdShort(total)}</span>
+      <span class="label">Month-to-Date</span>
+    </div>
+    <div class="cost-stat">
+      <span class="value">${fmtUsd(avgCost)}</span>
+      <span class="label">Avg per Task</span>
+    </div>
+    <div class="cost-stat">
+      <span class="value">${taskCount}</span>
+      <span class="label">Total Tasks</span>
+    </div>
+  `;
+
+  const tbody = document.getElementById("cost-backend-body");
+  tbody.innerHTML = "";
+  const entries = Object.entries(byBackend).sort((a, b) => b[1] - a[1]);
+  if (entries.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="2" style="color:var(--muted)">No data yet</td></tr>`;
+  }
+  for (const [backend, cost] of entries) {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `<td>${escapeHtml(backend)}</td><td>${fmtUsdShort(cost)}</td>`;
+    tbody.appendChild(tr);
+  }
+
+  renderCostTasks();
+}
+
+function renderCostTasks() {
+  const tbody = document.getElementById("cost-task-body");
+  if (!tbody) return;
+  tbody.innerHTML = "";
+  const sorted = [...state.tasks.values()]
+    .filter((t) => (t.cost_usd || 0) > 0)
+    .sort((a, b) => (b.cost_usd || 0) - (a.cost_usd || 0))
+    .slice(0, 20);
+  if (sorted.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="5" style="color:var(--muted)">No cost data yet</td></tr>`;
+    return;
+  }
+  for (const t of sorted) {
+    const target = t.issue_repo ? `${t.issue_repo}#${t.issue_number}` : (t.prompt || "").slice(0, 50);
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${escapeHtml(t.id)}</td>
+      <td>${escapeHtml(target)}</td>
+      <td>${escapeHtml(t.backend || "—")}</td>
+      <td><span class="status-${t.status}">${escapeHtml(t.status)}</span></td>
+      <td>${fmtUsd(t.cost_usd)}</td>
+    `;
+    tbody.appendChild(tr);
+  }
+}
+
+let _fleetData = null;
+
+async function fetchFleet() {
+  const r = await fetch("/api/v1/fleet", { headers: headers() });
+  if (!r.ok) return;
+  _fleetData = await r.json();
+  renderFleet();
+  renderRepos();
+}
+
+function renderFleet() {
+  if (!_fleetData) return;
+  const { fleet, repos } = _fleetData;
+
+  const metaEl = document.getElementById("fleet-meta");
+  metaEl.textContent =
+    `${fleet.name} — discovery every ${fleet.discovery_interval_seconds}s` +
+    (fleet.auto_promote_staging ? " — auto-promote enabled" : "");
+
+  const tbody = document.getElementById("fleet-body");
+  tbody.innerHTML = "";
+  for (const r of repos) {
+    const tr = document.createElement("tr");
+    const ghLink = r.github_url
+      ? `<a href="${escapeHtml(r.github_url)}" target="_blank" rel="noopener">${escapeHtml(r.name)}</a>`
+      : escapeHtml(r.name);
+    const labels = (r.watch_labels || []).map((l) => `<code>${escapeHtml(l)}</code>`).join(" ");
+    const activeCell = r.active_tasks > 0
+      ? `<span class="status-running">${r.active_tasks}</span>`
+      : "0";
+    tr.innerHTML = `
+      <td>${ghLink}</td>
+      <td>${escapeHtml(r.org)}</td>
+      <td>${r.slots}</td>
+      <td>${activeCell}</td>
+      <td>${fmtUsdShort(r.budget_per_story)}</td>
+      <td>${escapeHtml(r.pr_target_branch)}</td>
+      <td>${fmtUsd(r.total_cost_usd)}</td>
+      <td>${labels}</td>
+    `;
+    tbody.appendChild(tr);
+  }
+}
+
+function renderRepos() {
+  if (!_fleetData) return;
+  const grid = document.getElementById("repos-grid");
+  grid.innerHTML = "";
+  for (const r of _fleetData.repos) {
+    const div = document.createElement("div");
+    div.className = "repo-card";
+    const nameHtml = r.github_url
+      ? `<a href="${escapeHtml(r.github_url)}" target="_blank" rel="noopener">${escapeHtml(r.name)}</a>`
+      : escapeHtml(r.name);
+    const activeHtml = r.active_tasks > 0
+      ? `<span class="repo-active">${r.active_tasks} active</span>`
+      : "";
+    div.innerHTML = `
+      <h3>${nameHtml}</h3>
+      <div class="repo-meta">
+        <span>${escapeHtml(r.org)}</span>
+        <span>${r.slots} slot${r.slots !== 1 ? "s" : ""}</span>
+        <span>${fmtUsdShort(r.budget_per_story)}/story</span>
+        <span>→ ${escapeHtml(r.pr_target_branch)}</span>
+        ${activeHtml}
+      </div>
+    `;
+    grid.appendChild(div);
+  }
 }
 
 async function fetchTaskDetail(id) {
@@ -93,12 +283,12 @@ function renderTasks() {
       <td>${t.kind}</td>
       <td><span class="status-${t.status}">${t.status}</span></td>
       <td>${escapeHtml(target)}</td>
-      <td>$${(t.cost_usd || 0).toFixed(4)}</td>
+      <td>${fmtUsd(t.cost_usd)}</td>
       <td>${pr}</td>
       <td>${cancel}</td>
     `;
     tr.addEventListener("click", (ev) => {
-      if (ev.target.dataset.cancel) return;  // handled below
+      if (ev.target.dataset.cancel) return;
       fetchTaskDetail(t.id);
     });
     tbody.appendChild(tr);
@@ -115,8 +305,7 @@ function renderTasks() {
 function renderDetail(task) {
   state.selected = task.id;
   document.getElementById("detail-card").hidden = false;
-  document.getElementById("detail-title").textContent =
-    `Task ${task.id}`;
+  document.getElementById("detail-title").textContent = `Task ${task.id}`;
   const dl = document.getElementById("detail-fields");
   dl.innerHTML = "";
   const fields = [
@@ -139,10 +328,94 @@ function renderDetail(task) {
   out.textContent = state.testOutput.get(task.id) || "(no streamed output)";
 }
 
-function escapeHtml(s) {
-  return String(s).replace(/[&<>"']/g, (c) => ({
-    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
-  }[c]));
+function renderHistory() {
+  const ol = document.getElementById("history-list");
+  if (!ol) return;
+  ol.innerHTML = "";
+  const filterVal = document.getElementById("history-filter")?.value || "";
+  const terminalStatuses = new Set(["completed", "failed", "cancelled"]);
+  const items = [...state.tasks.values()]
+    .filter((t) => {
+      if (filterVal) return t.status === filterVal;
+      return terminalStatuses.has(t.status);
+    })
+    .sort((a, b) => {
+      const aT = a.finished_at || a.created_at;
+      const bT = b.finished_at || b.created_at;
+      return bT.localeCompare(aT);
+    });
+
+  if (items.length === 0) {
+    ol.innerHTML = `<li style="padding:14px;color:var(--muted)">No finished tasks yet.</li>`;
+    return;
+  }
+  for (const t of items) {
+    const li = document.createElement("li");
+    const target = t.issue_repo
+      ? `${t.issue_repo}#${t.issue_number}`
+      : (t.prompt || "").slice(0, 80);
+    const pr = t.pr_url
+      ? ` <a href="${t.pr_url}" target="_blank" rel="noopener">PR ↗</a>`
+      : "";
+    li.innerHTML = `
+      <span class="ts">${escapeHtml(fmtTs(t.finished_at || t.created_at))}</span>
+      <span class="title">
+        <span class="status-${t.status}">${t.status}</span>
+        ${escapeHtml(target)}${pr}
+      </span>
+      <span class="cost">${fmtUsd(t.cost_usd)}</span>
+    `;
+    li.addEventListener("click", () => {
+      switchView("tasks");
+      fetchTaskDetail(t.id);
+    });
+    ol.appendChild(li);
+  }
+}
+
+// ---- monitor view ----------------------------------------------------------
+
+function appendMonitorLine(line) {
+  state.monitorLines.push(line);
+  if (state.monitorLines.length > 500) state.monitorLines.shift();
+
+  if (state.currentView !== "monitor") return;
+  const el = document.getElementById("monitor-log");
+  const filterVal = document.getElementById("monitor-filter")?.value?.toLowerCase() || "";
+  const visible = filterVal
+    ? state.monitorLines.filter((l) => l.toLowerCase().includes(filterVal))
+    : state.monitorLines;
+  el.textContent = visible.join("\n") || "(no matching events)";
+  el.scrollTop = el.scrollHeight;
+}
+
+function refreshMonitorDisplay() {
+  const el = document.getElementById("monitor-log");
+  if (!el) return;
+  const filterVal = document.getElementById("monitor-filter")?.value?.toLowerCase() || "";
+  const visible = filterVal
+    ? state.monitorLines.filter((l) => l.toLowerCase().includes(filterVal))
+    : state.monitorLines;
+  el.textContent = visible.join("\n") || "(waiting for events…)";
+  el.scrollTop = el.scrollHeight;
+}
+
+// ---- debug view ------------------------------------------------------------
+
+function appendDebugEvent(raw) {
+  state.debugEvents.push(raw);
+  if (state.debugEvents.length > 200) state.debugEvents.shift();
+  if (state.currentView !== "debug") return;
+  const el = document.getElementById("debug-log");
+  el.textContent = state.debugEvents.join("\n");
+  el.scrollTop = el.scrollHeight;
+}
+
+function refreshDebugDisplay() {
+  const el = document.getElementById("debug-log");
+  if (!el) return;
+  el.textContent = state.debugEvents.join("\n") || "(no events yet)";
+  el.scrollTop = el.scrollHeight;
 }
 
 // ---- live event stream -----------------------------------------------------
@@ -173,6 +446,9 @@ function openEventStream() {
   ws.addEventListener("message", (ev) => {
     let evt;
     try { evt = JSON.parse(ev.data); } catch { return; }
+    appendDebugEvent(ev.data);
+    const ts = fmtTsShort(new Date().toISOString());
+    appendMonitorLine(`[${ts}] ${evt.kind} ${JSON.stringify(evt.payload || {}).slice(0, 120)}`);
     handleEvent(evt);
   });
 }
@@ -189,7 +465,6 @@ function handleEvent(evt) {
     return;
   }
   if (p.id) {
-    // Any task-lifecycle event triggers a refresh of that task row.
     fetchTaskDetail(p.id).catch(() => {});
     fetchTasks().catch(() => {});
   }
@@ -198,6 +473,12 @@ function handleEvent(evt) {
 // ---- wiring ----------------------------------------------------------------
 
 document.addEventListener("DOMContentLoaded", () => {
+  // Tab navigation
+  document.querySelectorAll(".tab").forEach((btn) => {
+    btn.addEventListener("click", () => switchView(btn.dataset.view));
+  });
+
+  // Tasks view
   document.getElementById("refresh-btn").addEventListener("click", fetchTasks);
   document.getElementById("status-filter").addEventListener("change", fetchTasks);
   document.getElementById("detail-close").addEventListener("click", () => {
@@ -205,6 +486,45 @@ document.addEventListener("DOMContentLoaded", () => {
     state.selected = null;
   });
 
+  // Fleet view
+  document.getElementById("fleet-refresh-btn").addEventListener("click", () => fetchFleet().catch(console.error));
+
+  // Cost view
+  document.getElementById("cost-refresh-btn").addEventListener("click", () => fetchCostDetail().catch(console.error));
+
+  // History view
+  document.getElementById("history-filter").addEventListener("change", renderHistory);
+  document.getElementById("history-refresh-btn").addEventListener("click", () => fetchTasks().catch(console.error));
+
+  // Monitor view
+  document.getElementById("monitor-filter").addEventListener("input", refreshMonitorDisplay);
+  document.getElementById("monitor-clear-btn").addEventListener("click", () => {
+    state.monitorLines.length = 0;
+    document.getElementById("monitor-log").textContent = "(cleared)";
+  });
+
+  // Repos view
+  document.getElementById("repos-refresh-btn").addEventListener("click", () => fetchFleet().catch(console.error));
+
+  // Debug view
+  document.getElementById("debug-clear-btn").addEventListener("click", () => {
+    state.debugEvents.length = 0;
+    document.getElementById("debug-log").textContent = "(cleared)";
+  });
+
+  // Keyboard shortcut: digit keys 1-7 switch tabs
+  document.addEventListener("keydown", (ev) => {
+    const tag = document.activeElement?.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+    const views = ["tasks", "fleet", "cost", "history", "monitor", "repos", "debug"];
+    const idx = parseInt(ev.key, 10) - 1;
+    if (idx >= 0 && idx < views.length) {
+      ev.preventDefault();
+      switchView(views[idx]);
+    }
+  });
+
+  // Initial load
   fetchTasks().catch(console.error);
   fetchBackends().catch(console.error);
   fetchCost().catch(console.error);

--- a/maxwell_daemon/api/ui/index.html
+++ b/maxwell_daemon/api/ui/index.html
@@ -16,7 +16,18 @@
     </div>
   </header>
 
-  <main>
+  <nav class="tab-bar" role="tablist">
+    <button class="tab active" data-view="tasks" role="tab" aria-selected="true">Tasks</button>
+    <button class="tab" data-view="fleet" role="tab" aria-selected="false">Fleet</button>
+    <button class="tab" data-view="cost" role="tab" aria-selected="false">Cost</button>
+    <button class="tab" data-view="history" role="tab" aria-selected="false">History</button>
+    <button class="tab" data-view="monitor" role="tab" aria-selected="false">Monitor</button>
+    <button class="tab" data-view="repos" role="tab" aria-selected="false">Repos</button>
+    <button class="tab" data-view="debug" role="tab" aria-selected="false">Debug</button>
+  </nav>
+
+  <!-- ── Tasks view ─────────────────────────────────────────────────── -->
+  <main id="view-tasks" class="view active">
     <section class="card" id="tasks-card">
       <div class="card-head">
         <h2>Tasks</h2>
@@ -63,6 +74,119 @@
         <h2>Backends</h2>
       </div>
       <ul id="backends-list"></ul>
+    </section>
+  </main>
+
+  <!-- ── Fleet view ─────────────────────────────────────────────────── -->
+  <main id="view-fleet" class="view" hidden>
+    <section class="card full-width">
+      <div class="card-head">
+        <h2>Fleet Overview</h2>
+        <button id="fleet-refresh-btn">refresh</button>
+      </div>
+      <div id="fleet-meta" class="fleet-meta"></div>
+      <table id="fleet-table">
+        <thead>
+          <tr>
+            <th>Repository</th>
+            <th>Org</th>
+            <th>Slots</th>
+            <th>Active</th>
+            <th>Budget/Story</th>
+            <th>PR Target</th>
+            <th>Total Cost</th>
+            <th>Labels</th>
+          </tr>
+        </thead>
+        <tbody id="fleet-body"></tbody>
+      </table>
+    </section>
+  </main>
+
+  <!-- ── Cost analytics view ────────────────────────────────────────── -->
+  <main id="view-cost" class="view" hidden>
+    <section class="card full-width">
+      <div class="card-head">
+        <h2>Cost Analytics</h2>
+        <button id="cost-refresh-btn">refresh</button>
+      </div>
+      <div id="cost-summary-detail" class="cost-summary-detail"></div>
+      <h3 class="section-label">Cost by Backend</h3>
+      <table id="cost-backend-table">
+        <thead>
+          <tr><th>Backend</th><th>Month-to-Date</th></tr>
+        </thead>
+        <tbody id="cost-backend-body"></tbody>
+      </table>
+      <h3 class="section-label">Top Tasks by Cost</h3>
+      <table id="cost-task-table">
+        <thead>
+          <tr>
+            <th>Task ID</th>
+            <th>Target</th>
+            <th>Backend</th>
+            <th>Status</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody id="cost-task-body"></tbody>
+      </table>
+    </section>
+  </main>
+
+  <!-- ── History timeline view ──────────────────────────────────────── -->
+  <main id="view-history" class="view" hidden>
+    <section class="card full-width">
+      <div class="card-head">
+        <h2>History Timeline</h2>
+        <div class="filters">
+          <select id="history-filter" aria-label="Filter history">
+            <option value="">all finished</option>
+            <option value="completed">completed</option>
+            <option value="failed">failed</option>
+            <option value="cancelled">cancelled</option>
+          </select>
+          <button id="history-refresh-btn">refresh</button>
+        </div>
+      </div>
+      <ol id="history-list" class="timeline"></ol>
+    </section>
+  </main>
+
+  <!-- ── Agent monitor view ─────────────────────────────────────────── -->
+  <main id="view-monitor" class="view" hidden>
+    <section class="card full-width">
+      <div class="card-head">
+        <h2>Agent Monitor</h2>
+        <div class="filters">
+          <input id="monitor-filter" type="text" placeholder="filter events…" aria-label="Filter events">
+          <button id="monitor-clear-btn">clear</button>
+        </div>
+      </div>
+      <pre id="monitor-log" class="monitor-log">(waiting for events…)</pre>
+    </section>
+  </main>
+
+  <!-- ── Repository dashboard view ──────────────────────────────────── -->
+  <main id="view-repos" class="view" hidden>
+    <section class="card full-width">
+      <div class="card-head">
+        <h2>Repository Dashboard</h2>
+        <button id="repos-refresh-btn">refresh</button>
+      </div>
+      <div id="repos-grid" class="repos-grid"></div>
+    </section>
+  </main>
+
+  <!-- ── Debug inspector view ───────────────────────────────────────── -->
+  <main id="view-debug" class="view" hidden>
+    <section class="card full-width">
+      <div class="card-head">
+        <h2>Debug Inspector</h2>
+        <button id="debug-clear-btn">clear</button>
+      </div>
+      <p class="debug-hint">Last 200 WebSocket events received in this session.</p>
+      <pre id="debug-log" class="monitor-log">(no events yet)</pre>
     </section>
   </main>
 

--- a/maxwell_daemon/api/ui/style.css
+++ b/maxwell_daemon/api/ui/style.css
@@ -64,11 +64,51 @@ header h1 {
 .pill.warn  { color: var(--warn); }
 .pill.err   { color: var(--err); }
 
+/* ---- tab navigation ------------------------------------------------- */
+.tab-bar {
+  display: flex;
+  gap: 0;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+  overflow-x: auto;
+}
+.tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  padding: 10px 16px;
+  transition: color 0.1s, border-color 0.1s;
+}
+.tab:hover { background: none; color: var(--text); }
+.tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+/* ---- views ---------------------------------------------------------- */
 main {
-  display: grid;
+  display: none;
+  padding: 16px 24px;
+}
+main.active { display: grid; }
+
+#view-tasks {
   grid-template-columns: 2fr 1fr;
   gap: 16px;
-  padding: 16px 24px;
+}
+
+#view-tasks #detail-card:not([hidden]) ~ #backends-card {
+  grid-row: 2 / 3;
+}
+
+.full-width { grid-column: 1 / -1; }
+
+main:not(#view-tasks).active {
+  grid-template-columns: 1fr;
+  gap: 16px;
 }
 
 .card {
@@ -228,3 +268,111 @@ kbd {
   font-size: 11px;
 }
 .hint { color: var(--muted); font-size: 11px; }
+
+/* ---- fleet view ----------------------------------------------------- */
+.fleet-meta {
+  padding: 12px 14px;
+  color: var(--muted);
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* ---- cost view ------------------------------------------------------ */
+.cost-summary-detail {
+  display: flex;
+  gap: 24px;
+  padding: 16px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.cost-stat { text-align: center; }
+.cost-stat .value {
+  display: block;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--accent);
+  font-family: ui-monospace, Menlo, monospace;
+}
+.cost-stat .label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.4px; }
+.section-label {
+  margin: 0;
+  padding: 10px 14px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  border-top: 1px solid var(--border);
+  background: var(--panel-alt);
+}
+
+/* ---- history timeline ----------------------------------------------- */
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.timeline li {
+  display: grid;
+  grid-template-columns: 120px 1fr auto;
+  gap: 12px;
+  align-items: start;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.timeline li:hover { background: var(--panel-alt); cursor: pointer; }
+.timeline .ts { color: var(--muted); font-family: ui-monospace, Menlo, monospace; font-size: 11px; }
+.timeline .title { word-break: break-all; }
+.timeline .cost { color: var(--muted); font-family: ui-monospace, Menlo, monospace; font-size: 12px; text-align: right; }
+
+/* ---- monitor / debug log -------------------------------------------- */
+.monitor-log {
+  margin: 0;
+  padding: 14px;
+  max-height: 60vh;
+  overflow: auto;
+  background: #000;
+  color: #eee;
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.debug-hint { margin: 0; padding: 10px 14px; font-size: 12px; color: var(--muted); border-bottom: 1px solid var(--border); }
+#monitor-filter {
+  background: var(--panel-alt);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font: inherit;
+  min-width: 160px;
+}
+
+/* ---- repos grid ----------------------------------------------------- */
+.repos-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px;
+  padding: 14px;
+}
+.repo-card {
+  background: var(--panel-alt);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 14px;
+}
+.repo-card h3 { margin: 0 0 6px; font-size: 14px; }
+.repo-card h3 a { color: var(--accent); text-decoration: none; }
+.repo-card h3 a:hover { text-decoration: underline; }
+.repo-meta { font-size: 11px; color: var(--muted); display: flex; gap: 10px; flex-wrap: wrap; margin-top: 8px; }
+.repo-meta span { white-space: nowrap; }
+.repo-active { color: var(--ok); font-weight: 600; }
+
+/* ---- responsive ------------------------------------------------------- */
+@media (max-width: 768px) {
+  #view-tasks { grid-template-columns: 1fr; }
+  .cost-summary-detail { flex-wrap: wrap; }
+  .timeline li { grid-template-columns: 1fr auto; }
+  .timeline .ts { grid-column: 1 / -1; }
+}

--- a/maxwell_daemon/metrics.py
+++ b/maxwell_daemon/metrics.py
@@ -14,12 +14,12 @@ from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, gene
 
 __all__ = [
     "MAXWELL_COST_FORECAST_USD",
+    "MAXWELL_COST_FORECAST_USD",
     "MAXWELL_FREE_REQUESTS_TOTAL",
     "MAXWELL_REQUESTS_TOTAL",
     "MAXWELL_REQUEST_COST",
     "MAXWELL_REQUEST_DURATION",
     "MAXWELL_TOKENS_TOTAL",
-    "MAXWELL_COST_FORECAST_USD",
     "build_registry",
     "mount_metrics_endpoint",
     "record_request",

--- a/maxwell_daemon/tools/builtins.py
+++ b/maxwell_daemon/tools/builtins.py
@@ -214,27 +214,40 @@ def _build_run_bash_env() -> dict[str, str]:
 
 
 def get_sandboxed_bash_cmd(cmd: list[str], root: str) -> list[str]:
-    import sys
     import shutil
-    
+    import sys
+
     if sys.platform == "darwin":
         if shutil.which("sandbox-exec"):
-            return ["sandbox-exec", "-f", "/usr/share/sandbox/pure_computation.sb"] + cmd
+            return [
+                "sandbox-exec",
+                "-f",
+                "/usr/share/sandbox/pure_computation.sb",
+                *cmd,
+            ]
     elif sys.platform.startswith("linux"):
         # landlock-restrict if available, else bwrap fallback
         if shutil.which("landlock-restrict"):
-            return ["landlock-restrict", "--ro", "/", "--rw", root] + cmd
+            return ["landlock-restrict", "--ro", "/", "--rw", root, *cmd]
         if shutil.which("bwrap"):
             tmpfs_dir = os.path.join(os.sep, "tmp")
             return [
                 "bwrap",
                 "--unshare-all",
-                "--ro-bind", "/", "/",
-                "--bind", root, root,
-                "--dev", "/dev",
-                "--proc", "/proc",
-                "--tmpfs", tmpfs_dir,
-            ] + cmd
+                "--ro-bind",
+                "/",
+                "/",
+                "--bind",
+                root,
+                root,
+                "--dev",
+                "/dev",
+                "--proc",
+                "/proc",
+                "--tmpfs",
+                tmpfs_dir,
+                *cmd,
+            ]
     return cmd
 
 

--- a/tests/unit/test_tools_builtins.py
+++ b/tests/unit/test_tools_builtins.py
@@ -179,6 +179,7 @@ class TestRunBash:
 
 def test_sandbox_cmd_linux_bwrap(monkeypatch: pytest.MonkeyPatch) -> None:
     from maxwell_daemon.tools.builtins import get_sandboxed_bash_cmd
+
     monkeypatch.setattr("sys.platform", "linux")
     monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/bwrap" if cmd == "bwrap" else None)
     res = get_sandboxed_bash_cmd(["bash", "-c", "echo hi"], "/tmp/workspace")
@@ -190,8 +191,11 @@ def test_sandbox_cmd_linux_bwrap(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_sandbox_cmd_mac_sandbox_exec(monkeypatch: pytest.MonkeyPatch) -> None:
     from maxwell_daemon.tools.builtins import get_sandboxed_bash_cmd
+
     monkeypatch.setattr("sys.platform", "darwin")
-    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/sandbox-exec" if cmd == "sandbox-exec" else None)
+    monkeypatch.setattr(
+        "shutil.which", lambda cmd: "/usr/bin/sandbox-exec" if cmd == "sandbox-exec" else None
+    )
     res = get_sandboxed_bash_cmd(["bash", "-c", "echo hi"], "/tmp/workspace")
     assert res[:3] == ["sandbox-exec", "-f", "/usr/share/sandbox/pure_computation.sb"]
 


### PR DESCRIPTION
## Summary

Implements the multi-view dashboard requested in issue #6 (Dashboard Views).

**New tab-bar navigation** (keyboard: digits 1–7 switch tabs):

| Tab | Description |
|-----|-------------|
| Tasks | Existing task list + detail panel — unchanged |
| Fleet | Repo manifest table with live active-task counts and per-repo cost |
| Cost | MTD summary stat, per-backend breakdown table, top 20 tasks by cost |
| History | Chronological timeline of finished tasks with filter; click-through to detail |
| Monitor | Live WebSocket event log with text filter and clear |
| Repos | Card grid of fleet repos with GitHub links and slot/budget metadata |
| Debug | Raw WebSocket JSON event inspector (last 200 events) |

**Backend addition**: `GET /api/v1/fleet` reads `fleet.yaml` (respecting `$MAXWELL_FLEET_CONFIG`), merges fleet defaults into each repo entry, and annotates with live active-task counts + per-repo cost totals from running tasks.

**Responsive**: mobile breakpoint at 768 px collapses the tasks grid and timeline.

## Test plan
- [x] Unit tests pass (`tests/unit/test_fleet_dispatcher.py` — 29 passed)
- [x] `ruff check` + `ruff format --check` pass on `server.py`
- [x] Python AST parse confirms `server.py` syntax is valid
- [x] Existing task/detail/dispatch flow preserved on Tasks tab
- [x] N shortcut still opens dispatch dialog
- [x] Esc closes dialog (inherited from `<dialog method="dialog">`)

Closes #6