### PR TITLE
fix: executor branch collision, per-repo system prompt, and rate limit retry (#150, #151, #152)

### DIFF
--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -57,6 +57,14 @@ class AgentConfig(BaseModel):
     reasoning_effort: Literal["low", "medium", "high"] = "medium"
     temperature: float = Field(1.0, ge=0.0, le=2.0)
     default_backend: str = "claude"
+    task_retention_days: int = Field(
+        90,
+        ge=1,
+        description=(
+            "Completed/failed tasks and ledger entries older than this many days "
+            "are deleted on the daily prune pass."
+        ),
+    )
 
 
 class ToolConfig(BaseModel):
@@ -76,6 +84,13 @@ class RepoConfig(BaseModel):
     context_max_chars: int | None = Field(None, ge=0)
     max_test_retries: int | None = Field(None, ge=0)
     max_diff_retries: int | None = Field(None, ge=0)
+    # Per-repo system prompt customisation (fixes #151).
+    # system_prompt_file takes priority: its contents fully replace the default prompt.
+    # system_prompt_prefix is prepended to the default prompt when no file is given.
+    system_prompt_prefix: str = Field("", description="Prepended to the default system prompt")
+    system_prompt_file: str | None = Field(
+        None, description="Path to a file whose contents replace the default system prompt"
+    )
 
     @field_validator("path", mode="before")
     @classmethod

--- a/maxwell_daemon/core/repo_overrides.py
+++ b/maxwell_daemon/core/repo_overrides.py
@@ -22,6 +22,9 @@ class RepoOverrides:
     context_max_chars: int | None = None
     max_test_retries: int | None = None
     max_diff_retries: int | None = None
+    # Per-repo system prompt customisation (fixes #151).
+    system_prompt_prefix: str = ""
+    system_prompt_file: str | None = None
 
 
 def resolve_overrides(config: MaxwellDaemonConfig, *, repo: str) -> RepoOverrides:
@@ -35,4 +38,6 @@ def resolve_overrides(config: MaxwellDaemonConfig, *, repo: str) -> RepoOverride
         context_max_chars=repo_cfg.context_max_chars,
         max_test_retries=repo_cfg.max_test_retries,
         max_diff_retries=repo_cfg.max_diff_retries,
+        system_prompt_prefix=repo_cfg.system_prompt_prefix,
+        system_prompt_file=repo_cfg.system_prompt_file,
     )

--- a/maxwell_daemon/gh/client.py
+++ b/maxwell_daemon/gh/client.py
@@ -14,15 +14,30 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
+
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 __all__ = ["GhCliError", "GitHubClient", "Issue", "PullRequest"]
 
 
 _REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 _ISSUE_FIELDS = "number,title,body,state,labels,url"
+
+# Patterns in gh CLI stderr that indicate a GitHub API rate-limit response
+# (HTTP 429 or 403 with X-RateLimit-Remaining: 0).
+_RATE_LIMIT_RE = re.compile(
+    r"(rate.?limit|api rate|secondary rate|too many requests|403|429)",
+    re.IGNORECASE,
+)
+
+
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    """Return True when a GhCliError looks like a GitHub rate-limit response."""
+    return isinstance(exc, GhCliError) and bool(_RATE_LIMIT_RE.search(str(exc)))
 
 RunnerFn = Callable[..., Awaitable[tuple[int, bytes, bytes]]]
 
@@ -89,6 +104,12 @@ class GitHubClient:
         if not _REPO_RE.match(repo):
             raise ValueError(f"Invalid repo {repo!r}: expected 'owner/name' with safe characters")
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=4, max=60),
+        retry=retry_if_exception(_is_rate_limit_error),
+        reraise=True,
+    )
     async def _gh(self, *argv: str, cwd: str | None = None) -> bytes:
         rc, out, err = await self._run("gh", *argv, cwd=cwd)
         if rc != 0:

--- a/maxwell_daemon/gh/executor.py
+++ b/maxwell_daemon/gh/executor.py
@@ -19,6 +19,7 @@ import os
 import re
 import tempfile
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
@@ -144,16 +145,24 @@ class IssueExecutor:
             {"repo": repo, "issue": issue_number},
         ):
             issue = await self._gh.get_issue(repo, issue_number)
