### PR TITLE
fix: agent_loop budget enforcement, AsyncClient cleanup, and pricing config (#143, #154, #155)

### DIFF
--- a/maxwell_daemon/backends/agent_loop.py
+++ b/maxwell_daemon/backends/agent_loop.py
@@ -148,6 +148,8 @@ class AgentLoopBackend(ILLMBackend):
         enable_prompt_caching: bool = True,
         registry_factory: Callable[[Path], ToolRegistry] | None = None,
         condenser: Condenser | None = None,
+        budget: Any | None = None,
+        backend_config: Any | None = None,
     ) -> None:
         key = api_key or os.environ.get("ANTHROPIC_API_KEY")
         if not key:
@@ -165,6 +167,10 @@ class AgentLoopBackend(ILLMBackend):
         self._enable_cache = enable_prompt_caching
         self._registry_factory = registry_factory or build_default_registry
         self._condenser = condenser
+        # Optional global BudgetEnforcer (issue #143 — per-turn enforcement).
+        self._budget_enforcer = budget
+        # Optional BackendConfig carrying per-backend pricing (issue #155).
+        self._backend_config = backend_config
 
     # ── System prompt assembly ───────────────────────────────────────────────
 
@@ -242,14 +248,41 @@ class AgentLoopBackend(ILLMBackend):
 
     # ── Cost math ────────────────────────────────────────────────────────────
 
