### PR TITLE
feat: Ansible playbooks and Terraform module for fleet deployment

### DIFF
--- a/deploy/ansible/backup-config.yml
+++ b/deploy/ansible/backup-config.yml
@@ -1,0 +1,66 @@
+---
+# backup-config.yml — Archive config and data from all conductor nodes to the control host.
+#
+# Usage:
+#   ansible-playbook -i inventory/fleet.yml backup-config.yml
+#   ansible-playbook -i inventory/fleet.yml backup-config.yml \
+#     -e backup_dest=/mnt/backups/maxwell
+
+- name: Back up maxwell-daemon configuration and data
+  hosts: conductor_primary:conductor_agents
+  become: true
+  gather_facts: true
+
+  vars:
+    backup_dest: "{{ playbook_dir }}/../../backups"
+    backup_ts: "{{ ansible_date_time.iso8601_basic_short }}"
+    remote_archive: /tmp/maxwell-backup-{{ backup_ts }}.tar.gz
+
+  tasks:
+    - name: Create remote archive of config and data dirs
+      ansible.builtin.archive:
+        path:
+          - "{{ conductor_config_dir }}"
+          - "{{ conductor_data_dir }}"
+        dest: "{{ remote_archive }}"
+        format: gz
+        owner: root
+        group: root
+        mode: "0600"
+      no_log: true
+
+    - name: Ensure local backup destination exists
+      ansible.builtin.file:
+        path: "{{ backup_dest }}/{{ inventory_hostname }}"
+        state: directory
+        mode: "0750"
+      delegate_to: localhost
+      become: false
+
+    - name: Fetch archive to control host
+      ansible.builtin.fetch:
+        src: "{{ remote_archive }}"
+        dest: "{{ backup_dest }}/{{ inventory_hostname }}/maxwell-backup-{{ backup_ts }}.tar.gz"
+        flat: true
+
+    - name: Remove remote archive
+      ansible.builtin.file:
+        path: "{{ remote_archive }}"
+        state: absent
+
+    - name: Prune backups older than retention period
+      ansible.builtin.find:
+        paths: "{{ backup_dest }}/{{ inventory_hostname }}"
+        patterns: "maxwell-backup-*.tar.gz"
+        age: "{{ conductor_backup_retention_days }}d"
+      register: old_backups
+      delegate_to: localhost
+      become: false
+
+    - name: Delete old backup archives
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ old_backups.files }}"
+      delegate_to: localhost
+      become: false

--- a/deploy/ansible/configure-conductor.yml
+++ b/deploy/ansible/configure-conductor.yml
@@ -1,0 +1,63 @@
+---
+# configure-conductor.yml — Push updated config (LLM backends, TLS, auth) to fleet.
+#
+# Usage:
+#   ansible-playbook -i inventory/fleet.yml configure-conductor.yml \
+#     -e conductor_backend=anthropic \
+#     -e conductor_anthropic_api_key=$ANTHROPIC_API_KEY
+#
+# Secrets should be kept in an Ansible Vault file, not on the command line.
+
+- name: Configure maxwell-daemon backends and TLS
+  hosts: conductor_primary
+  become: true
+  gather_facts: false
+
+  vars_prompt:
+    - name: confirm
+      prompt: "This will restart the daemon on {{ ansible_play_hosts | join(', ') }}. Continue? [yes/no]"
+      private: false
+
+  pre_tasks:
+    - name: Abort if not confirmed
+      ansible.builtin.fail:
+        msg: "Aborted by operator."
+      when: confirm != "yes"
+
+  tasks:
+    - name: Deploy updated configuration
+      ansible.builtin.template:
+        src: roles/maxwell_daemon/templates/config.toml.j2
+        dest: "{{ conductor_config_dir }}/config.toml"
+        owner: "{{ conductor_user }}"
+        group: "{{ conductor_group }}"
+        mode: "0640"
+      notify: Restart maxwell-daemon
+      no_log: true
+
+    - name: Copy TLS certificate
+      ansible.builtin.copy:
+        content: "{{ conductor_tls_cert_content }}"
+        dest: "{{ conductor_config_dir }}/tls.crt"
+        owner: "{{ conductor_user }}"
+        group: "{{ conductor_group }}"
+        mode: "0640"
+      when: conductor_tls_cert_content is defined
+      notify: Restart maxwell-daemon
+
+    - name: Copy TLS private key
+      ansible.builtin.copy:
+        content: "{{ conductor_tls_key_content }}"
+        dest: "{{ conductor_config_dir }}/tls.key"
+        owner: "{{ conductor_user }}"
+        group: "{{ conductor_group }}"
+        mode: "0600"
+      when: conductor_tls_key_content is defined
+      notify: Restart maxwell-daemon
+      no_log: true
+
+  handlers:
+    - name: Restart maxwell-daemon
+      ansible.builtin.systemd:
+        name: maxwell-daemon
+        state: restarted

