### PR TITLE
docs: sync fleet-managed AGENTS.md sections — network & API hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ d = json.load(sys.stdin)['resources']
 for k in ['core', 'graphql']:
     r = d[k]
     reset = datetime.datetime.fromtimestamp(r['reset']).strftime('%H:%M:%S')
-    print(f'{k}: {r[\"remaining\"]}/{r[\"limit\"]} remaining — resets {reset}')
+    print(f'{k}: {r["remaining"]}/{r["limit"]} remaining — resets {reset}')
 "
 ```
 


### PR DESCRIPTION
## Summary

Propagates the fleet-wide **Network & API Hygiene** rules from the central [Repository_Management/AGENTS.md](https://github.com/D-sorganization/Repository_Management/blob/main/AGENTS.md) to this repository.

### What changed

The following section is appended to \`AGENTS.md\` (wrapped in fleet-managed markers so future syncs can update it automatically):

- **GraphQL vs REST quota table** — both are 5,000 req/hr but separate; exhausting GraphQL blocks all PR operations fleet-wide
- **No tight polling loops** — \`while true; do gh pr checks; sleep 30\` drains quota in <3 hours
- **REST over GraphQL for CI status checks**
- **Stop monitors immediately** when their condition is satisfied
- **Long polling intervals** (≥270 s)
- Rate limit check command

### Going forward

This section is managed centrally. To update it across all repos, edit \`AGENTS.md\` in Repository_Management and the \`sync-fleet-agents\` workflow will automatically open PRs like this one.

Auto-generated by \`scripts/sync_fleet_agents_sections.sh\`.