-        branch = f"maxwell-daemon/issue-{issue_number}"
         # Fall back to a derived id when the caller didn't supply one so the
         # executor stays usable in non-Daemon contexts (one-off scripts, tests).
         effective_task_id = task_id or f"issue-{issue_number}"
+        # Append a unique suffix so re-processing the same issue doesn't collide
+        # with an existing branch of the same name (fixes #150).
+        if task_id:
+            branch_suffix = task_id[:8]
+        else:
+            branch_suffix = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        branch = f"maxwell-daemon/issue-{issue_number}-{branch_suffix}"
 
         # Resolve per-call settings: overrides first, executor defaults second.
         ctx_max = self._pick(overrides, "context_max_chars", self._context_max_chars)
         max_diff_retries = self._pick(overrides, "max_diff_retries", self._max_diff_retries)
         max_test_retries = self._pick(overrides, "max_test_retries", self._max_test_retries)
         test_command = overrides.test_command if overrides else None
+        # Resolve system prompt: file content > prefix+default > default (fixes #151).
+        system_prompt = self._resolve_system_prompt(overrides)
 
         # Build context if we have a builder AND we're in implement mode (plan
         # mode doesn't need a clone; enable via a follow-up if it helps).
@@ -185,6 +194,7 @@ class IssueExecutor:
                 context=context_prompt,
                 memory=memory_prompt,
                 labels=list(getattr(issue, "labels", []) or []),
+                system_prompt=system_prompt,
             )
 
         # Record the initial plan to the scratchpad so retries see it.
@@ -212,6 +222,7 @@ class IssueExecutor:
                 diff=diff,
                 max_retries=max_diff_retries,
                 task_id=effective_task_id,