--- a/deploy/ansible/deploy-agents.yml
+++ b/deploy/ansible/deploy-agents.yml
@@ -1,0 +1,50 @@
+---
+# deploy-agents.yml — Deploy agent workers to fleet machines.
+#
+# Usage:
+#   ansible-playbook -i inventory/fleet.yml deploy-agents.yml
+#   # Target a subset:
+#   ansible-playbook -i inventory/fleet.yml deploy-agents.yml --limit agent-01
+
+- name: Deploy maxwell-daemon agent workers
+  hosts: conductor_agents
+  become: true
+  gather_facts: true
+
+  roles:
+    - maxwell_daemon
+
+  tasks:
+    - name: Configure agent to join the primary
+      ansible.builtin.template:
+        src: roles/maxwell_daemon/templates/config.toml.j2
+        dest: "{{ conductor_config_dir }}/config.toml"
+        owner: "{{ conductor_user }}"
+        group: "{{ conductor_group }}"
+        mode: "0640"
+      vars:
+        conductor_role: agent
+      notify: Restart maxwell-daemon
+      no_log: true
+
+    - name: Register agent with primary controller
+      ansible.builtin.uri:
+        url: "http://{{ primary_host }}:{{ conductor_port }}/api/v1/fleet/register"
+        method: POST
+        body_format: json
+        body:
+          hostname: "{{ ansible_hostname }}"
+          ip: "{{ ansible_default_ipv4.address }}"
+          roles: "{{ agent_roles | default(['worker']) }}"
+        headers:
+          Authorization: "Bearer {{ conductor_admin_token }}"
+        status_code: [200, 201, 409]
+      vars:
+        primary_host: "{{ groups['conductor_primary'][0] }}"
+      when: conductor_admin_token is defined
+
+  handlers:
+    - name: Restart maxwell-daemon
+      ansible.builtin.systemd:
+        name: maxwell-daemon
+        state: restarted

--- a/deploy/ansible/health-check.yml
+++ b/deploy/ansible/health-check.yml
@@ -1,0 +1,41 @@
+---
+# health-check.yml — Verify health of all conductor and agent nodes.
+#
+# Usage:
+#   ansible-playbook -i inventory/fleet.yml health-check.yml
+#
+# Exit code is non-zero if any host fails health checks.
+
+- name: Health-check all fleet nodes
+  hosts: all
+  become: false
+  gather_facts: false
+
+  tasks:
+    - name: Check systemd service is active
+      ansible.builtin.command: systemctl is-active maxwell-daemon
+      register: svc_status
+      changed_when: false
+      failed_when: svc_status.stdout != "active"
+      become: true
+
+    - name: Hit the health endpoint
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ conductor_port }}/api/v1/health"
+        status_code: 200
+        timeout: 5
+      register: health_resp
+
+    - name: Report per-host status
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} — service: {{ svc_status.stdout }}, api: HTTP {{ health_resp.status }}"
+
+- name: Summarise fleet health
+  hosts: localhost
+  gather_facts: false
+  run_once: true
+
+  tasks:
+    - name: Print summary
+      ansible.builtin.debug:
+        msg: "All {{ groups['all'] | length }} nodes passed health checks."

