### PR TITLE
feat: mobile PWA — installable, offline-first, touch-optimized

### DIFF
--- a/maxwell_daemon/api/ui/app.js
+++ b/maxwell_daemon/api/ui/app.js
@@ -524,6 +524,30 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  // Touch swipe to navigate tabs (left/right swipe)
+  const views = ["tasks", "fleet", "cost", "history", "monitor", "repos", "debug"];
+  let touchStartX = 0;
+  let touchStartY = 0;
+  document.addEventListener("touchstart", (ev) => {
+    touchStartX = ev.touches[0].clientX;
+    touchStartY = ev.touches[0].clientY;
+  }, { passive: true });
+  document.addEventListener("touchend", (ev) => {
+    const dx = ev.changedTouches[0].clientX - touchStartX;
+    const dy = ev.changedTouches[0].clientY - touchStartY;
+    if (Math.abs(dx) < 50 || Math.abs(dy) > Math.abs(dx)) return; // not a horizontal swipe
+    const current = views.indexOf(state.currentView);
+    if (current === -1) return;
+    const next = dx < 0
+      ? Math.min(current + 1, views.length - 1)
+      : Math.max(current - 1, 0);
+    if (next !== current) switchView(views[next]);
+  }, { passive: true });
+
+  // Handle ?view= URL param on load (PWA shortcut links)
+  const viewParam = new URLSearchParams(location.search).get("view");
+  if (viewParam && views.includes(viewParam)) switchView(viewParam);
+
   // Initial load
   fetchTasks().catch(console.error);
   fetchBackends().catch(console.error);

--- a/maxwell_daemon/api/ui/index.html
+++ b/maxwell_daemon/api/ui/index.html
@@ -3,7 +3,14 @@
 <head>
   <meta charset="utf-8">
   <title>Maxwell-Daemon — Agent Fleet</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#0f1115" media="(prefers-color-scheme: dark)">
+  <meta name="theme-color" content="#f8f9fc" media="(prefers-color-scheme: light)">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="Maxwell">
+  <link rel="manifest" href="/ui/manifest.json">
   <link rel="stylesheet" href="/ui/style.css">
 </head>
 <body>
@@ -233,5 +240,10 @@
   </footer>
 
   <script src="/ui/app.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/ui/sw.js', { scope: '/ui/' });
+    }
+  </script>
 </body>
 </html>

--- a/maxwell_daemon/api/ui/manifest.json
+++ b/maxwell_daemon/api/ui/manifest.json
@@ -1,0 +1,37 @@
+{
+  "name": "Maxwell-Daemon",
+  "short_name": "Maxwell",
+  "description": "Agent fleet control panel",
+  "start_url": "/ui/",
+  "display": "standalone",
+  "background_color": "#0f1115",
+  "theme_color": "#0f1115",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/ui/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/ui/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["developer", "productivity"],
+  "shortcuts": [
+    {
+      "name": "Tasks",
+      "url": "/ui/?view=tasks",
+      "description": "View active agent tasks"
+    },
+    {
+      "name": "Fleet",
+      "url": "/ui/?view=fleet",
+      "description": "View fleet status"
+    }
+  ]
+}

--- a/maxwell_daemon/api/ui/style.css
+++ b/maxwell_daemon/api/ui/style.css
@@ -376,3 +376,62 @@ kbd {
   .timeline li { grid-template-columns: 1fr auto; }
   .timeline .ts { grid-column: 1 / -1; }
 }
+
+/* ---- PWA / mobile touch targets --------------------------------------- */
+
+/* Safe area insets for notched phones (iPhone X+) */
+body {
+  padding-bottom: env(safe-area-inset-bottom, 0);
+  padding-left: env(safe-area-inset-left, 0);
+  padding-right: env(safe-area-inset-right, 0);
+}
+
+/* All interactive elements meet 44×44px WCAG touch target minimum */
+button, .tab, select, input[type="checkbox"], input[type="radio"] {
+  min-height: 44px;
+  min-width: 44px;
+}
+
+/* Tab bar scrolls horizontally on narrow screens; larger tap area */
+.tab-bar { -webkit-overflow-scrolling: touch; }
+.tab { padding: 12px 16px; }
+
+/* Table rows: taller for easier tapping on mobile */
+@media (max-width: 768px) {
+  th, td { padding: 12px 14px; }
+  .timeline li { padding: 14px; }
+  button { padding: 10px 14px; }
+  header { padding: 12px 16px; }
+  main { padding: 12px 16px; }
+  footer { padding: 12px 16px; }
+
+  /* Quick-action floating button for dispatching tasks */
+  #new-task-btn {
+    position: fixed;
+    right: max(16px, env(safe-area-inset-right, 16px));
+    bottom: max(72px, calc(72px + env(safe-area-inset-bottom, 0)));
+    width: 56px;
+    height: 56px;
+    min-width: 56px;
+    border-radius: 50%;
+    font-size: 24px;
+    line-height: 1;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+/* Prevent text selection during swipe gestures on touch screens */
+.tab-bar, table thead { user-select: none; -webkit-user-select: none; }
+
+/* Smooth momentum scrolling for scrollable areas */
+.monitor-log, #detail-output, .repos-grid {
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}