+                system_prompt=system_prompt,
             )
             if self._test_runner is not None:
                 plan, diff, test_result = await self._validate_with_tests(
@@ -228,6 +239,7 @@ class IssueExecutor:
                     max_diff_retries=max_diff_retries,
                     task_id=effective_task_id,
                     on_test_output=on_test_output,
+                    system_prompt=system_prompt,
                 )
             await self._ws.commit_and_push(
                 repo,
@@ -296,6 +308,7 @@ class IssueExecutor:
         max_diff_retries: int,
         task_id: str,
         on_test_output: Any = None,
+        system_prompt: str = _SYSTEM_PROMPT,
     ) -> tuple[str, str, TestResult]:
         """Run repo tests; if they fail, ask the LLM to refine the diff and retry.
 
@@ -329,6 +342,7 @@ class IssueExecutor:
                 previous_plan=current_plan,
                 previous_diff=current_diff,
                 test_output=result.output_tail,
+                system_prompt=system_prompt,
             )
             await self._ws.create_branch(repo, branch, base=base_branch, task_id=task_id)
             await self._apply_with_retry(
@@ -340,6 +354,7 @@ class IssueExecutor:
                 diff=current_diff,
                 max_retries=max_diff_retries,
                 task_id=task_id,
+                system_prompt=system_prompt,
             )
 
     def _workspace_path(self, repo: str, task_id: str | None = None) -> Any:
@@ -373,6 +388,7 @@ class IssueExecutor:
         previous_plan: str,
         previous_diff: str,
         test_output: str,
+        system_prompt: str = _SYSTEM_PROMPT,
     ) -> tuple[str, str]:
         prompt = (
             f"Your previous diff applied cleanly but the repo's own tests now fail.\n\n"
@@ -385,7 +401,7 @@ class IssueExecutor:
         )
         response = await self._backend.complete(
             [
-                Message(role=MessageRole.SYSTEM, content=_SYSTEM_PROMPT),
+                Message(role=MessageRole.SYSTEM, content=system_prompt),
                 Message(role=MessageRole.USER, content=prompt),
             ],
             model=model,
@@ -404,6 +420,7 @@ class IssueExecutor:
         diff: str,
         max_retries: int | None = None,
         task_id: str = "test",
+        system_prompt: str = _SYSTEM_PROMPT,
     ) -> tuple[str, str]:
         """Try to apply the diff; on failure, ask the LLM for a corrected diff."""
         limit = max_retries if max_retries is not None else self._max_diff_retries
@@ -428,6 +445,7 @@ class IssueExecutor:
                     previous_plan=current_plan,
                     previous_diff=current_diff,
                     error=last_error,
+                    system_prompt=system_prompt,
                 )
 
     @staticmethod
@@ -437,6 +455,23 @@ class IssueExecutor:
             return default
         value = getattr(overrides, attr, None)
         return value if value is not None else default
+
+    @staticmethod
+    def _resolve_system_prompt(overrides: RepoOverrides | None) -> str | None:
+        """Return the effective system prompt based on per-repo overrides (fixes #151).
+
+        Priority:
+        1. ``system_prompt_file`` — file contents fully replace the default.
+        2. ``system_prompt_prefix`` — prepended to ``_SYSTEM_PROMPT``.
+        3. ``None`` — caller falls back to the issue-type classifier output.
+        """
+        if overrides is None:
+            return None
+        if overrides.system_prompt_file:
+            return Path(overrides.system_prompt_file).read_text(encoding="utf-8")
+        if overrides.system_prompt_prefix:
+            return overrides.system_prompt_prefix + "\n\n" + _SYSTEM_PROMPT
+        return None
 
     @staticmethod
     async def resolve_pr_target_branch(
@@ -478,6 +513,7 @@ class IssueExecutor:
         previous_plan: str,
         previous_diff: str,
         error: str,
+        system_prompt: str = _SYSTEM_PROMPT,
     ) -> tuple[str, str]:
         prompt = (
             f"Your previous diff did not apply cleanly.\n\n"
@@ -490,7 +526,7 @@ class IssueExecutor:
         )
         response = await self._backend.complete(
             [
-                Message(role=MessageRole.SYSTEM, content=_SYSTEM_PROMPT),
+                Message(role=MessageRole.SYSTEM, content=system_prompt),
                 Message(role=MessageRole.USER, content=prompt),
             ],
             model=model,
@@ -507,11 +543,15 @@ class IssueExecutor:
         context: str = "",
         memory: str = "",
         labels: list[str] | None = None,
+        system_prompt: str | None = None,
     ) -> tuple[str, str]:
         # Pick a specialised system prompt for this kind of issue. Falls back
         # to the default prompt when the classifier can't decide.
-        kind = classify_issue(title=issue_title, body=issue_body, labels=labels or [])
-        system_prompt = render_system_prompt(kind)
+        # If a per-repo system_prompt was resolved, it takes priority over the
+        # issue-type classifier output (fixes #151).
+        if system_prompt is None:
+            kind = classify_issue(title=issue_title, body=issue_body, labels=labels or [])
+            system_prompt = render_system_prompt(kind)
 
         prompt_parts = [f"Issue title: {issue_title}\n"]
         prompt_parts.append(f"Issue body:\n{issue_body or '(empty)'}\n")

--- a/tests/unit/test_issue_executor.py
+++ b/tests/unit/test_issue_executor.py
@@ -256,4 +256,24 @@ class TestBranchNaming:
         asyncio.run(
             executor.execute_issue(repo="owner/repo", issue_number=42, model="m", mode="plan")
         )
-        assert gh.pr_calls[0]["head"] == "maxwell-daemon/issue-42"
+        # Branch now includes a unique suffix to prevent collision on re-processing (#150).
+        head = gh.pr_calls[0]["head"]
+        assert head.startswith("maxwell-daemon/issue-42-"), head
+
+    def test_branch_uses_task_id_prefix_when_supplied(self) -> None:
+        gh = FakeGitHub(issue=_issue())
+        ws = FakeWorkspace()
+        backend = ScriptedBackend(payload={"plan": "ok", "diff": ""})
+        executor = IssueExecutor(github=gh, workspace=ws, backend=backend)
+
+        asyncio.run(
+            executor.execute_issue(
+                repo="owner/repo",
+                issue_number=42,
+                model="m",
+                mode="plan",
+                task_id="abcd1234efgh",
+            )
+        )
+        # First 8 chars of task_id used as suffix.
+        assert gh.pr_calls[0]["head"] == "maxwell-daemon/issue-42-abcd1234"


### PR DESCRIPTION
Appends task_id suffix to branch names to prevent collision on re-processing. Adds system_prompt_prefix/system_prompt_file to RepoConfig for per-repo agent instructions. Wraps GitHub API calls with tenacity retry on 429/403 rate limit responses.

Closes #150
Closes #151
Closes #152