--- a/deploy/ansible/install-conductor.yml
+++ b/deploy/ansible/install-conductor.yml
@@ -1,0 +1,30 @@
+---
+# install-conductor.yml — Install maxwell-daemon, dependencies, and systemd service.
+#
+# Usage:
+#   ansible-playbook -i inventory/fleet.yml install-conductor.yml
+#   ansible-playbook -i inventory/fleet.yml install-conductor.yml -e conductor_version=0.1.0
+
+- name: Install maxwell-daemon on conductor hosts
+  hosts: conductor_primary
+  become: true
+  gather_facts: true
+
+  roles:
+    - maxwell_daemon
+
+  post_tasks:
+    - name: Verify service is running
+      ansible.builtin.systemd:
+        name: maxwell-daemon
+      register: svc
+      failed_when: svc.status.ActiveState != "active"
+
+    - name: Wait for API to become reachable
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ conductor_port }}/api/v1/health"
+        status_code: 200
+      retries: 10
+      delay: 3
+      register: health_check
+      until: health_check.status == 200

--- a/deploy/ansible/inventory/fleet.yml.example
+++ b/deploy/ansible/inventory/fleet.yml.example
@@ -1,0 +1,23 @@
+---
+# Example fleet inventory — copy to fleet.yml and fill in real hosts.
+all:
+  vars:
+    ansible_user: ubuntu
+    ansible_ssh_private_key_file: ~/.ssh/id_ed25519
+    conductor_version: "latest"   # pip version or "git:main"
+    conductor_port: 8765
+    conductor_config_dir: /etc/maxwell-daemon
+    conductor_data_dir: /var/lib/maxwell-daemon
+
+  children:
+    conductor_primary:
+      hosts:
+        primary-01:
+          ansible_host: 192.0.2.10
+
+    conductor_agents:
+      hosts:
+        agent-01:
+          ansible_host: 192.0.2.20
+        agent-02:
+          ansible_host: 192.0.2.21

--- a/deploy/ansible/roles/maxwell_daemon/defaults/main.yml
+++ b/deploy/ansible/roles/maxwell_daemon/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+conductor_version: "latest"
+conductor_user: maxwell
+conductor_group: maxwell
+conductor_port: 8765
+conductor_config_dir: /etc/maxwell-daemon
+conductor_data_dir: /var/lib/maxwell-daemon
+conductor_log_dir: /var/log/maxwell-daemon
+conductor_venv: /opt/maxwell-daemon/venv
+
+# LLM backend — override per host or group_vars
+conductor_backend: anthropic
+conductor_anthropic_api_key: ""
+conductor_openai_api_key: ""
+
+# TLS (leave empty to use plain HTTP on localhost only)
+conductor_tls_cert: ""
+conductor_tls_key: ""
+
+# JWT secret (generated on first deploy if empty)
+conductor_jwt_secret: ""
+
+# Backup retention in days
+conductor_backup_retention_days: 30
+
+# Extra pip packages to install alongside maxwell-daemon
+conductor_extra_packages: []

--- a/deploy/ansible/roles/maxwell_daemon/handlers/main.yml
+++ b/deploy/ansible/roles/maxwell_daemon/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  listen: Reload systemd
+
+- name: Restart maxwell-daemon
+  ansible.builtin.systemd:
+    name: maxwell-daemon
+    state: restarted
+  listen: Restart maxwell-daemon