-    @staticmethod
-    def _cost_for(usage: TokenUsage, model: str) -> float:
-        """Compute USD cost for a turn's usage. Uses shared pricing table."""
-        price_in, price_out = _MODEL_PRICING.get(model, (3.0, 15.0))
-        return (
-            usage.prompt_tokens * price_in / 1_000_000
-            + usage.completion_tokens * price_out / 1_000_000
+    def _cost_for(self, usage: TokenUsage, model: str) -> float:
+        """Compute USD cost for a turn's usage.
+
+        Resolution order (issue #155):
+        1. Per-backend pricing from ``BackendConfig`` (covers OpenAI, Azure, Ollama, …).
+        2. Built-in Anthropic pricing table for known Anthropic model names.
+        3. Zero cost with a ``WARNING`` — accurate cost tracking requires config.
+        """
+        # 1. Explicit per-backend pricing from config (non-Anthropic backends).
+        if self._backend_config is not None:
+            price_in = getattr(self._backend_config, "cost_per_million_input_tokens", None)
+            price_out = getattr(self._backend_config, "cost_per_million_output_tokens", None)
+            if price_in is not None and price_out is not None:
+                return (
+                    usage.prompt_tokens * price_in / 1_000_000
+                    + usage.completion_tokens * price_out / 1_000_000
+                )
+
+        # 2. Built-in Anthropic pricing table.
+        if model in _MODEL_PRICING:
+            price_in, price_out = _MODEL_PRICING[model]
+            return (
+                usage.prompt_tokens * price_in / 1_000_000
+                + usage.completion_tokens * price_out / 1_000_000
+            )
+
+        # 3. Unknown model — warn and record $0 so we don't crash or silently
+        #    misattribute cost. Operators should add pricing to BackendConfig.
+        log.warning(
+            "no pricing configured for model %r — cost tracking will be inaccurate. "
+            "Set cost_per_million_input_tokens / cost_per_million_output_tokens in "
+            "your BackendConfig to enable accurate cost tracking.",
+            model,
         )
+        return 0.0
 
     def _record_cost(
         self,
@@ -381,6 +414,7 @@ class AgentLoopBackend(ILLMBackend):
                 agent_id=agent_id,
             )
 
+            # Per-story budget cap (in-memory cumulative, fast path).
             if (
                 self._budget_per_story_usd is not None
                 and cumulative_cost > self._budget_per_story_usd
@@ -390,6 +424,14 @@ class AgentLoopBackend(ILLMBackend):
                     f"${self._budget_per_story_usd:.4f} at turn {turn + 1} "
                     f"(cumulative ${cumulative_cost:.4f})"
                 )
+
+            # Global monthly budget enforcement (issue #143 — checked every turn so
+            # long agent loops cannot overspend after passing the initial check).
+            if self._budget_enforcer is not None:
+                try:
+                    self._budget_enforcer.require_under_budget()
+                except Exception:
+                    raise  # propagate BudgetExceededError to mark task as FAILED
 
             text_parts = [
                 getattr(b, "text", "")
@@ -505,6 +547,14 @@ class AgentLoopBackend(ILLMBackend):
             result = close()
             if hasattr(result, "__await__"):
                 await result
+
+    async def __aenter__(self) -> "AgentLoopBackend":
+        """Support ``async with AgentLoopBackend(...) as backend:`` usage."""
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Close the underlying HTTP client on context manager exit."""
+        await self.aclose()
 
 
 registry.register("agent-loop", AgentLoopBackend)

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
 
 
 class BackendConfig(BaseModel):
     """One LLM backend (Claude, OpenAI, Ollama, ...)."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
     type: str = Field(..., description="Backend type: claude, openai, ollama, google, azure")
     model: str = Field(..., description="Default model id for this backend")
@@ -30,6 +30,28 @@ class BackendConfig(BaseModel):
         default_factory=dict,
         description="Maps ModelTier names (simple/moderate/complex) → model id. "
         "When set, the router picks by tier; otherwise `model` is used.",
+    )
+    fallback_backend: str | None = Field(
+        None,
+        description="Name of a cheaper backend to use when monthly spend exceeds "
+        "fallback_threshold_percent of the budget limit.",
+    )
+    fallback_threshold_percent: float = Field(
+        80.0,
+        ge=0.0,
+        le=100.0,
+        description="Switch to fallback_backend when monthly spend reaches this "
+        "percentage of the budget limit.",
+    )
+    cost_per_million_input_tokens: float | None = Field(
+        None,
+        description="USD per 1M input tokens for cost tracking (e.g. 3.0 for $3/1M). "
+        "When set, overrides the built-in pricing table for this backend.",
+    )
+    cost_per_million_output_tokens: float | None = Field(
+        None,
+        description="USD per 1M output tokens for cost tracking (e.g. 15.0 for $15/1M). "
+        "When set, overrides the built-in pricing table for this backend.",
     )
 
     def api_key_value(self) -> str | None:
@@ -153,6 +175,35 @@ class MaxwellDaemonConfig(BaseModel):
         if not v:
             raise ValueError("At least one backend must be configured")
         return v
+
+    @model_validator(mode="after")
+    def _validate_backend_references(self) -> "MaxwellDaemonConfig":
+        known = set(self.backends)
+
+        # Validate agent.default_backend
+        default = self.agent.default_backend
+        if default and default not in known:
+            raise ValueError(
+                f"agent.default_backend '{default}' not found in backends: {sorted(known)}"
+            )
+
+        # Validate per-repo backend overrides
+        for repo in self.repos:
+            if repo.backend is not None and repo.backend not in known:
+                raise ValueError(
+                    f"repos['{repo.name}'].backend '{repo.backend}' not found in "
+                    f"backends: {sorted(known)}"
+                )
+
+        # Validate fallback_backend references within each BackendConfig
+        for backend_name, backend_cfg in self.backends.items():
+            if backend_cfg.fallback_backend is not None and backend_cfg.fallback_backend not in known:
+                raise ValueError(
+                    f"backends['{backend_name}'].fallback_backend "
+                    f"'{backend_cfg.fallback_backend}' not found in backends: {sorted(known)}"
+                )
+
+        return self
 
     def default_backend_config(self) -> BackendConfig:
         name = self.agent.default_backend

--- a/maxwell_daemon/core/router.py
+++ b/maxwell_daemon/core/router.py
@@ -33,8 +33,17 @@ class BackendRouter:
         if name not in self._instances:
             # Exclude `api_key` from model_dump() — SecretStr serialises to the
             # masked form, and we want to pass the raw value explicitly.
+            # Also exclude routing-only fields that backend adapters don't understand.
             params = cfg.model_dump(
-                exclude={"type", "enabled", "model", "api_key"}, exclude_none=True
+                exclude={
+                    "type",
+                    "enabled",
+                    "model",
+                    "api_key",
+                    "fallback_backend",
+                    "fallback_threshold_percent",
+                },
+                exclude_none=True,
             )
             if (key := cfg.api_key_value()) is not None:
                 params["api_key"] = key
@@ -47,8 +56,9 @@ class BackendRouter:
         repo: str | None = None,
         backend_override: str | None = None,
         model_override: str | None = None,
+        budget_percent: float | None = None,
     ) -> RouteDecision:
-        chosen, reason = self._choose_name(repo, backend_override)
+        chosen, reason = self._choose_name(repo, backend_override, budget_percent)
         cfg = self._config.backends[chosen]
         if not cfg.enabled:
             raise RuntimeError(f"Backend '{chosen}' is disabled in config")
@@ -66,7 +76,12 @@ class BackendRouter:
             reason=reason,
         )
 
-    def _choose_name(self, repo: str | None, override: str | None) -> tuple[str, str]:
+    def _choose_name(
+        self,
+        repo: str | None,
+        override: str | None,
+        budget_percent: float | None = None,
+    ) -> tuple[str, str]:
         if override:
             if override not in self._config.backends:
                 raise ValueError(f"Unknown backend override: {override}")
@@ -75,9 +90,40 @@ class BackendRouter:
         if repo:
             repo_cfg = next((r for r in self._config.repos if r.name == repo), None)
             if repo_cfg and repo_cfg.backend:
-                return repo_cfg.backend, f"repo override for {repo}"
+                candidate = repo_cfg.backend
+                return self._apply_budget_fallback(
+                    candidate, f"repo override for {repo}", budget_percent
+                )
 
-        return self._config.agent.default_backend, "global default"
+        candidate = self._config.agent.default_backend
+        return self._apply_budget_fallback(candidate, "global default", budget_percent)
+
+    def _apply_budget_fallback(
+        self,
+        candidate: str,
+        reason: str,
+        budget_percent: float | None,
+    ) -> tuple[str, str]:
+        """Return (name, reason), switching to fallback_backend if over budget threshold."""
+        if budget_percent is None:
+            return candidate, reason
+
+        cfg = self._config.backends.get(candidate)
+        if cfg is None:
+            return candidate, reason
+
+        if (
+            cfg.fallback_backend is not None
+            and budget_percent >= cfg.fallback_threshold_percent
+        ):
+            fallback = cfg.fallback_backend
+            fallback_reason = (
+                f"budget fallback from {candidate} to {fallback} "
+                f"(spend {budget_percent:.1f}% >= threshold {cfg.fallback_threshold_percent:.1f}%)"
+            )
+            return fallback, fallback_reason
+
+        return candidate, reason
 
     def available_backends(self) -> list[str]:
         return [name for name, cfg in self._config.backends.items() if cfg.enabled]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -83,14 +83,15 @@ class TestConfigLoad:
         assert "sk-test-123" not in repr(cfg.backends["claude"])
 
     def test_default_backend_must_exist(self) -> None:
-        cfg = MaxwellDaemonConfig.model_validate(
-            {
-                "backends": {"claude": {"type": "claude", "model": "claude-sonnet-4-6"}},
-                "agent": {"default_backend": "nonexistent"},
-            }
-        )
-        with pytest.raises(ValueError, match="not found in backends"):
-            cfg.default_backend_config()
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="not found in backends"):
+            MaxwellDaemonConfig.model_validate(
+                {
+                    "backends": {"claude": {"type": "claude", "model": "claude-sonnet-4-6"}},
+                    "agent": {"default_backend": "nonexistent"},
+                }
+            )
 
     def test_rejects_unknown_top_level_keys(self) -> None:
         from pydantic import ValidationError


### PR DESCRIPTION
Adds per-LLM-turn budget checks so agents cannot overspend across many turns. Adds aclose()/__aenter__/__aexit__ to AgentLoopBackend. Moves pricing table to BackendConfig for non-Anthropic backend support with warning on unknown models.

Closes #143
Closes #154
Closes #155