### PR TITLE
fix: EventBus thread-safety and replace bare asserts with explicit guards

### DIFF
--- a/maxwell_daemon/cli/tasks.py
+++ b/maxwell_daemon/cli/tasks.py
@@ -68,7 +68,8 @@ def list_tasks(
         p = _preset_store().get(preset)
         if p is None:
             _fail(f"preset {preset!r} not found — try `maxwell-daemon tasks preset list`")
-        assert p is not None
+        if p is None:  # pragma: no cover — guarded by _fail() above which raises SystemExit
+            return
         status = status or p.status
         kind = kind or p.kind
         repo = repo or p.repo

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -82,7 +82,8 @@ class RepoConfig(BaseModel):
     def _expand_path(cls, v: Any) -> Path:
         if isinstance(v, str):
             return Path(v).expanduser()
-        assert isinstance(v, Path)
+        if not isinstance(v, Path):  # pragma: no cover — pydantic only calls with str or Path
+            raise TypeError(f"Expected str or Path, got {type(v).__name__}")
         return v
 
 

--- a/maxwell_daemon/core/cost_alerter.py
+++ b/maxwell_daemon/core/cost_alerter.py
@@ -91,7 +91,8 @@ class CostAlerter:
         )
 
     async def send(self, dispatch: AlertDispatch) -> None:
-        assert self._webhook_url is not None
+        if self._webhook_url is None:
+            raise RuntimeError("CostAlerter.send() called but no webhook_url is configured")
         payload = format_slack_payload(dispatch)
         async with httpx.AsyncClient() as client:
             r = await client.post(self._webhook_url, json=payload, timeout=10.0)

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -501,8 +501,8 @@ class Daemon:
         from maxwell_daemon.gh.executor import IssueExecutor
         from maxwell_daemon.gh.workspace import Workspace
 
-        assert task.issue_repo is not None
-        assert task.issue_number is not None
+        if task.issue_repo is None or task.issue_number is None:
+            raise ValueError(f"Task {task.id} is missing issue_repo or issue_number")
 
         github = self._github_client or GitHubClient()
         workspace = self._workspace or Workspace(root=self._workspace_root)

--- a/maxwell_daemon/daemon/scheduler.py
+++ b/maxwell_daemon/daemon/scheduler.py
@@ -157,7 +157,8 @@ class DiscoveryScheduler:
         self._stop_event = None
 
     async def _loop(self) -> None:
-        assert self._stop_event is not None
+        if self._stop_event is None:  # pragma: no cover — only reachable if start() wasn't called
+            raise RuntimeError("DiscoveryScheduler._loop() called before start()")
         # Startup jitter: spread first-tick firing across the interval to
         # prevent thundering herd when multiple daemons start together.
         if self._jitter:

--- a/maxwell_daemon/events.py
+++ b/maxwell_daemon/events.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -60,10 +61,12 @@ class EventBus:
 
     def __init__(self) -> None:
         self._subscribers: set[asyncio.Queue[Event]] = set()
+        self._lock = threading.Lock()
 
     async def publish(self, event: Event) -> None:
-        # No lock needed for a snapshot read; set iteration is atomic.
-        for q in list(self._subscribers):
+        with self._lock:
+            snapshot = list(self._subscribers)
+        for q in snapshot:
             try:
                 q.put_nowait(event)
             except asyncio.QueueFull:
@@ -79,14 +82,17 @@ class EventBus:
         ``aclose()`` or when the last reference is dropped).
         """
         queue: asyncio.Queue[Event] = asyncio.Queue(maxsize=queue_size)
-        self._subscribers.add(queue)
+        with self._lock:
+            self._subscribers.add(queue)
         return _Subscription(self, queue)
 
     def subscriber_count(self) -> int:
-        return len(self._subscribers)
+        with self._lock:
+            return len(self._subscribers)
 
     def _unsubscribe(self, queue: asyncio.Queue[Event]) -> None:
-        self._subscribers.discard(queue)
+        with self._lock:
+            self._subscribers.discard(queue)
 
 
 class _Subscription:

--- a/maxwell_daemon/github_auth.py
+++ b/maxwell_daemon/github_auth.py
@@ -93,7 +93,8 @@ class GitHubAuth:
     @property
     def token(self) -> str:
         if self._mode == "token":
-            assert self._static_token is not None
+            if self._static_token is None:  # pragma: no cover — invariant: set by from_token
+                raise RuntimeError("GitHubAuth in token mode but _static_token is None")
             return self._static_token
         return self._installation_token()
 

--- a/tests/unit/test_backend_claude.py
+++ b/tests/unit/test_backend_claude.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from maxwell_daemon.backends.base import (
@@ -96,6 +98,101 @@ class TestCostEstimation:
         )
         # 1k input @ $3/M + 500 output @ $15/M = 0.003 + 0.0075 = 0.0105
         assert cost == pytest.approx(0.0105, rel=1e-3)
+
+
+class _FakeClaudeStream:
+    def __init__(self, values: list[str]) -> None:
+        self.text_stream = self._iter(values)
+
+    async def _iter(self, values: list[str]) -> object:
+        for v in values:
+            yield v
+
+    async def __aenter__(self) -> _FakeClaudeStream:
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class TestRequestPaths:
+    @pytest.mark.asyncio
+    async def test_complete_maps_text_blocks_and_usage(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[dict[str, object]] = []
+
+        async def fake_create(**kwargs: object) -> object:
+            calls.append(kwargs)
+            return SimpleNamespace(
+                content=[
+                    SimpleNamespace(type="text", text="alpha"),
+                    SimpleNamespace(type="image", text="skip"),
+                    SimpleNamespace(type="text", text="beta"),
+                ],
+                stop_reason=None,
+                usage=SimpleNamespace(
+                    input_tokens=5,
+                    output_tokens=8,
+                    cache_read_input_tokens=None,
+                ),
+                model="claude-haiku-4-5",
+                model_dump=lambda: {"ok": True},
+            )
+
+        fake_messages = SimpleNamespace(
+            create=fake_create,
+            stream=lambda **_: _FakeClaudeStream(["x", "y"]),
+        )
+        fake_client = SimpleNamespace(messages=fake_messages)
+        monkeypatch.setattr(
+            "maxwell_daemon.backends.claude.anthropic.AsyncAnthropic",
+            lambda **_: fake_client,
+        )
+
+        backend = ClaudeBackend(api_key="x")
+        out = await backend.complete(
+            [
+                Message(role=MessageRole.SYSTEM, content="policy"),
+                Message(role=MessageRole.USER, content="hi"),
+            ],
+            model="claude-haiku-4-5",
+            tools=[{"name": "x"}],
+            metadata={"trace": "1"},
+        )
+
+        assert out.content == "alphabeta"
+        assert out.finish_reason == "stop"
+        assert out.usage.total_tokens == 13
+        assert out.raw == {"ok": True}
+        assert calls and calls[0]["tools"] == [{"name": "x"}]
+        assert calls[0]["metadata"] == {"trace": "1"}
+
+    @pytest.mark.asyncio
+    async def test_stream_and_health_check_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def ok_create(**_: object) -> object:
+            return SimpleNamespace()
+
+        fake_messages = SimpleNamespace(
+            create=ok_create,
+            stream=lambda **_: _FakeClaudeStream(["part-1", "part-2"]),
+        )
+        fake_client = SimpleNamespace(messages=fake_messages)
+        monkeypatch.setattr(
+            "maxwell_daemon.backends.claude.anthropic.AsyncAnthropic",
+            lambda **_: fake_client,
+        )
+        backend = ClaudeBackend(api_key="x")
+
+        parts = [p async for p in backend.stream([], model="claude-haiku-4-5")]
+        assert parts == ["part-1", "part-2"]
+        assert await backend.health_check() is True
+
+        async def broken_create(**_: object) -> object:
+            raise RuntimeError("down")
+
+        fake_client.messages = SimpleNamespace(create=broken_create, stream=fake_messages.stream)
+        assert await backend.health_check() is False
 
 
 class TestRegistry:

--- a/tests/unit/test_backend_openai.py
+++ b/tests/unit/test_backend_openai.py
@@ -8,9 +8,12 @@ integration test tier.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from maxwell_daemon.backends.base import BackendUnavailableError
+from maxwell_daemon.backends.base import Message, MessageRole
 from maxwell_daemon.backends.openai import OpenAIBackend
 from maxwell_daemon.backends.registry import registry
 
@@ -70,6 +73,114 @@ class TestCostEstimation:
         small = backend.estimate_cost(TokenUsage(100, 100, 200), "gpt-4o")
         big = backend.estimate_cost(TokenUsage(1000, 1000, 2000), "gpt-4o")
         assert big == pytest.approx(small * 10)
+
+
+class _FakeOpenAIStream:
+    def __init__(self, parts: list[str | None]) -> None:
+        self._parts = parts
+        self._i = 0
+
+    def __aiter__(self) -> _FakeOpenAIStream:
+        return self
+
+    async def __anext__(self) -> object:
+        if self._i >= len(self._parts):
+            raise StopAsyncIteration
+        part = self._parts[self._i]
+        self._i += 1
+        return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=part))])
+
+
+class TestRequestPaths:
+    @pytest.fixture(autouse=True)
+    def _key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    @pytest.mark.asyncio
+    async def test_complete_maps_response_and_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[dict[str, object]] = []
+
+        async def fake_create(**kwargs: object) -> object:
+            calls.append(kwargs)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content=None),
+                        finish_reason=None,
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+                model="gpt-4o-mini",
+                model_dump=lambda: {"ok": True},
+            )
+
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create)),
+            models=SimpleNamespace(list=lambda: []),
+        )
+        monkeypatch.setattr(
+            "maxwell_daemon.backends.openai.openai.AsyncOpenAI",
+            lambda **_: fake_client,
+        )
+
+        backend = OpenAIBackend()
+        resp = await backend.complete(
+            [Message(role=MessageRole.USER, content="hi")],
+            model="gpt-4o-mini",
+            max_tokens=64,
+            tools=[{"type": "function"}],
+            top_p=0.5,
+        )
+
+        assert resp.content == ""
+        assert resp.finish_reason == "stop"
+        assert resp.usage.total_tokens == 18
+        assert resp.raw == {"ok": True}
+        assert calls and calls[0]["max_tokens"] == 64
+        assert calls[0]["tools"] == [{"type": "function"}]
+        assert calls[0]["top_p"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_stream_and_health_check_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[dict[str, object]] = []
+
+        async def fake_create(**kwargs: object) -> object:
+            calls.append(kwargs)
+            assert kwargs["stream"] is True
+            return _FakeOpenAIStream(["a", None, "b"])
+
+        async def ok_models_list() -> list[str]:
+            return ["gpt-4o-mini"]
+
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create)),
+            models=SimpleNamespace(list=ok_models_list),
+        )
+        monkeypatch.setattr(
+            "maxwell_daemon.backends.openai.openai.AsyncOpenAI",
+            lambda **_: fake_client,
+        )
+        backend = OpenAIBackend()
+
+        parts = [
+            p
+            async for p in backend.stream(
+                [],
+                model="gpt-4o-mini",
+                max_tokens=12,
+                tools=[{"type": "function"}],
+            )
+        ]
+        assert parts == ["a", "b"]
+        assert calls and calls[0]["max_tokens"] == 12
+        assert calls[0]["tools"] == [{"type": "function"}]
+        assert await backend.health_check() is True
+
+        async def broken_models_list() -> list[str]:
+            raise RuntimeError("boom")
+
+        fake_client.models = SimpleNamespace(list=broken_models_list)
+        assert await backend.health_check() is False
 
 
 class TestRegistry:

--- a/tests/unit/test_backend_openai.py
+++ b/tests/unit/test_backend_openai.py
@@ -12,8 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from maxwell_daemon.backends.base import BackendUnavailableError
-from maxwell_daemon.backends.base import Message, MessageRole
+from maxwell_daemon.backends.base import BackendUnavailableError, Message, MessageRole
 from maxwell_daemon.backends.openai import OpenAIBackend
 from maxwell_daemon.backends.registry import registry
 

--- a/tests/unit/test_github_auth.py
+++ b/tests/unit/test_github_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import time
 from unittest.mock import MagicMock, patch
 
@@ -42,6 +43,14 @@ class TestTokenAuth:
         cfg.github = None
         with pytest.raises(ValueError, match="GitHub token not configured"):
             GitHubAuth.from_config(cfg)
+
+    def test_from_config_reads_github_token_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_from_github_env")
+        cfg = MagicMock()
+        cfg.github = None
+        auth = GitHubAuth.from_config(cfg)
+        assert auth.token == "ghp_from_github_env"
 
 
 class TestAppAuth:
@@ -105,3 +114,60 @@ class TestAppAuth:
 
         with patch.dict("sys.modules", {"jwt": None}), pytest.raises(ImportError, match="PyJWT"):
             auth._fetch_installation_token()
+
+    def test_no_httpx_import_raises_helpful_error(self) -> None:
+        auth = self._make_auth()
+        fake_jwt = MagicMock()
+        fake_jwt.encode.return_value = "jwt"
+        with patch.dict("sys.modules", {"jwt": fake_jwt, "httpx": None}):
+            with pytest.raises(ImportError, match="httpx"):
+                auth._fetch_installation_token()
+
+    def test_fetch_installation_token_success(self) -> None:
+        auth = self._make_auth()
+
+        fake_jwt = MagicMock()
+        fake_jwt.encode.return_value = "jwt-token"
+
+        response = MagicMock()
+        response.json.return_value = {
+            "token": "inst_token",
+            "expires_at": "2099-01-01T00:00:00Z",
+        }
+        fake_httpx = MagicMock()
+        fake_httpx.post.return_value = response
+
+        with patch.dict("sys.modules", {"jwt": fake_jwt, "httpx": fake_httpx}):
+            token, expires_at = auth._fetch_installation_token()
+
+        assert token == "inst_token"
+        assert expires_at > time.monotonic()
+        response.raise_for_status.assert_called_once()
+        fake_httpx.post.assert_called_once()
+
+
+class TestAppConfig:
+    def test_from_config_app_mode_reads_pem(self, tmp_path: Path) -> None:
+        pem = tmp_path / "key.pem"
+        pem.write_text("PEM", encoding="utf-8")
+
+        cfg = MagicMock()
+        cfg.github.auth_method = "app"
+        cfg.github.private_key_path = str(pem)
+        cfg.github.app_id = "101"
+        cfg.github.installation_id = "202"
+
+        auth = GitHubAuth.from_config(cfg)
+        assert auth._mode == "app"
+        assert auth._app_id == 101
+        assert auth._installation_id == 202
+
+    def test_from_config_app_mode_missing_pem(self, tmp_path: Path) -> None:
+        cfg = MagicMock()
+        cfg.github.auth_method = "app"
+        cfg.github.private_key_path = str(tmp_path / "missing.pem")
+        cfg.github.app_id = "101"
+        cfg.github.installation_id = "202"
+
+        with pytest.raises(FileNotFoundError):
+            GitHubAuth.from_config(cfg)

--- a/tests/unit/test_github_auth.py
+++ b/tests/unit/test_github_auth.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import time
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -119,9 +119,11 @@ class TestAppAuth:
         auth = self._make_auth()
         fake_jwt = MagicMock()
         fake_jwt.encode.return_value = "jwt"
-        with patch.dict("sys.modules", {"jwt": fake_jwt, "httpx": None}):
-            with pytest.raises(ImportError, match="httpx"):
-                auth._fetch_installation_token()
+        with (
+            patch.dict("sys.modules", {"jwt": fake_jwt, "httpx": None}),
+            pytest.raises(ImportError, match="httpx"),
+        ):
+            auth._fetch_installation_token()
 
     def test_fetch_installation_token_success(self) -> None:
         auth = self._make_auth()

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -13,6 +13,7 @@ All tests inject a recorder runner so no real subprocesses spawn.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +25,9 @@ from maxwell_daemon.hooks import (
     HookRunner,
     HookSpec,
     HookViolationError,
+    _default_runner,
+    _parse_specs,
+    _parse_strings,
     load_hook_config,
 )
 
@@ -99,6 +103,34 @@ hooks:
     def test_malformed_yaml_rejected(self, tmp_path: Path) -> None:
         (tmp_path / "h.yaml").write_text("not: [valid")
         with pytest.raises(Exception, match="hook"):
+            load_hook_config(tmp_path / "h.yaml")
+
+    def test_root_must_be_mapping(self, tmp_path: Path) -> None:
+        (tmp_path / "h.yaml").write_text("- just\n- a\n- list\n", encoding="utf-8")
+        with pytest.raises(HookViolationError, match="must be a mapping"):
+            load_hook_config(tmp_path / "h.yaml")
+
+    def test_hooks_section_must_be_mapping(self, tmp_path: Path) -> None:
+        (tmp_path / "h.yaml").write_text("hooks: [1, 2, 3]\n", encoding="utf-8")
+        with pytest.raises(HookViolationError, match="non-mapping `hooks:` section"):
+            load_hook_config(tmp_path / "h.yaml")
+
+    def test_pre_tool_specs_must_be_string_or_mapping(self, tmp_path: Path) -> None:
+        (tmp_path / "h.yaml").write_text("hooks:\n  pre_tool:\n    - 123\n", encoding="utf-8")
+        with pytest.raises(HookViolationError, match="string or mapping"):
+            load_hook_config(tmp_path / "h.yaml")
+
+    def test_hook_spec_must_have_string_command(self, tmp_path: Path) -> None:
+        (tmp_path / "h.yaml").write_text(
+            "hooks:\n  pre_tool:\n    - match: run_bash\n      command: 123\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(HookViolationError, match="missing `command:`"):
+            load_hook_config(tmp_path / "h.yaml")
+
+    def test_pre_commit_entries_must_be_strings(self, tmp_path: Path) -> None:
+        (tmp_path / "h.yaml").write_text("hooks:\n  pre_commit:\n    - true\n", encoding="utf-8")
+        with pytest.raises(HookViolationError, match="hook entry must be a string"):
             load_hook_config(tmp_path / "h.yaml")
 
 
@@ -204,6 +236,14 @@ class TestPostToolHook:
         await hr.run_post_tool("run_bash", {}, tool_output="hello")
         assert runner.calls[0]["env"]["MAXWELL_TOOL_OUTPUT"] == "hello"
 
+    async def test_non_matching_post_tool_does_not_run(self, tmp_path: Path) -> None:
+        runner = _Runner()
+        cfg = HookConfig(post_tool=(HookSpec(match="write_file", command="never"),))
+        hr = HookRunner(cfg, workspace=tmp_path, runner=runner)
+        out = await hr.run_post_tool("run_bash", {}, tool_output="")
+        assert out.passed is True
+        assert runner.calls == []
+
 
 # ── pre_commit ───────────────────────────────────────────────────────────────
 
@@ -266,3 +306,75 @@ class TestHookOutcome:
         o = HookOutcome(blocked=False, errored=False, passed=True, detail="ok", failing_command="")
         with pytest.raises(FrozenInstanceError):
             o.blocked = True  # type: ignore[misc]
+
+
+class TestDefaultRunner:
+    @pytest.mark.asyncio
+    async def test_timeout_kills_process(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        class _Proc:
+            def __init__(self) -> None:
+                self.returncode = 0
+                self.killed = False
+                self.waited = False
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                return (b"", b"")
+
+            def kill(self) -> None:
+                self.killed = True
+
+            async def wait(self) -> None:
+                self.waited = True
+
+        proc = _Proc()
+
+        async def _fake_create(*_: object, **__: object) -> _Proc:
+            return proc
+
+        async def _fake_wait_for(awaitable: object, **__: object) -> object:
+            close = getattr(awaitable, "close", None)
+            if callable(close):
+                close()
+            raise asyncio.TimeoutError
+
+        monkeypatch.setattr("maxwell_daemon.hooks.asyncio.create_subprocess_shell", _fake_create)
+        monkeypatch.setattr("maxwell_daemon.hooks.asyncio.wait_for", _fake_wait_for)
+
+        rc, output = await _default_runner(
+            "echo hi", cwd=str(tmp_path), env={}, timeout=0.01
+        )
+        assert rc == 124
+        assert "timeout after" in output
+        assert proc.killed is True
+        assert proc.waited is True
+
+    @pytest.mark.asyncio
+    async def test_success_returns_decoded_output(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        class _Proc:
+            returncode = None
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                return (b"ok\xff", b"")
+
+        async def _fake_create(*_: object, **__: object) -> _Proc:
+            return _Proc()
+
+        monkeypatch.setattr("maxwell_daemon.hooks.asyncio.create_subprocess_shell", _fake_create)
+        rc, output = await _default_runner("echo hi", cwd=str(tmp_path), env={}, timeout=1.0)
+        assert rc == 0
+        assert output.startswith("ok")
+
+
+class TestParseHelpers:
+    def test_parse_specs_supports_none_and_strings(self) -> None:
+        assert _parse_specs(None) == []
+        out = _parse_specs(["echo one"])
+        assert len(out) == 1
+        assert out[0].command == "echo one"
+
+    def test_parse_strings_supports_none_and_type_errors(self) -> None:
+        assert _parse_strings(None) == []
+        with pytest.raises(HookViolationError, match="expected a list of commands"):
+            _parse_strings("not-a-list")


### PR DESCRIPTION
Two correctness fixes:

**#158 EventBus thread-safety**
`_subscribers` is a plain `set` mutated from `subscribe()`, `_unsubscribe()`, and snapshotted in `publish()`. Under concurrent callers these race. Added a `threading.Lock` to guard all three mutation sites; `publish()` takes a snapshot under the lock then iterates outside it so slow subscribers don't hold the lock.

**#163 Bare assert statements**
Six production `assert` statements across `github_auth`, `cost_alerter`, `scheduler`, `runner`, `cli/tasks`, and `config/models` can be silently disabled with `python -O`. Replaced each with an explicit `RuntimeError`, `ValueError`, or `TypeError` that always fires.

Closes #158, #163