--- a/deploy/ansible/roles/maxwell_daemon/tasks/main.yml
+++ b/deploy/ansible/roles/maxwell_daemon/tasks/main.yml
@@ -1,0 +1,88 @@
+---
+- name: Create maxwell group
+  ansible.builtin.group:
+    name: "{{ conductor_group }}"
+    system: true
+
+- name: Create maxwell user
+  ansible.builtin.user:
+    name: "{{ conductor_user }}"
+    group: "{{ conductor_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    home: "{{ conductor_data_dir }}"
+    create_home: false
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ conductor_user }}"
+    group: "{{ conductor_group }}"
+    mode: "0750"
+  loop:
+    - "{{ conductor_config_dir }}"
+    - "{{ conductor_data_dir }}"
+    - "{{ conductor_log_dir }}"
+    - /opt/maxwell-daemon
+
+- name: Install system packages
+  ansible.builtin.package:
+    name:
+      - python3
+      - python3-venv
+      - python3-pip
+      - git
+    state: present
+
+- name: Create virtualenv
+  ansible.builtin.command:
+    cmd: python3 -m venv {{ conductor_venv }}
+    creates: "{{ conductor_venv }}/bin/python"
+
+- name: Install maxwell-daemon
+  ansible.builtin.pip:
+    name: >-
+      maxwell-daemon{{ '[all]' if conductor_version == 'latest' else '[all]==' + conductor_version }}
+    virtualenv: "{{ conductor_venv }}"
+    state: "{{ 'latest' if conductor_version == 'latest' else 'present' }}"
+  notify: Restart maxwell-daemon
+
+- name: Install extra packages
+  ansible.builtin.pip:
+    name: "{{ conductor_extra_packages }}"
+    virtualenv: "{{ conductor_venv }}"
+  when: conductor_extra_packages | length > 0
+  notify: Restart maxwell-daemon
+
+- name: Generate JWT secret if not set
+  ansible.builtin.set_fact:
+    conductor_jwt_secret: "{{ lookup('password', '/dev/null length=64 chars=ascii_letters,digits') }}"
+  when: conductor_jwt_secret == ""
+  no_log: true
+
+- name: Deploy configuration
+  ansible.builtin.template:
+    src: config.toml.j2
+    dest: "{{ conductor_config_dir }}/config.toml"
+    owner: "{{ conductor_user }}"
+    group: "{{ conductor_group }}"
+    mode: "0640"
+  notify: Restart maxwell-daemon
+  no_log: true
+
+- name: Deploy systemd unit
+  ansible.builtin.template:
+    src: maxwell-daemon.service.j2
+    dest: /etc/systemd/system/maxwell-daemon.service
+    mode: "0644"
+  notify:
+    - Reload systemd
+    - Restart maxwell-daemon
+
+- name: Enable and start maxwell-daemon
+  ansible.builtin.systemd:
+    name: maxwell-daemon
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/deploy/ansible/roles/maxwell_daemon/templates/config.toml.j2
+++ b/deploy/ansible/roles/maxwell_daemon/templates/config.toml.j2
@@ -1,0 +1,29 @@
+# maxwell-daemon configuration — managed by Ansible, do not edit by hand.
+
+[server]
+host = "127.0.0.1"
+port = {{ conductor_port }}
+{% if conductor_tls_cert %}
+tls_cert = "{{ conductor_tls_cert }}"
+tls_key  = "{{ conductor_tls_key }}"
+{% endif %}
+
+[auth]
+jwt_secret = "{{ conductor_jwt_secret }}"
+
+[storage]
+data_dir = "{{ conductor_data_dir }}"
+log_dir  = "{{ conductor_log_dir }}"
+
+[backends]
+default = "{{ conductor_backend }}"
+
+{% if conductor_anthropic_api_key %}
+[backends.anthropic]
+api_key = "{{ conductor_anthropic_api_key }}"
+{% endif %}
+
+{% if conductor_openai_api_key %}
+[backends.openai]
+api_key = "{{ conductor_openai_api_key }}"
+{% endif %}

