### PR TITLE
[superseded] Expand documentation site and publishing workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,11 @@ labels: bug
 
 ## What happened
 
+Describe the failure and the command, API call, or workflow that exposed it.
+
 ## What you expected
+
+Describe the behavior you expected instead.
 
 ## Reproduction steps
 
@@ -14,12 +18,20 @@ labels: bug
 # commands / code
 ```
 
+## Impact
+
+- [ ] Blocks all usage
+- [ ] Blocks one backend, repo, or deployment path
+- [ ] Degraded behavior with a workaround
+- [ ] Cosmetic or documentation issue
+
 ## Environment
 
 - Maxwell-Daemon version:
 - Python version:
 - OS:
 - Backend(s) in use:
+- Install method:
 
 ## Config (redact secrets)
 
@@ -30,3 +42,7 @@ labels: bug
 
 ```
 ```
+
+## Additional context
+
+Link related issues, PRs, deployments, or screenshots if relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: mailto:dieterolson@gmail.com
+    about: Please report security issues privately instead of opening a public issue.
+  - name: Roadmap and governance
+    url: https://github.com/D-sorganization/Maxwell-Daemon/blob/main/docs/community/roadmap-governance.md
+    about: Learn how roadmap decisions, voting, and feature proposals are handled.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -12,6 +12,21 @@ What can't you do today, and what pain does that cause?
 
 What would you like Maxwell-Daemon to do? Include API/CLI/config sketches if relevant.
 
+## Users and workflows
+
+Who needs this, and what workflow should improve?
+
+## Acceptance criteria
+
+- [ ] 
+
+## Compatibility and risks
+
+- Public API impact:
+- Configuration or migration impact:
+- Security impact:
+- Operational impact:
+
 ## Alternatives considered
 
 ## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+- 
+
+## Related Issue
+
+Closes #
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Refactor or maintenance
+- [ ] CI, release, or infrastructure
+
+## Verification
+
+- [ ] `pytest`
+- [ ] `ruff check .`
+- [ ] `ruff format --check .`
+- [ ] `mypy maxwell_daemon`
+- [ ] Documentation updated, if user-facing behavior changed
+
+## Risk
+
+- [ ] Migration or config changes documented
+- [ ] Secrets, credentials, and tokens are not logged or committed
+- [ ] Backward compatibility impact is described
+
+## Notes for Reviewers
+
+ 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,40 @@ name: Docs
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  disabled:
-    runs-on: [self-hosted, d-sorg-fleet-4core]
+  build:
+    runs-on: ubuntu-latest
     steps:
-      - run: echo "Docs deployment temporarily disabled — re-enable after 2026-05-01"
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install ".[docs]"
+      - run: mkdocs build --strict --site-dir site
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
 
+  deploy:
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+
+Maxwell-Daemon follows the Contributor Covenant Code of Conduct, version 2.1.
+
+## Our Pledge
+
+We pledge to make participation in this project a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability,
+ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language.
+- Respecting differing viewpoints and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Focusing on what is best for the community.
+- Showing empathy toward other community members.
+
+Examples of unacceptable behavior:
+
+- Sexualized language or imagery, and sexual attention or advances.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information without explicit permission.
+- Other conduct that could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing standards of
+acceptable behavior. They may remove, edit, or reject comments, commits, code,
+wiki edits, issues, and other contributions that do not align with this Code of
+Conduct.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at dieterolson@gmail.com. Reports will be handled as
+confidentially as possible.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1,
+available at https://www.contributor-covenant.org/version/2/1/code_of_conduct/.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,15 @@ pytest
 ruff check .
 ```
 
