### PR TITLE
feat: compliance & audit logging with hash-chained JSONL

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -35,6 +35,7 @@ from fastapi import (
 from pydantic import BaseModel, Field, field_validator
 
 from maxwell_daemon import __version__
+from maxwell_daemon.audit import AuditLogger
 from maxwell_daemon.daemon import Daemon
 from maxwell_daemon.daemon.runner import Task
 from maxwell_daemon.logging import bind_context
@@ -172,6 +173,7 @@ def create_app(
     *,
     auth_token: str | None = None,
     github_client: Any = None,
+    audit_log_path: _Path | None = None,
 ) -> FastAPI:
     """Build the FastAPI app.
 
@@ -186,6 +188,10 @@ def create_app(
     mount_metrics_endpoint(app)
     _mount_web_ui(app)
     auth = _auth_dep(auth_token)
+
+    _audit: AuditLogger | None = (
+        AuditLogger(audit_log_path) if audit_log_path is not None else None
+    )
 
     # Rate-limit middleware — installs only when config declares a default group.
     api_cfg = daemon._config.api
@@ -213,6 +219,16 @@ def create_app(
         with bind_context(request_id=request_id):
             response: Response = await call_next(request)
         response.headers["x-request-id"] = request_id
+        if _audit is not None and not request.url.path.startswith("/ui"):
+            auth_header = request.headers.get("authorization", "")
+            user = auth_header.removeprefix("Bearer ").strip() if auth_header else None
+            _audit.log_api_call(
+                method=request.method,
+                path=request.url.path,
+                status=response.status_code,
+                user=user,
+                request_id=request_id,
+            )
         return response
 
     def _gh() -> Any:
@@ -481,6 +497,33 @@ def create_app(
                 "discovery_interval_seconds": fleet_section.get("discovery_interval_seconds", 300),
             },
             "repos": repos,
+        }
+
+    @app.get("/api/v1/audit", dependencies=[Depends(auth)])
+    async def audit_log(
+        limit: int = Query(default=200, ge=1, le=10_000),
+        offset: int = Query(default=0, ge=0),
+    ) -> dict[str, Any]:
+        """Return paginated audit log entries (oldest first)."""
+        if _audit is None:
+            return {"entries": [], "audit_enabled": False}
+        return {
+            "entries": _audit.entries(limit=limit, offset=offset),
+            "audit_enabled": True,
+        }
+
+    @app.get("/api/v1/audit/verify", dependencies=[Depends(auth)])
+    async def audit_verify() -> dict[str, Any]:
+        """Verify the audit log hash chain.  Returns violations (empty = clean)."""
+        from maxwell_daemon.audit import verify_chain
+
+        if _audit is None or audit_log_path is None:
+            return {"clean": True, "violations": [], "audit_enabled": False}
+        violations = verify_chain(audit_log_path)
+        return {
+            "clean": len(violations) == 0,
+            "violations": violations,
+            "audit_enabled": True,
         }
 
     @app.get("/api/v1/cost", dependencies=[Depends(auth)])

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -189,9 +189,7 @@ def create_app(
     _mount_web_ui(app)
     auth = _auth_dep(auth_token)
 
-    _audit: AuditLogger | None = (
-        AuditLogger(audit_log_path) if audit_log_path is not None else None
-    )
+    _audit: AuditLogger | None = AuditLogger(audit_log_path) if audit_log_path is not None else None
 
     # Rate-limit middleware — installs only when config declares a default group.
     api_cfg = daemon._config.api

--- a/maxwell_daemon/audit.py
+++ b/maxwell_daemon/audit.py
@@ -1,0 +1,320 @@
+"""Append-only audit logger with SHA-256 hash chaining for tamper detection.
+
+Each log entry is a JSONL line written atomically. Entries are chained:
+``entry["prev_hash"]`` is the SHA-256 of the previous line's raw bytes, forming
+a chain that makes silent insertion or deletion detectable.
+
+Usage::
+
+    logger = AuditLogger(Path("/var/log/maxwell/audit.jsonl"))
+    logger.log_api_call(method="POST", path="/api/v1/tasks", status=202,
+                        user=None, request_id="abc")
+
+The ``AuditLogger`` is intentionally lightweight — no threads, no queues.
+Callers serialise access via the surrounding async event loop.  The file is
+opened in append mode on every write to be safe under SIGKILL.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "AuditEntry",
+    "AuditLogger",
+    "AuditViolationError",
+    "verify_chain",
+]
+
+_GENESIS_HASH = "0" * 64  # prev_hash sentinel for the first entry
+
+
+class AuditViolationError(RuntimeError):
+    """Raised by ``verify_chain`` when the hash chain is broken."""
+
+
+@dataclass
+class AuditEntry:
+    """A single audit log record (written as one JSON line)."""
+
+    timestamp: str
+    event_type: str
+    method: str | None
+    path: str | None
+    status: int | None
+    user: str | None
+    request_id: str | None
+    details: dict[str, Any]
+    prev_hash: str
+    entry_hash: str = field(default="", init=False)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "event_type": self.event_type,
+            "method": self.method,
+            "path": self.path,
+            "status": self.status,
+            "user": self.user,
+            "request_id": self.request_id,
+            "details": self.details,
+            "prev_hash": self.prev_hash,
+            "entry_hash": self.entry_hash,
+        }
+
+
+class AuditLogger:
+    """Write-once, hash-chained audit log.
+
+    Parameters
+    ----------
+    path:
+        Destination JSONL file.  Parent directories are created on first write.
+    retention_days:
+        If >0, ``rotate()`` removes lines older than this many days (call it
+        from a scheduler; not automatic so tests stay deterministic).
+    """
+
+    def __init__(self, path: Path, *, retention_days: int = 0) -> None:
+        self._path = path
+        self._retention_days = retention_days
+        self._last_hash: str | None = None  # cached tail hash; None = unread
+
+    # ── public API ──────────────────────────────────────────────────────────
+
+    def log_api_call(
+        self,
+        *,
+        method: str,
+        path: str,
+        status: int,
+        user: str | None = None,
+        request_id: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> AuditEntry:
+        return self._append(
+            event_type="api_call",
+            method=method,
+            path=path,
+            status=status,
+            user=user,
+            request_id=request_id,
+            details=details or {},
+        )
+
+    def log_agent_operation(
+        self,
+        *,
+        operation: str,
+        task_id: str | None = None,
+        repo: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> AuditEntry:
+        return self._append(
+            event_type="agent_operation",
+            method=None,
+            path=None,
+            status=None,
+            user=None,
+            request_id=None,
+            details={"operation": operation, "task_id": task_id, "repo": repo, **(details or {})},
+        )
+
+    def log_config_change(
+        self,
+        *,
+        key: str,
+        user: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> AuditEntry:
+        return self._append(
+            event_type="config_change",
+            method=None,
+            path=None,
+            status=None,
+            user=user,
+            request_id=None,
+            details={"key": key, **(details or {})},
+        )
+
+    def entries(self, *, limit: int = 1000, offset: int = 0) -> list[dict[str, Any]]:
+        """Return up to *limit* entries starting at *offset* (oldest first)."""
+        if not self._path.is_file():
+            return []
+        lines = self._path.read_text(encoding="utf-8").splitlines()
+        slice_ = lines[offset : offset + limit]
+        result = []
+        for line in slice_:
+            line = line.strip()
+            if line:
+                with contextlib.suppress(json.JSONDecodeError):
+                    result.append(json.loads(line))
+        return result
+
+    def rotate(self) -> int:
+        """Delete entries older than ``retention_days``.  Returns lines removed."""
+        if self._retention_days <= 0 or not self._path.is_file():
+            return 0
+        from datetime import timedelta
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=self._retention_days)
+        lines = self._path.read_text(encoding="utf-8").splitlines()
+        kept: list[str] = []
+        removed = 0
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                ts = datetime.fromisoformat(entry.get("timestamp", ""))
+                if ts >= cutoff:
+                    kept.append(line)
+                else:
+                    removed += 1
+            except (json.JSONDecodeError, ValueError):
+                kept.append(line)  # keep malformed lines; chain verifier will flag them
+        if removed:
+            self._write_lines(kept)
+            self._last_hash = None  # invalidate cache
+        return removed
+
+    # ── internals ───────────────────────────────────────────────────────────
+
+    def _tail_hash(self) -> str:
+        """Read the hash of the last line without loading the whole file."""
+        if self._last_hash is not None:
+            return self._last_hash
+        if not self._path.is_file():
+            return _GENESIS_HASH
+        with self._path.open("rb") as fh:
+            # Walk backwards to find the last non-empty line.
+            fh.seek(0, 2)
+            size = fh.tell()
+            if size == 0:
+                return _GENESIS_HASH
+            pos = size - 1
+            buf = b""
+            while pos >= 0:
+                fh.seek(pos)
+                ch = fh.read(1)
+                if ch == b"\n" and buf.strip():
+                    break
+                buf = ch + buf
+                pos -= 1
+            line = buf.strip()
+        if not line:
+            return _GENESIS_HASH
+        try:
+            obj: dict[str, Any] = json.loads(line)
+            result: str = obj.get("entry_hash", _GENESIS_HASH)
+            return result
+        except json.JSONDecodeError:
+            return _GENESIS_HASH
+
+    def _append(
+        self,
+        *,
+        event_type: str,
+        method: str | None,
+        path: str | None,
+        status: int | None,
+        user: str | None,
+        request_id: str | None,
+        details: dict[str, Any],
+    ) -> AuditEntry:
+        prev = self._tail_hash()
+        entry = AuditEntry(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            event_type=event_type,
+            method=method,
+            path=path,
+            status=status,
+            user=user,
+            request_id=request_id,
+            details=details,
+            prev_hash=prev,
+        )
+        d = entry.as_dict()
+        # Hash everything except entry_hash itself.
+        payload = json.dumps({k: v for k, v in d.items() if k != "entry_hash"}, sort_keys=True)
+        entry.entry_hash = hashlib.sha256(payload.encode()).hexdigest()
+        d["entry_hash"] = entry.entry_hash
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(d, separators=(",", ":")) + "\n"
+        with self._path.open("ab") as fh:
+            fh.write(line.encode())
+            fh.flush()
+            os.fsync(fh.fileno())
+
+        self._last_hash = entry.entry_hash
+        return entry
+
+    def _write_lines(self, lines: list[str]) -> None:
+        """Atomically replace the log file (used by rotate())."""
+        fd, tmp = tempfile.mkstemp(dir=self._path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                for line in lines:
+                    f.write(line + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, self._path)
+        except Exception:
+            os.unlink(tmp)
+            raise
+
+
+# ── standalone verifier ─────────────────────────────────────────────────────
+
+
+def verify_chain(path: Path) -> list[dict[str, Any]]:
+    """Verify every entry's hash and the chain links.
+
+    Returns a list of violation dicts (empty = clean).  Each violation has:
+    ``{"line": N, "error": "...", "entry": {...}}``.
+    """
+    if not path.is_file():
+        return []
+    violations: list[dict[str, Any]] = []
+    prev_hash = _GENESIS_HASH
+    with path.open(encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                obj = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                violations.append(
+                    {"line": lineno, "error": f"JSON parse error: {exc}", "entry": raw}
+                )
+                continue
+            stored_hash = obj.get("entry_hash", "")
+            stored_prev = obj.get("prev_hash", "")
+            # Re-derive the expected hash.
+            payload = json.dumps(
+                {k: v for k, v in obj.items() if k != "entry_hash"}, sort_keys=True
+            )
+            expected_hash = hashlib.sha256(payload.encode()).hexdigest()
+            if stored_hash != expected_hash:
+                violations.append({"line": lineno, "error": "entry_hash mismatch", "entry": obj})
+            if stored_prev != prev_hash and lineno > 1:
+                violations.append(
+                    {
+                        "line": lineno,
+                        "error": f"chain broken: expected prev_hash={prev_hash!r}, got {stored_prev!r}",
+                        "entry": obj,
+                    }
+                )
+            prev_hash = stored_hash or expected_hash
+    return violations

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -1,0 +1,233 @@
+"""Tests for the AuditLogger and verify_chain."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from maxwell_daemon.audit import AuditLogger, verify_chain
+
+try:
+    import prometheus_client  # noqa: F401
+
+    _HAS_API_DEPS = True
+except ModuleNotFoundError:
+    _HAS_API_DEPS = False
+
+
+@pytest.fixture
+def daemon(minimal_config: Any, isolated_ledger_path: Any) -> Iterator[Any]:
+    if not _HAS_API_DEPS:
+        pytest.skip("api deps not installed")
+    from maxwell_daemon.daemon import Daemon
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    d = Daemon(minimal_config, ledger_path=isolated_ledger_path)
+    loop.run_until_complete(d.start(worker_count=1))
+    try:
+        yield d
+    finally:
+        loop.run_until_complete(d.stop())
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+@pytest.fixture
+def client(daemon: Any) -> Iterator[Any]:
+    from fastapi.testclient import TestClient
+
+    from maxwell_daemon.api import create_app
+
+    with TestClient(create_app(daemon)) as c:
+        yield c
+
+
+@pytest.fixture
+def log_path(tmp_path: Path) -> Path:
+    return tmp_path / "audit.jsonl"
+
+
+@pytest.fixture
+def logger(log_path: Path) -> AuditLogger:
+    return AuditLogger(log_path)
+
+
+class TestAuditLogger:
+    def test_creates_file_on_first_write(self, logger: AuditLogger, log_path: Path) -> None:
+        logger.log_api_call(method="GET", path="/health", status=200)
+        assert log_path.is_file()
+
+    def test_entry_fields_present(self, logger: AuditLogger, log_path: Path) -> None:
+        logger.log_api_call(method="POST", path="/api/v1/tasks", status=202, request_id="abc")
+        lines = log_path.read_text().splitlines()
+        assert len(lines) == 1
+        obj = json.loads(lines[0])
+        assert obj["event_type"] == "api_call"
+        assert obj["method"] == "POST"
+        assert obj["path"] == "/api/v1/tasks"
+        assert obj["status"] == 202
+        assert obj["request_id"] == "abc"
+        assert "timestamp" in obj
+        assert "entry_hash" in obj
+        assert "prev_hash" in obj
+
+    def test_first_entry_genesis_prev_hash(self, logger: AuditLogger, log_path: Path) -> None:
+        logger.log_api_call(method="GET", path="/health", status=200)
+        obj = json.loads(log_path.read_text())
+        assert obj["prev_hash"] == "0" * 64
+
+    def test_chain_links_entries(self, logger: AuditLogger, log_path: Path) -> None:
+        logger.log_api_call(method="GET", path="/health", status=200)
+        logger.log_api_call(method="POST", path="/api/v1/tasks", status=202)
+        lines = log_path.read_text().splitlines()
+        first = json.loads(lines[0])
+        second = json.loads(lines[1])
+        assert second["prev_hash"] == first["entry_hash"]
+
+    def test_multiple_entries_appended(self, logger: AuditLogger, log_path: Path) -> None:
+        for i in range(5):
+            logger.log_api_call(method="GET", path=f"/api/v1/tasks/{i}", status=200)
+        assert len(log_path.read_text().splitlines()) == 5
+
+    def test_log_agent_operation(self, logger: AuditLogger, log_path: Path) -> None:
+        logger.log_agent_operation(operation="task_start", task_id="t-1", repo="org/repo")
+        obj = json.loads(log_path.read_text())
+        assert obj["event_type"] == "agent_operation"
+        assert obj["details"]["operation"] == "task_start"
+        assert obj["details"]["task_id"] == "t-1"
+
+    def test_log_config_change(self, logger: AuditLogger, log_path: Path) -> None:
+        logger.log_config_change(key="api.auth_token", user="admin")
+        obj = json.loads(log_path.read_text())
+        assert obj["event_type"] == "config_change"
+        assert obj["user"] == "admin"
+        assert obj["details"]["key"] == "api.auth_token"
+
+    def test_entries_pagination(self, logger: AuditLogger) -> None:
+        for i in range(10):
+            logger.log_api_call(method="GET", path=f"/{i}", status=200)
+        page = logger.entries(limit=3, offset=2)
+        assert len(page) == 3
+
+    def test_entries_empty_when_no_file(self, log_path: Path) -> None:
+        fresh = AuditLogger(log_path)
+        assert fresh.entries() == []
+
+    def test_rotate_removes_old_entries(self, tmp_path: Path) -> None:
+        from datetime import datetime, timedelta, timezone
+
+        path = tmp_path / "audit.jsonl"
+        logger = AuditLogger(path, retention_days=7)
+        # Write an entry with a timestamp 10 days ago by patching the file directly.
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+        # Use a fresh logger to write a "now" entry first, then manually append old one.
+        entry = logger.log_api_call(method="GET", path="/old", status=200)
+        # Overwrite the file with a backdated entry.
+        old_obj = {
+            "timestamp": old_ts,
+            "event_type": "api_call",
+            "method": "GET",
+            "path": "/old",
+            "status": 200,
+            "user": None,
+            "request_id": None,
+            "details": {},
+            "prev_hash": "0" * 64,
+            "entry_hash": entry.entry_hash,
+        }
+        path.write_text(json.dumps(old_obj) + "\n")
+        logger._last_hash = None  # reset cache
+        # Write a current entry.
+        logger.log_api_call(method="GET", path="/new", status=200)
+        removed = logger.rotate()
+        assert removed == 1
+        remaining = logger.entries()
+        assert len(remaining) == 1
+        assert remaining[0]["path"] == "/new"
+
+    def test_new_logger_reads_tail_from_file(self, log_path: Path) -> None:
+        """A fresh AuditLogger instance reads the existing tail hash."""
+        logger1 = AuditLogger(log_path)
+        e = logger1.log_api_call(method="GET", path="/a", status=200)
+        logger2 = AuditLogger(log_path)
+        logger2.log_api_call(method="GET", path="/b", status=200)
+        lines = log_path.read_text().splitlines()
+        second = json.loads(lines[1])
+        assert second["prev_hash"] == e.entry_hash
+
+
+class TestVerifyChain:
+    def test_clean_chain(self, logger: AuditLogger, log_path: Path) -> None:
+        for i in range(5):
+            logger.log_api_call(method="GET", path=f"/{i}", status=200)
+        assert verify_chain(log_path) == []
+
+    def test_tampered_entry_detected(self, logger: AuditLogger, log_path: Path) -> None:
+        logger.log_api_call(method="GET", path="/a", status=200)
+        logger.log_api_call(method="GET", path="/b", status=200)
+        lines = log_path.read_text().splitlines()
+        obj = json.loads(lines[0])
+        obj["status"] = 999  # tamper
+        lines[0] = json.dumps(obj)
+        log_path.write_text("\n".join(lines) + "\n")
+        violations = verify_chain(log_path)
+        assert any(v["line"] == 1 for v in violations)
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert verify_chain(tmp_path / "nonexistent.jsonl") == []
+
+    def test_broken_chain_detected(self, logger: AuditLogger, log_path: Path) -> None:
+        logger.log_api_call(method="GET", path="/a", status=200)
+        logger.log_api_call(method="GET", path="/b", status=200)
+        lines = log_path.read_text().splitlines()
+        obj = json.loads(lines[1])
+        obj["prev_hash"] = "dead" * 16  # break chain
+        lines[1] = json.dumps(obj)
+        log_path.write_text("\n".join(lines) + "\n")
+        violations = verify_chain(log_path)
+        assert any("chain broken" in v["error"] for v in violations)
+
+
+class TestAuditApiEndpoints:
+    """Integration tests for /api/v1/audit and /api/v1/audit/verify."""
+
+    def test_audit_disabled_by_default(
+        self,
+        daemon: Any,
+        client: Any,
+    ) -> None:
+        r = client.get("/api/v1/audit")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["audit_enabled"] is False
+        assert body["entries"] == []
+
+    def test_audit_endpoint_with_log(
+        self,
+        daemon: Any,
+        tmp_path: Path,
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        from maxwell_daemon.api import create_app
+
+        log_path = tmp_path / "audit.jsonl"
+        with TestClient(create_app(daemon, audit_log_path=log_path)) as client:
+            client.get("/health")
+            r = client.get("/api/v1/audit")
+            assert r.status_code == 200
+            body = r.json()
+            assert body["audit_enabled"] is True
+            assert len(body["entries"]) >= 1
+
+            rv = client.get("/api/v1/audit/verify")
+            assert rv.status_code == 200
+            vbody = rv.json()
+            assert vbody["clean"] is True
+            assert vbody["violations"] == []


### PR DESCRIPTION
## Summary

- New `maxwell_daemon/audit.py`: append-only audit logger that SHA-256 chains every entry — silent insertion or deletion breaks the chain and is reported by `verify_chain()`
- HTTP middleware records all non-UI API calls (method, path, status, request_id) when `audit_log_path` is passed to `create_app()`
- `GET /api/v1/audit` — paginated export (oldest-first, limit/offset query params)
- `GET /api/v1/audit/verify` — integrity check; returns `{"clean": true, "violations": []}`
- `AuditLogger.rotate(retention_days=N)` for configurable log retention
- Three event types: `api_call`, `agent_operation`, `config_change`

## Test plan
- [x] `ruff check` + `ruff format --check` pass
- [x] `mypy --strict --ignore-missing-imports` passes on audit.py
- [x] 15 unit tests pass locally (2 API integration tests skip without prometheus_client, run on CI)
- [x] Chain linking verified: `second["prev_hash"] == first["entry_hash"]`
- [x] Tamper detection: mutating any field breaks `entry_hash` → violation reported
- [x] Chain break detection: wrong `prev_hash` caught by verifier
- [x] Rotation removes entries older than retention window

Closes #18