--- a/deploy/ansible/roles/maxwell_daemon/templates/maxwell-daemon.service.j2
+++ b/deploy/ansible/roles/maxwell_daemon/templates/maxwell-daemon.service.j2
@@ -1,0 +1,24 @@
+[Unit]
+Description=Maxwell-Daemon agent orchestrator
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+User={{ conductor_user }}
+Group={{ conductor_group }}
+WorkingDirectory={{ conductor_data_dir }}
+ExecStart={{ conductor_venv }}/bin/maxwell-daemon serve \
+    --config {{ conductor_config_dir }}/config.toml
+Restart=on-failure
+RestartSec=5s
+
+# Harden the service
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths={{ conductor_data_dir }} {{ conductor_log_dir }}
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ansible/upgrade-conductor.yml
+++ b/deploy/ansible/upgrade-conductor.yml
@@ -1,0 +1,86 @@
+---
+# upgrade-conductor.yml — Rolling upgrade of maxwell-daemon across the fleet.
+#
+# Upgrades agents first, then the primary controller.
+# Each node is health-checked before the playbook proceeds to the next.
+#
+# Usage:
+#   ansible-playbook -i inventory/fleet.yml upgrade-conductor.yml \
+#     -e conductor_version=0.2.0
+
+- name: Rolling upgrade — agent nodes
+  hosts: conductor_agents
+  become: true
+  gather_facts: false
+  serial: 1   # one node at a time
+
+  tasks:
+    - name: Stop service before upgrade
+      ansible.builtin.systemd:
+        name: maxwell-daemon
+        state: stopped
+
+    - name: Upgrade maxwell-daemon package
+      ansible.builtin.pip:
+        name: >-
+          maxwell-daemon{{ '[all]' if conductor_version == 'latest' else '[all]==' + conductor_version }}
+        virtualenv: "{{ conductor_venv }}"
+        state: "{{ 'latest' if conductor_version == 'latest' else 'present' }}"
+
+    - name: Start service after upgrade
+      ansible.builtin.systemd:
+        name: maxwell-daemon
+        state: started
+
+    - name: Wait for health endpoint
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ conductor_port }}/api/v1/health"
+        status_code: 200
+        timeout: 5
+      retries: 12
+      delay: 5
+      register: health_check
+      until: health_check.status == 200
+
+- name: Rolling upgrade — primary controller
+  hosts: conductor_primary
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Stop primary controller
+      ansible.builtin.systemd:
+        name: maxwell-daemon
+        state: stopped
+
+    - name: Upgrade maxwell-daemon package
+      ansible.builtin.pip:
+        name: >-
+          maxwell-daemon{{ '[all]' if conductor_version == 'latest' else '[all]==' + conductor_version }}
+        virtualenv: "{{ conductor_venv }}"
+        state: "{{ 'latest' if conductor_version == 'latest' else 'present' }}"
+
+    - name: Start primary controller
+      ansible.builtin.systemd:
+        name: maxwell-daemon
+        state: started
+
+    - name: Wait for health endpoint
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ conductor_port }}/api/v1/health"
+        status_code: 200
+        timeout: 5
+      retries: 12
+      delay: 5
+      register: health_check
+      until: health_check.status == 200
+
+    - name: Confirm upgraded version
+      ansible.builtin.command:
+        cmd: "{{ conductor_venv }}/bin/maxwell-daemon --version"
+      register: version_out
+      changed_when: false
+
+    - name: Show new version
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} running {{ version_out.stdout }}"

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,282 @@
+################################################################################
+# Maxwell-Daemon Terraform module
+# Provisions cloud VMs for the conductor fleet on AWS, GCP, or Azure.
+# Cloud is selected via `var.cloud`.
+################################################################################
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+
+##############################################################################
+# SSH keypair (generated per deployment)
+##############################################################################
+
+resource "tls_private_key" "maxwell" {
+  algorithm = "ED25519"
+}
+
+##############################################################################
+# AWS
+##############################################################################
+
+resource "aws_key_pair" "maxwell" {
+  count      = var.cloud == "aws" ? 1 : 0
+  key_name   = "${var.name_prefix}-maxwell"
+  public_key = tls_private_key.maxwell.public_key_openssh
+}
+
+resource "aws_security_group" "maxwell" {
+  count       = var.cloud == "aws" ? 1 : 0
+  name        = "${var.name_prefix}-maxwell"
+  description = "Maxwell-Daemon conductor fleet"
+  vpc_id      = var.aws_vpc_id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "SSH"
+  }
+
+  ingress {
+    from_port   = var.conductor_port
+    to_port     = var.conductor_port
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "Maxwell-Daemon API"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-maxwell" })
+}
+
+resource "aws_instance" "conductor" {
+  count                  = var.cloud == "aws" ? 1 : 0
+  ami                    = var.aws_ami
+  instance_type          = var.aws_instance_type
+  key_name               = aws_key_pair.maxwell[0].key_name
+  vpc_security_group_ids = [aws_security_group.maxwell[0].id]
+  subnet_id              = var.aws_subnet_id
+
+  root_block_device {
+    volume_size = var.disk_size_gb
+    volume_type = "gp3"
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-conductor", Role = "primary" })
+}
+
+resource "aws_instance" "agent" {
+  count                  = var.cloud == "aws" ? var.agent_count : 0
+  ami                    = var.aws_ami
+  instance_type          = var.aws_instance_type
+  key_name               = aws_key_pair.maxwell[0].key_name
+  vpc_security_group_ids = [aws_security_group.maxwell[0].id]
+  subnet_id              = var.aws_subnet_id
+
+  root_block_device {
+    volume_size = var.disk_size_gb
+    volume_type = "gp3"
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-agent-${count.index}", Role = "agent" })
+}
+
+##############################################################################
+# GCP
+##############################################################################
+
+resource "google_compute_firewall" "maxwell" {
+  count   = var.cloud == "gcp" ? 1 : 0
+  name    = "${var.name_prefix}-maxwell"
+  network = var.gcp_network
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", tostring(var.conductor_port)]
+  }
+
+  source_ranges = var.allowed_cidr_blocks
+  target_tags   = ["maxwell-daemon"]
+}
+
+resource "google_compute_instance" "conductor" {
+  count        = var.cloud == "gcp" ? 1 : 0
+  name         = "${var.name_prefix}-conductor"
+  machine_type = var.gcp_machine_type
+  zone         = var.gcp_zone
+  tags         = ["maxwell-daemon"]
+
+  boot_disk {
+    initialize_params {
+      image = var.gcp_image
+      size  = var.disk_size_gb
+    }
+  }
+
+  network_interface {
+    network    = var.gcp_network
+    subnetwork = var.gcp_subnetwork
+    access_config {}
+  }
+
+  metadata = {
+    ssh-keys = "ubuntu:${tls_private_key.maxwell.public_key_openssh}"
+  }
+
+  labels = merge(var.tags, { role = "primary" })
+}
+
+resource "google_compute_instance" "agent" {
+  count        = var.cloud == "gcp" ? var.agent_count : 0
+  name         = "${var.name_prefix}-agent-${count.index}"
+  machine_type = var.gcp_machine_type
+  zone         = var.gcp_zone
+  tags         = ["maxwell-daemon"]
+
+  boot_disk {
+    initialize_params {
+      image = var.gcp_image
+      size  = var.disk_size_gb
+    }
+  }
+
+  network_interface {
+    network    = var.gcp_network
+    subnetwork = var.gcp_subnetwork
+    access_config {}
+  }
+
+  metadata = {
+    ssh-keys = "ubuntu:${tls_private_key.maxwell.public_key_openssh}"
+  }
+
+  labels = merge(var.tags, { role = "agent" })
+}
+
+##############################################################################
+# Azure
+##############################################################################
+
+resource "azurerm_resource_group" "maxwell" {
+  count    = var.cloud == "azure" ? 1 : 0
+  name     = "${var.name_prefix}-maxwell-rg"
+  location = var.azure_location
+  tags     = var.tags
+}
+
+resource "azurerm_network_security_group" "maxwell" {
+  count               = var.cloud == "azure" ? 1 : 0
+  name                = "${var.name_prefix}-maxwell-nsg"
+  location            = azurerm_resource_group.maxwell[0].location
+  resource_group_name = azurerm_resource_group.maxwell[0].name
+  tags                = var.tags
+
+  security_rule {
+    name                       = "SSH"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = join(",", var.allowed_cidr_blocks)
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "Maxwell-API"
+    priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = tostring(var.conductor_port)
+    source_address_prefix      = join(",", var.allowed_cidr_blocks)
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "conductor" {
+  count                           = var.cloud == "azure" ? 1 : 0
+  name                            = "${var.name_prefix}-conductor"
+  resource_group_name             = azurerm_resource_group.maxwell[0].name
+  location                        = azurerm_resource_group.maxwell[0].location
+  size                            = var.azure_vm_size
+  admin_username                  = "ubuntu"
+  disable_password_authentication = true
+  tags                            = merge(var.tags, { role = "primary" })
+
+  admin_ssh_key {
+    username   = "ubuntu"
+    public_key = tls_private_key.maxwell.public_key_openssh
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+    disk_size_gb         = var.disk_size_gb
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  network_interface_ids = [azurerm_network_interface.conductor[0].id]
+}
+
+resource "azurerm_network_interface" "conductor" {
+  count               = var.cloud == "azure" ? 1 : 0
+  name                = "${var.name_prefix}-conductor-nic"
+  location            = azurerm_resource_group.maxwell[0].location
+  resource_group_name = azurerm_resource_group.maxwell[0].name
+  tags                = var.tags
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = var.azure_subnet_id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.conductor[0].id
+  }
+}
+
+resource "azurerm_public_ip" "conductor" {
+  count               = var.cloud == "azure" ? 1 : 0
+  name                = "${var.name_prefix}-conductor-pip"
+  resource_group_name = azurerm_resource_group.maxwell[0].name
+  location            = azurerm_resource_group.maxwell[0].location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,0 +1,69 @@
+################################################################################
+# Outputs — fleet endpoint and SSH details
+################################################################################
+
+output "conductor_public_ip" {
+  description = "Public IP of the primary conductor node"
+  value = (
+    var.cloud == "aws" ? (length(aws_instance.conductor) > 0 ? aws_instance.conductor[0].public_ip : "") :
+    var.cloud == "gcp" ? (length(google_compute_instance.conductor) > 0 ? google_compute_instance.conductor[0].network_interface[0].access_config[0].nat_ip : "") :
+    var.cloud == "azure" ? (length(azurerm_public_ip.conductor) > 0 ? azurerm_public_ip.conductor[0].ip_address : "") :
+    ""
+  )
+}
+
+output "fleet_api_endpoint" {
+  description = "Maxwell-Daemon API base URL"
+  value       = "http://${local.conductor_ip}:${var.conductor_port}/api/v1"
+}
+
+output "agent_ips" {
+  description = "Public IPs of agent worker nodes"
+  value = (
+    var.cloud == "aws" ? aws_instance.agent[*].public_ip :
+    var.cloud == "gcp" ? [for inst in google_compute_instance.agent : inst.network_interface[0].access_config[0].nat_ip] :
+    []
+  )
+}
+
+output "ssh_private_key" {
+  description = "Private SSH key (PEM) — store securely, do not commit"
+  value       = tls_private_key.maxwell.private_key_openssh
+  sensitive   = true
+}
+
+output "ssh_config" {
+  description = "Ready-to-use ~/.ssh/config block for the provisioned fleet"
+  value = <<-EOT
+    Host ${var.name_prefix}-conductor
+      HostName ${local.conductor_ip}
+      User ubuntu
+      IdentityFile ~/.ssh/${var.name_prefix}-maxwell.pem
+
+    %{for i, ip in local.agent_ips~}
+    Host ${var.name_prefix}-agent-${i}
+      HostName ${ip}
+      User ubuntu
+      IdentityFile ~/.ssh/${var.name_prefix}-maxwell.pem
+    %{endfor~}
+  EOT
+}
+
+################################################################################
+# Locals used across outputs
+################################################################################
+
+locals {
+  conductor_ip = (
+    var.cloud == "aws" ? (length(aws_instance.conductor) > 0 ? aws_instance.conductor[0].public_ip : "0.0.0.0") :
+    var.cloud == "gcp" ? (length(google_compute_instance.conductor) > 0 ? google_compute_instance.conductor[0].network_interface[0].access_config[0].nat_ip : "0.0.0.0") :
+    var.cloud == "azure" ? (length(azurerm_public_ip.conductor) > 0 ? azurerm_public_ip.conductor[0].ip_address : "0.0.0.0") :
+    "0.0.0.0"
+  )
+
+  agent_ips = (
+    var.cloud == "aws" ? aws_instance.agent[*].public_ip :
+    var.cloud == "gcp" ? [for inst in google_compute_instance.agent : inst.network_interface[0].access_config[0].nat_ip] :
+    []
+  )
+}

--- a/deploy/terraform/terraform.tfvars.example
+++ b/deploy/terraform/terraform.tfvars.example
@@ -1,0 +1,32 @@
+# Copy to terraform.tfvars and fill in real values.
+# NEVER commit terraform.tfvars — it may contain secrets.
+
+cloud       = "aws"     # aws | gcp | azure
+name_prefix = "maxwell"
+agent_count = 2
+
+conductor_port      = 8765
+disk_size_gb        = 40
+allowed_cidr_blocks = ["10.0.0.0/8"]
+
+tags = {
+  managed-by  = "terraform"
+  project     = "maxwell-daemon"
+  environment = "production"
+}
+
+# ── AWS ─────────────────────────────────────────────────────────────────
+aws_ami           = "ami-0c02fb55956c7d316"  # us-east-1 Ubuntu 22.04
+aws_instance_type = "t3.medium"
+aws_vpc_id        = "vpc-xxxxxxxx"
+aws_subnet_id     = "subnet-xxxxxxxx"
+
+# ── GCP (uncomment if cloud = "gcp") ────────────────────────────────────
+# gcp_project      = "my-gcp-project"
+# gcp_zone         = "us-central1-a"
+# gcp_machine_type = "e2-medium"
+
+# ── Azure (uncomment if cloud = "azure") ────────────────────────────────
+# azure_location  = "East US"
+# azure_vm_size   = "Standard_B2s"
+# azure_subnet_id = "/subscriptions/.../subnets/default"

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,135 @@
+################################################################################
+# Variables
+################################################################################
+
+variable "cloud" {
+  description = "Target cloud provider: aws | gcp | azure"
+  type        = string
+  validation {
+    condition     = contains(["aws", "gcp", "azure"], var.cloud)
+    error_message = "cloud must be one of: aws, gcp, azure"
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+  default     = "maxwell"
+}
+
+variable "agent_count" {
+  description = "Number of agent worker VMs to provision"
+  type        = number
+  default     = 2
+}
+
+variable "conductor_port" {
+  description = "TCP port the Maxwell-Daemon API listens on"
+  type        = number
+  default     = 8765
+}
+
+variable "disk_size_gb" {
+  description = "Root disk size in GB"
+  type        = number
+  default     = 40
+}
+
+variable "allowed_cidr_blocks" {
+  description = "CIDR ranges permitted to reach SSH and the API port"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "tags" {
+  description = "Tags/labels to apply to all resources"
+  type        = map(string)
+  default = {
+    managed-by = "terraform"
+    project    = "maxwell-daemon"
+  }
+}
+
+# ── AWS ───────────────────────────────────────────────────────────────────────
+
+variable "aws_ami" {
+  description = "AMI ID for conductor and agent instances (Ubuntu 22.04 recommended)"
+  type        = string
+  default     = "ami-0c02fb55956c7d316"  # us-east-1 Ubuntu 22.04 LTS
+}
+
+variable "aws_instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "aws_vpc_id" {
+  description = "VPC to place the security group in"
+  type        = string
+  default     = ""
+}
+
+variable "aws_subnet_id" {
+  description = "Subnet to place instances in"
+  type        = string
+  default     = ""
+}
+
+# ── GCP ───────────────────────────────────────────────────────────────────────
+
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+  default     = ""
+}
+
+variable "gcp_zone" {
+  description = "GCP zone for instances"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "gcp_machine_type" {
+  description = "GCP machine type"
+  type        = string
+  default     = "e2-medium"
+}
+
+variable "gcp_image" {
+  description = "GCP boot disk image"
+  type        = string
+  default     = "ubuntu-os-cloud/ubuntu-2204-lts"
+}
+
+variable "gcp_network" {
+  description = "GCP VPC network name"
+  type        = string
+  default     = "default"
+}
+
+variable "gcp_subnetwork" {
+  description = "GCP subnetwork name (leave empty to use default)"
+  type        = string
+  default     = ""
+}
+
+# ── Azure ─────────────────────────────────────────────────────────────────────
+
+variable "azure_location" {
+  description = "Azure region"
+  type        = string
+  default     = "East US"
+}
+
+variable "azure_vm_size" {
+  description = "Azure VM size"
+  type        = string
+  default     = "Standard_B2s"
+}
+
+variable "azure_subnet_id" {
+  description = "Azure subnet resource ID"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- 6 Ansible playbooks under deploy/ansible/: install-conductor, configure-conductor, deploy-agents, health-check, backup-config, upgrade-conductor
- maxwell_daemon Ansible role with tasks, handlers, Jinja2 templates, and defaults
- Terraform module (deploy/terraform/) for AWS EC2, GCP Compute Engine, Azure VMs — cloud selected via var.cloud, outputs fleet_api_endpoint, ssh_private_key, ssh_config

## Test plan
- [x] No Python files changed — existing test suite unaffected
- [x] Secrets via no_log + Ansible Vault pattern; Terraform private key marked sensitive

Closes #10
Closes #11