--- a/maxwell_daemon/api/ui/sw.js
+++ b/maxwell_daemon/api/ui/sw.js
@@ -1,0 +1,94 @@
+/* Maxwell-Daemon Service Worker — offline-first caching strategy.
+ *
+ * Strategy:
+ *   - Shell assets (HTML, CSS, JS, manifest) → cache-first, update in background
+ *   - API calls → network-first, fall back to stale if offline
+ *   - WebSocket events → always network (can't cache WS)
+ *
+ * Cache version: bump CACHE_VERSION on breaking UI changes to force refresh.
+ */
+
+const CACHE_VERSION = 'v1';
+const SHELL_CACHE = `maxwell-shell-${CACHE_VERSION}`;
+const API_CACHE   = `maxwell-api-${CACHE_VERSION}`;
+
+const SHELL_ASSETS = [
+  '/ui/',
+  '/ui/index.html',
+  '/ui/style.css',
+  '/ui/app.js',
+  '/ui/manifest.json',
+];
+
+// ── install ─────────────────────────────────────────────────────────────────
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(SHELL_CACHE).then((cache) => cache.addAll(SHELL_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+// ── activate — delete old caches ────────────────────────────────────────────
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((k) => k !== SHELL_CACHE && k !== API_CACHE)
+          .map((k) => caches.delete(k))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+// ── fetch ────────────────────────────────────────────────────────────────────
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Never intercept WebSocket upgrades or cross-origin requests.
+  if (request.headers.get('upgrade') === 'websocket') return;
+  if (url.origin !== self.location.origin) return;
+
+  if (url.pathname.startsWith('/api/')) {
+    // API: network-first, stale fallback for GET requests only.
+    if (request.method !== 'GET') return;
+    event.respondWith(networkFirstApi(request));
+  } else {
+    // UI shell: cache-first, background update.
+    event.respondWith(cacheFirstShell(request));
+  }
+});
+
+async function networkFirstApi(request) {
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(API_CACHE);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    return new Response(
+      JSON.stringify({ error: 'offline', cached: false }),
+      { status: 503, headers: { 'content-type': 'application/json' } }
+    );
+  }
+}
+
+async function cacheFirstShell(request) {
+  const cached = await caches.match(request);
+  const fetchPromise = fetch(request).then((response) => {
+    if (response.ok) {
+      caches.open(SHELL_CACHE).then((cache) => cache.put(request, response.clone()));
+    }
+    return response;
+  });
+  return cached || fetchPromise;
+}


### PR DESCRIPTION
## Summary

- **PWA manifest** (`manifest.json`): installable on iOS/Android/desktop; shortcuts to Tasks and Fleet views
- **Service worker** (`sw.js`): cache-first shell assets, network-first API calls with stale offline fallback; old cache versions pruned on activate
- **Mobile meta tags**: `apple-mobile-web-app-*`, `theme-color`, `viewport-fit=cover` for notched phones
- **Touch targets**: all buttons/tabs/selects enforced to 44×44px minimum (WCAG 2.5.5)
- **Safe area insets**: `env(safe-area-inset-*)` padding so content clears iPhone notch/home bar
- **Swipe navigation**: horizontal swipe gesture (50px threshold) switches tabs; blocked if vertical swipe dominates
- **PWA shortcuts**: `?view=tasks` / `?view=fleet` URL params applied on load; manifest shortcut links use these

## Test plan
- [x] No TODO/FIXME in new files
- [x] All UI files under 200KB file size budget
- [x] `ruff check` clean (Python files unchanged)
- [ ] Installable via Chrome DevTools → Application → Manifest
- [ ] Offline: disable network → Tasks view shows stale data, API returns cached response
- [ ] Swipe left/right between tabs on mobile
- [ ] Touch targets pass: all interactive elements ≥44px

Closes #14