### PR TITLE
[codex] Add community contribution framework

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,11 @@ labels: bug
 
 ## What happened
 
+Describe the failure and the command, API call, or workflow that exposed it.
+
 ## What you expected
+
+Describe the behavior you expected instead.
 
 ## Reproduction steps
 
@@ -14,12 +18,20 @@ labels: bug
 # commands / code
 ```
 
+## Impact
+
+- [ ] Blocks all usage
+- [ ] Blocks one backend, repo, or deployment path
+- [ ] Degraded behavior with a workaround
+- [ ] Cosmetic or documentation issue
+
 ## Environment
 
 - Maxwell-Daemon version:
 - Python version:
 - OS:
 - Backend(s) in use:
+- Install method:
 
 ## Config (redact secrets)
 
@@ -30,3 +42,7 @@ labels: bug
 
 ```
 ```
+
+## Additional context
+
+Link related issues, PRs, deployments, or screenshots if relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: mailto:dieterolson@gmail.com
+    about: Please report security issues privately instead of opening a public issue.
+  - name: Roadmap and governance
+    url: https://github.com/D-sorganization/Maxwell-Daemon/blob/main/docs/community/roadmap-governance.md
+    about: Learn how roadmap decisions, voting, and feature proposals are handled.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,6 +12,21 @@ What can't you do today, and what pain does that cause?
 
 What would you like Maxwell-Daemon to do? Include API/CLI/config sketches if relevant.
 
+## Users and workflows
+
+Who needs this, and what workflow should improve?
+
+## Acceptance criteria
+
+- [ ] 
+
+## Compatibility and risks
+
+- Public API impact:
+- Configuration or migration impact:
+- Security impact:
+- Operational impact:
+
 ## Alternatives considered
 
 ## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+- 
+
+## Related Issue
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Refactor or maintenance
+- [ ] CI, release, or infrastructure
+
+## Verification
+
+- [ ] `pytest`
+- [ ] `ruff check .`
+- [ ] `ruff format --check .`
+- [ ] `mypy maxwell_daemon`
+- [ ] Documentation updated, if user-facing behavior changed
+
+## Risk
+
+- [ ] Migration or config changes documented
+- [ ] Secrets, credentials, and tokens are not logged or committed
+- [ ] Backward compatibility impact is described
+
+## Notes for Reviewers
+
+ 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+
+Maxwell-Daemon follows the Contributor Covenant Code of Conduct, version 2.1.
+
+## Our Pledge
+
+We pledge to make participation in this project a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability,
+ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language.
+- Respecting differing viewpoints and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Focusing on what is best for the community.
+- Showing empathy toward other community members.
+
+Examples of unacceptable behavior:
+
+- Sexualized language or imagery, and sexual attention or advances.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information without explicit permission.
+- Other conduct that could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing standards of
+acceptable behavior. They may remove, edit, or reject comments, commits, code,
+wiki edits, issues, and other contributions that do not align with this Code of
+Conduct.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at dieterolson@gmail.com. Reports will be handled as
+confidentially as possible.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1,
+available at https://www.contributor-covenant.org/version/2/1/code_of_conduct/.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,15 @@ pytest
 ruff check .
 ```
 