+Run the full local gate before opening a pull request:
+
+```bash
+ruff check .
+ruff format --check .
+mypy maxwell_daemon
+pytest
+```
+
 ## What we're looking for
 
 The [open issues](https://github.com/D-sorganization/Maxwell-Daemon/issues) are the authoritative list. Good first issues are labelled `good-first-issue`. If you want to tackle something bigger (a new backend, the GUI, the gRPC API), comment on the tracking issue first so we can align on design.
@@ -42,10 +51,21 @@ The `ClaudeBackend` and `OllamaBackend` adapters are good reference implementati
 - Line length 100. Ruff handles formatting.
 - No comments explaining *what* the code does — only *why* when it's non-obvious.
 - Fail fast on misconfiguration; never silently fall back to insecure defaults.
+- Keep public CLI, API, and config changes documented in `docs/`.
 
 ## Reporting bugs
 
 Use the bug-report issue template. Include: Maxwell-Daemon version, Python version, OS, config (redact secrets), and a minimal reproduction.
+
+## Community and governance
+
+Roadmap and decision-making expectations are documented in
+[`docs/community/roadmap-governance.md`](docs/community/roadmap-governance.md).
+The short version: open an issue for substantial design changes, keep discussion
+on the related issue or pull request, and use reactions/comments to signal
+priority with concrete user impact.
+
+All participants are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ See the [full issue roadmap](https://github.com/D-sorganization/Maxwell-Daemon/i
 | 6      | VS Code extension, desktop app  | ⚪ Planned |
 | 7      | Observability & cost analytics  | 🟡 Ledger done, Prometheus next |
 | 8      | Encryption, RBAC, audit logging | ⚪ Planned |
-| 9      | Docs site, community            | ⚪ Planned |
+| 9      | Docs site, community            | 🟡 Community standards scaffolded |
 | 10     | 1.0.0 release                   | ⚪ Target Q3 2026 |
 
 ## Contributing

--- a/docs/community/roadmap-governance.md
+++ b/docs/community/roadmap-governance.md
@@ -1,0 +1,74 @@
+# Roadmap and Governance
+
+Maxwell-Daemon is maintained in public through GitHub issues, pull requests, and
+release milestones. The roadmap is intentionally issue-driven so implementation
+work, design discussion, and release readiness stay linked.
+
+## Decision Model
+
+Maintainers make final calls on scope, security posture, release timing, and
+compatibility. Contributors influence those decisions through:
+
+- Feature requests with clear use cases and proposed interfaces.
+- Pull requests with tests, documentation, and migration notes.
+- Design comments on roadmap issues before implementation starts.
+- User reports that describe real operational constraints.
+
+For small changes, a passing pull request and maintainer approval are enough.
+For changes that affect public APIs, backend contracts, security, configuration,
+or deployment topology, open or update a tracking issue first.
+
+## Roadmap Process
+
+Roadmap issues are organized by phase:
+
+| Phase | Focus |
+| --- | --- |
+| 1 | Foundation and architecture |
+| 2 | Multi-backend LLM support |
+| 3 | VS Code-like GUI |
+| 4 | Remote access and fleet management |
+| 5 | Deployment automation |
+| 6 | Extensions and desktop packaging |
+| 7 | Observability and cost analytics |
+| 8 | Security, RBAC, and audit logging |
+| 9 | Documentation and community |
+| 10 | Beta and production releases |
+
+Each phase issue should define acceptance criteria, expected deliverables, and
+verification. Large phase issues can be split into smaller implementation
+issues when the scope becomes too broad for a single pull request.
+
+## Feature Voting
+
+Community members can signal demand by:
+
+- Reacting with thumbs-up on feature requests.
+- Commenting with concrete workflows, constraints, or failure modes.
+- Linking production examples or integrations that would benefit from the work.
+
+Maintainers prioritize work by user impact, implementation risk, maintenance
+cost, security implications, and alignment with the current release phase.
+
+## Community Channels
+
+The canonical project channel is GitHub:
+
+- Bugs and feature requests: GitHub Issues.
+- Design discussion: the relevant tracking issue.
+- Code review: GitHub Pull Requests.
+- Security reports: private email to the maintainer address in the security
+  section of `CONTRIBUTING.md`.
+
+If GitHub Discussions, Discord, or Slack are added later, this page should be
+updated with links and moderation expectations before the channel is announced.
+
+## Maintainer Responsibilities
+
+Maintainers are expected to:
+
+- Keep roadmap issues accurate enough for contributors to choose work.
+- Label approachable issues for new contributors.
+- Explain rejection or deferral decisions with actionable context.
+- Enforce the Code of Conduct consistently.
+- Avoid merging user-facing changes without matching documentation.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,17 +1,46 @@
 # Contributing
 
-See [CONTRIBUTING.md](https://github.com/D-sorganization/Maxwell-Daemon/blob/main/CONTRIBUTING.md) in the repo root.
+Maxwell-Daemon accepts bug fixes, documentation improvements, backend adapters,
+deployment examples, and feature work that is linked to a public issue.
 
-TL;DR for getting set up:
+## Development Setup
 
 ```bash
 git clone https://github.com/D-sorganization/Maxwell-Daemon.git
 cd Maxwell-Daemon
 python -m venv .venv && source .venv/bin/activate
 pip install -e ".[dev]"
-pytest
 ruff check .
+ruff format --check .
 mypy maxwell_daemon
+pytest
 ```
 
-Good first issues live at <https://github.com/D-sorganization/Maxwell-Daemon/labels/good-first-issue>.
+On Windows PowerShell, activate the environment with:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -e ".[dev]"
+```
+
+## Contribution Flow
+
+1. Pick an issue or open one for substantial changes.
+2. Keep each pull request focused on one behavior or documentation goal.
+3. Add tests for runtime behavior and docs for user-facing changes.
+4. Run the local gate before requesting review.
+5. Use the pull request template checklist to call out verification and risk.
+
+Good first issues live at
+<https://github.com/D-sorganization/Maxwell-Daemon/labels/good-first-issue>.
+
+## Community Standards
+
+All contributors must follow the
+[Code of Conduct](https://github.com/D-sorganization/Maxwell-Daemon/blob/main/CODE_OF_CONDUCT.md).
+Security issues should be reported privately to the maintainer address listed in
+the root contribution guide.
+
+Roadmap and governance details live in
+[Roadmap and Governance](community/roadmap-governance.md).

--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -1,0 +1,83 @@
+# Examples
+
+These examples show common Maxwell-Daemon workflows from a fresh checkout.
+
+## Smoke Test a Backend
+
+Use `health` first so credential or network failures are visible before a task
+enters the queue.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+maxwell-daemon health
+maxwell-daemon ask "Summarize this repository in five bullets"
+```
+
+## Route Cheap Work to a Local Model
+
+Use repo overrides when a repository has repetitive maintenance work that does
+not need a frontier model.
+
+```yaml
+agent:
+  default_backend: claude
+
+repos:
+  - name: docs-scratch
+    path: ~/work/docs-scratch
+    backend: local
+    model: llama3.1
+```
+
+Then run:
+
+```bash
+maxwell-daemon ask "Find stale links in docs/" --repo docs-scratch
+```
+
+## Queue GitHub Issue Work
+
+Use the tasks CLI when you want issue-driven implementation instead of a one-shot
+prompt.
+
+```bash
+maxwell-daemon tasks enqueue \
+  --repo my-service \
+  --issue https://github.com/example/my-service/issues/42
+
+maxwell-daemon tasks list
+maxwell-daemon-runner
+```
+
+The runner resolves repository context, selects a backend, runs the task, and
+records the result in the local task store.
+
+## Run a Small Fleet
+
+Each machine needs the same config shape and a unique fleet entry.
+
+```yaml
+fleet:
+  discovery_method: manual
+  heartbeat_seconds: 30
+  machines:
+    - name: laptop
+      host: 192.168.1.20
+      port: 8080
+      capacity: 2
+      tags: [local]
+    - name: gpu-box
+      host: 192.168.1.30
+      port: 8080
+      capacity: 6
+      tags: [gpu, local]
+```
+
+Start the API on each node:
+
+```bash
+maxwell-daemon serve
+```
+
+Use the fleet status commands from the coordinator to confirm nodes are visible
+before dispatching long-running work.

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -1,0 +1,70 @@
+# Troubleshooting
+
+Start with the smallest failing command and work outward: config load, backend
+health, API health, then task execution.
+
+## Config Does Not Load
+
+Check which config file is being used:
+
+```bash
+echo "$MAXWELL_CONFIG"
+maxwell-daemon status
+```
+
+Common causes:
+
+- Environment variables referenced as `${VAR}` are unset.
+- YAML indentation changed the shape of `backends`, `agent`, or `repos`.
+- A repo override names a backend that is not registered.
+
+## Backend Health Fails
+
+Run:
+
+```bash
+maxwell-daemon health
+```
+
+For remote APIs, confirm the key is present in the same shell that runs the
+daemon. For Ollama, confirm the server is up:
+
+```bash
+curl http://localhost:11434/api/tags
+```
+
+## Tasks Stay Queued
+
+Check that the runner is active:
+
+```bash
+maxwell-daemon tasks list
+maxwell-daemon-runner
+```
+
+If a runner exits immediately, inspect the logs for config errors or missing
+repository paths. Repository paths are resolved on the worker machine, not on
+the coordinator that created the task.
+
+## API Returns 401
+
+If `api.auth_token` is set, every `/api/v1/*` request must include:
+
+```http
+Authorization: Bearer <token>
+```
+
+The `/health` and `/metrics` endpoints are intentionally unauthenticated for
+infrastructure probes.
+
+## WebSocket Events Disconnect
+
+Slow subscribers are dropped so they do not block the daemon. Consume events
+promptly and reconnect from the last task state your client has persisted.
+
+Browser WebSocket APIs cannot set authorization headers, so pass the API token
+as a query parameter:
+
+```text
+wss://host/api/v1/events?token=<token>
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,10 @@ Existing autonomous-agent tools lock you to one vendor and one machine. Maxwell-
 
 - [Quick start](getting-started/quickstart.md) — install, init, ask
 - [Configuration](getting-started/configuration.md) — `maxwell-daemon.yaml` reference
+- [Examples](getting-started/examples.md) — common local, GitHub, and fleet workflows
+- [Troubleshooting](getting-started/troubleshooting.md) — diagnose config, backend, API, and task failures
 - [Architecture overview](architecture/overview.md) — how the pieces fit together
 - [Backend interface](architecture/backends.md) — add a new LLM in under an hour
 - [Design by Contract](architecture/contracts.md) — how Maxwell-Daemon stays correct at the boundaries
+- [Deployment guide](operations/deployment.md) — local, Ansible, Terraform, and container deployment paths
+- [Configuration reference](reference/configuration.md) — complete config keys and routing precedence

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,0 +1,81 @@
+# Deployment Guide
+
+Maxwell-Daemon can run as a local developer process, a systemd service managed
+by Ansible, or a cloud fleet provisioned with Terraform. Choose the smallest
+deployment model that matches the number of workers you need.
+
+## Local Service
+
+Use a local service for single-machine development or workstation automation.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+maxwell-daemon init
+maxwell-daemon health
+maxwell-daemon-runner
+```
+
+Keep secrets in the environment or your OS secret manager. Do not commit API
+keys to `maxwell-daemon.yaml`.
+
+## Ansible Fleet
+
+Use Ansible when you already know the hosts that should run workers.
+
+```bash
+cp ansible/inventory.example.yml ansible/inventory.yml
+$EDITOR ansible/inventory.yml
+ansible-playbook -i ansible/inventory.yml ansible/playbooks/install.yml
+```
+
+The playbook installs Python, creates a dedicated service user, renders
+configuration, installs a hardened systemd unit, and starts the daemon.
+
+Use the playbooks under `deploy/ansible/` for conductor-oriented fleet
+operations such as backups, health checks, upgrades, and agent deployment.
+
+## Terraform Infrastructure
+
+Use Terraform when the fleet should be provisioned from scratch.
+
+```bash
+cd deploy/terraform
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars
+terraform init
+terraform plan
+terraform apply
+```
+
+The Terraform module defines the cloud resources and outputs connection details
+that can feed the Ansible inventory or another configuration-management layer.
+
+## Containers and Kubernetes
+
+For container platforms, build an image with the project installed and provide
+configuration through mounted files plus environment variables:
+
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+RUN pip install .
+CMD ["maxwell-daemon-runner"]
+```
+
+In Kubernetes, keep API keys in Secrets, mount configuration as a ConfigMap, and
+run separate Deployments for API-serving nodes and worker nodes when you need
+different scaling policies.
+
+## Release Checklist
+
+Before promoting a deployment:
+
+- `maxwell-daemon health` passes on every backend expected to serve traffic.
+- `/health` is reachable from the load balancer or service monitor.
+- `/metrics` is scraped by Prometheus or an equivalent collector.
+- Budget thresholds are configured for paid backends.
+- Logs include task lifecycle events but do not include secrets.
+- Rollback instructions are documented for the selected deployment path.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,102 @@
+# Configuration Reference
+
+Maxwell-Daemon reads YAML configuration from
+`~/.config/maxwell-daemon/maxwell-daemon.yaml` unless `MAXWELL_CONFIG` points to
+another file.
+
+Environment references in the form `${VAR}` and `${VAR:-default}` are expanded
+when the config is loaded.
+
+## Top-Level Keys
+
+| Key | Required | Purpose |
+| --- | --- | --- |
+| `version` | Yes | Configuration schema version. Use `"1"`. |
+| `backends` | Yes | Named LLM backend definitions. |
+| `agent` | Yes | Default routing and loop behavior. |
+| `repos` | No | Per-repository routing overrides and worker slots. |
+| `fleet` | No | Multi-machine discovery and capacity metadata. |
+| `api` | No | HTTP API host, port, and authentication settings. |
+| `budget` | No | Monthly cost limits and alert thresholds. |
+
+## Backend Fields
+
+Every backend has a registry `type` and provider-specific fields.
+
+```yaml
+backends:
+  claude:
+    type: claude
+    model: claude-sonnet-4-6
+    api_key: ${ANTHROPIC_API_KEY}
+    enabled: true
+```
+
+Common fields:
+
+| Field | Purpose |
+| --- | --- |
+| `type` | Adapter name registered by Maxwell-Daemon. |
+| `model` | Provider model identifier. |
+| `api_key` | Secret token, usually provided from the environment. |
+| `base_url` | Endpoint for local or OpenAI-compatible providers. |
+| `enabled` | Set false to keep a backend configured but unavailable. |
+
+## Agent Fields
+
+```yaml
+agent:
+  default_backend: claude
+  max_turns: 200
+  discovery_interval_seconds: 300
+  delivery_interval_seconds: 60
+  reasoning_effort: medium
+  temperature: 1.0
+```
+
+`default_backend` must match a key under `backends`.
+
+## Repository Overrides
+
+Repository entries let you route work by repo name.
+
+```yaml
+repos:
+  - name: my-service
+    path: ~/work/my-service
+    slots: 2
+    backend: claude
+    model: claude-opus-4-7
+```
+
+Routing precedence is:
+
+1. Explicit backend or model passed with the task.
+2. Repository-level backend or model.
+3. Global agent default.
+
+## API Settings
+
+```yaml
+api:
+  enabled: true
+  host: 127.0.0.1
+  port: 8080
+  auth_token: ${MAXWELL_API_TOKEN}
+```
+
+When `auth_token` is configured, `/api/v1/*` routes require bearer-token
+authentication. `/health` and `/metrics` remain available for infrastructure
+probes.
+
+## Budget Settings
+
+```yaml
+budget:
+  monthly_limit_usd: 200.0
+  alert_thresholds: [0.75, 0.9, 1.0]
+  hard_stop: false
+```
+
+Set `hard_stop: true` when exceeding the monthly budget should block additional
+paid backend calls instead of only alerting.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,4 +64,6 @@ nav:
       - CLI: reference/cli.md
       - Tasks CLI: reference/tasks-cli.md
       - REST API: reference/api.md
-  - Contributing: contributing.md
+  - Community:
+      - Contributing: contributing.md
+      - Roadmap and Governance: community/roadmap-governance.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,11 +51,14 @@ nav:
       - Quick start: getting-started/quickstart.md
       - Configuration: getting-started/configuration.md
       - Autonomous workflow: getting-started/autonomous-workflow.md
+      - Examples: getting-started/examples.md
+      - Troubleshooting: getting-started/troubleshooting.md
   - Architecture:
       - Overview: architecture/overview.md
       - Backend interface: architecture/backends.md
       - Design by Contract: architecture/contracts.md
   - Operations:
+      - Deployment guide: operations/deployment.md
       - Deployment (Ansible): operations/ansible.md
       - Observability: operations/observability.md
       - Budgets: operations/budgets.md
@@ -64,6 +67,7 @@ nav:
       - CLI: reference/cli.md
       - Tasks CLI: reference/tasks-cli.md
       - REST API: reference/api.md
+      - Configuration: reference/configuration.md
   - Community:
       - Contributing: contributing.md
       - Roadmap and Governance: community/roadmap-governance.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,11 @@ google = ["google-cloud-aiplatform>=1.70.0"]
 azure = ["azure-identity>=1.18.0"]
 grpc = ["grpcio>=1.66.0", "grpcio-tools>=1.66.0", "protobuf>=5.28.0"]
 ssh = ["asyncssh>=2.14.0"]
+docs = [
+    "mkdocs>=1.6.0",
+    "mkdocs-material>=9.5.0",
+    "pymdown-extensions>=10.0",
+]
 dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.24.0",


### PR DESCRIPTION
Superseded by a fresh branch from current `main` because this stacked branch became dirty after PR #137 merged. The same issue #19 documentation-site changes are being republished without the merge conflict.