+Run the full local gate before opening a pull request:
+
+```bash
+ruff check .
+ruff format --check .
+mypy maxwell_daemon
+pytest
+```
+
 ## What we're looking for
 
 The [open issues](https://github.com/D-sorganization/Maxwell-Daemon/issues) are the authoritative list. Good first issues are labelled `good-first-issue`. If you want to tackle something bigger (a new backend, the GUI, the gRPC API), comment on the tracking issue first so we can align on design.
@@ -42,10 +51,21 @@ The `ClaudeBackend` and `OllamaBackend` adapters are good reference implementati
 - Line length 100. Ruff handles formatting.
 - No comments explaining *what* the code does — only *why* when it's non-obvious.
 - Fail fast on misconfiguration; never silently fall back to insecure defaults.
+- Keep public CLI, API, and config changes documented in `docs/`.
 
 ## Reporting bugs
 
 Use the bug-report issue template. Include: Maxwell-Daemon version, Python version, OS, config (redact secrets), and a minimal reproduction.
+
+## Community and governance
+
+Roadmap and decision-making expectations are documented in
+[`docs/community/roadmap-governance.md`](docs/community/roadmap-governance.md).
+The short version: open an issue for substantial design changes, keep discussion
+on the related issue or pull request, and use reactions/comments to signal
+priority with concrete user impact.
+
+All participants are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ See the [full issue roadmap](https://github.com/D-sorganization/Maxwell-Daemon/i
 | 6      | VS Code extension, desktop app  | ⚪ Planned |
 | 7      | Observability & cost analytics  | 🟡 Ledger done, Prometheus next |
 | 8      | Encryption, RBAC, audit logging | ⚪ Planned |
-| 9      | Docs site, community            | ⚪ Planned |
+| 9      | Docs site, community            | 🟡 Community standards scaffolded |
 | 10     | 1.0.0 release                   | ⚪ Target Q3 2026 |
 
 ## Contributing

--- a/docs/community/roadmap-governance.md
+++ b/docs/community/roadmap-governance.md
@@ -1,0 +1,74 @@
+# Roadmap and Governance
+
+Maxwell-Daemon is maintained in public through GitHub issues, pull requests, and
+release milestones. The roadmap is intentionally issue-driven so implementation
+work, design discussion, and release readiness stay linked.
+
+## Decision Model
+
+Maintainers make final calls on scope, security posture, release timing, and
+compatibility. Contributors influence those decisions through:
+
+- Feature requests with clear use cases and proposed interfaces.
+- Pull requests with tests, documentation, and migration notes.
+- Design comments on roadmap issues before implementation starts.
+- User reports that describe real operational constraints.
+
+For small changes, a passing pull request and maintainer approval are enough.
+For changes that affect public APIs, backend contracts, security, configuration,
+or deployment topology, open or update a tracking issue first.
+
+## Roadmap Process
+
+Roadmap issues are organized by phase:
+
+| Phase | Focus |
+| --- | --- |
+| 1 | Foundation and architecture |
+| 2 | Multi-backend LLM support |
+| 3 | VS Code-like GUI |
+| 4 | Remote access and fleet management |
+| 5 | Deployment automation |
+| 6 | Extensions and desktop packaging |
+| 7 | Observability and cost analytics |
+| 8 | Security, RBAC, and audit logging |
+| 9 | Documentation and community |
+| 10 | Beta and production releases |
+
+Each phase issue should define acceptance criteria, expected deliverables, and
+verification. Large phase issues can be split into smaller implementation
+issues when the scope becomes too broad for a single pull request.
+
+## Feature Voting
+
+Community members can signal demand by:
+
+- Reacting with thumbs-up on feature requests.
+- Commenting with concrete workflows, constraints, or failure modes.
+- Linking production examples or integrations that would benefit from the work.
+
+Maintainers prioritize work by user impact, implementation risk, maintenance
+cost, security implications, and alignment with the current release phase.
+
+## Community Channels
+
+The canonical project channel is GitHub:
+
+- Bugs and feature requests: GitHub Issues.
+- Design discussion: the relevant tracking issue.
+- Code review: GitHub Pull Requests.
+- Security reports: private email to the maintainer address in the security
+  section of `CONTRIBUTING.md`.
+
+If GitHub Discussions, Discord, or Slack are added later, this page should be
+updated with links and moderation expectations before the channel is announced.
+
+## Maintainer Responsibilities
+
+Maintainers are expected to:
+
+- Keep roadmap issues accurate enough for contributors to choose work.
+- Label approachable issues for new contributors.
+- Explain rejection or deferral decisions with actionable context.
+- Enforce the Code of Conduct consistently.
+- Avoid merging user-facing changes without matching documentation.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,17 +1,46 @@
 # Contributing
 
-See [CONTRIBUTING.md](https://github.com/D-sorganization/Maxwell-Daemon/blob/main/CONTRIBUTING.md) in the repo root.
+Maxwell-Daemon accepts bug fixes, documentation improvements, backend adapters,
+deployment examples, and feature work that is linked to a public issue.
 
-TL;DR for getting set up:
+## Development Setup
 
 ```bash
 git clone https://github.com/D-sorganization/Maxwell-Daemon.git
 cd Maxwell-Daemon
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-pytest
 ruff check .
+ruff format --check .
 mypy maxwell_daemon
+pytest
 ```
 
-Good first issues live at <https://github.com/D-sorganization/Maxwell-Daemon/labels/good-first-issue>.
+On Windows PowerShell, activate the environment with:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
+```
+
+## Contribution Flow
+
+1. Pick an issue or open one for substantial changes.
+2. Keep each pull request focused on one behavior or documentation goal.
+3. Add tests for runtime behavior and docs for user-facing changes.
+4. Run the local gate before requesting review.
+5. Use the pull request template checklist to call out verification and risk.
+
+Good first issues live at
+<https://github.com/D-sorganization/Maxwell-Daemon/labels/good-first-issue>.
+
+## Community Standards
+
+All contributors must follow the
+[Code of Conduct](https://github.com/D-sorganization/Maxwell-Daemon/blob/main/CODE_OF_CONDUCT.md).
+Security issues should be reported privately to the maintainer address listed in
+the root contribution guide.
+
+Roadmap and governance details live in
+[Roadmap and Governance](community/roadmap-governance.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,4 +64,6 @@ nav:
       - CLI: reference/cli.md
       - Tasks CLI: reference/tasks-cli.md
       - REST API: reference/api.md
-  - Contributing: contributing.md
+  - Community:
+      - Contributing: contributing.md
+      - Roadmap and Governance: community/roadmap-governance.md


### PR DESCRIPTION
## Summary

Completes the core repository infrastructure for issue #20 by adding community standards and contribution workflow metadata.

## Changes

- Add a Contributor Covenant-based code of conduct.
- Add a pull request template with verification and risk sections.
- Configure issue-template routing, including private security reporting.
- Expand bug and feature request templates with impact, acceptance criteria, and compatibility prompts.
- Add roadmap/governance documentation and surface it in the MkDocs navigation.
- Update contributor docs and README roadmap status.

## Validation

Local validation in the generated checkout:

- `python -m ruff check .` passed
- `python -m pytest tests/unit/test_story_templates.py` passed, 14 tests
- `mkdocs.yml` parsed as valid YAML

`python -m mkdocs build --strict` was not run locally because `mkdocs` is not installed in the current environment.

Closes #20
