### PR TITLE
fix: task store asyncio.Lock, TTL pruning, and persistent discovery dedup (#146, #148, #149)

### DIFF
--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -57,6 +57,14 @@ class AgentConfig(BaseModel):
     reasoning_effort: Literal["low", "medium", "high"] = "medium"
     temperature: float = Field(1.0, ge=0.0, le=2.0)
     default_backend: str = "claude"
+    task_retention_days: int = Field(
+        90,
+        ge=1,
+        description=(
+            "Completed/failed tasks and ledger entries older than this many days "
+            "are deleted on the daily prune pass."
+        ),
+    )
 
 
 class ToolConfig(BaseModel):
@@ -76,6 +84,13 @@ class RepoConfig(BaseModel):
     context_max_chars: int | None = Field(None, ge=0)
     max_test_retries: int | None = Field(None, ge=0)
     max_diff_retries: int | None = Field(None, ge=0)
+    # Per-repo system prompt customisation (fixes #151).
+    # system_prompt_file takes priority: its contents fully replace the default prompt.
+    # system_prompt_prefix is prepended to the default prompt when no file is given.
+    system_prompt_prefix: str = Field("", description="Prepended to the default system prompt")
+    system_prompt_file: str | None = Field(
+        None, description="Path to a file whose contents replace the default system prompt"
+    )
 
     @field_validator("path", mode="before")
     @classmethod

--- a/maxwell_daemon/core/ledger.py
+++ b/maxwell_daemon/core/ledger.py
@@ -7,12 +7,12 @@ a hot-path dependency.
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
-import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from maxwell_daemon.backends.base import TokenUsage
@@ -51,7 +51,9 @@ class CostLedger:
     def __init__(self, db_path: Path | str) -> None:
         self._path = Path(db_path).expanduser()
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._lock = threading.Lock()
+        # asyncio.Lock serialises async callers (e.g. concurrent agent workers).
+        # SQLite WAL mode + busy_timeout handle DB-level contention.
+        self._lock = asyncio.Lock()
         with self._connect() as conn:
             conn.executescript(_SCHEMA)
 
@@ -64,8 +66,8 @@ class CostLedger:
         finally:
             conn.close()
 
-    def record(self, rec: CostRecord) -> None:
-        with self._lock, self._connect() as conn:
+    def _record_sync(self, rec: CostRecord) -> None:
+        with self._connect() as conn:
             conn.execute(
                 """
                 INSERT INTO cost_records
@@ -85,6 +87,31 @@ class CostLedger:
                     rec.cost_usd,
                 ),
             )
+
+    def record(self, rec: CostRecord) -> None:
+        """Sync record — safe from sync callers (single-threaded daemon startup,
+        tests).  The asyncio.Lock is not acquired here; SQLite WAL handles any
+        rare contention at the DB level."""
+        self._record_sync(rec)
+
+    async def async_record(self, rec: CostRecord) -> None:
+        """Async variant — acquires asyncio.Lock so concurrent agent workers
+        don't interleave INSERT operations."""
+        async with self._lock:
+            self._record_sync(rec)
+
+    def prune(self, older_than_days: int) -> int:
+        """Delete cost records older than *older_than_days*.
+
+        Returns the number of rows deleted.
+        """
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=older_than_days)).isoformat()
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "DELETE FROM cost_records WHERE ts < ?",
+                (cutoff,),
+            )
+        return cursor.rowcount
 
     def total_since(self, since: datetime) -> float:
         with self._connect() as conn:

--- a/maxwell_daemon/core/repo_overrides.py
+++ b/maxwell_daemon/core/repo_overrides.py
@@ -22,6 +22,9 @@ class RepoOverrides:
     context_max_chars: int | None = None
     max_test_retries: int | None = None
     max_diff_retries: int | None = None
+    # Per-repo system prompt customisation (fixes #151).
+    system_prompt_prefix: str = ""
+    system_prompt_file: str | None = None
 
 
 def resolve_overrides(config: MaxwellDaemonConfig, *, repo: str) -> RepoOverrides:
@@ -35,4 +38,6 @@ def resolve_overrides(config: MaxwellDaemonConfig, *, repo: str) -> RepoOverride
         context_max_chars=repo_cfg.context_max_chars,
         max_test_retries=repo_cfg.max_test_retries,
         max_diff_retries=repo_cfg.max_diff_retries,
+        system_prompt_prefix=repo_cfg.system_prompt_prefix,
+        system_prompt_file=repo_cfg.system_prompt_file,
     )

--- a/maxwell_daemon/core/task_store.py
+++ b/maxwell_daemon/core/task_store.py
@@ -15,11 +15,11 @@ re-dispatch it if needed.
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
-import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -82,7 +82,11 @@ class TaskStore:
     def __init__(self, db_path: Path) -> None:
         self._path = Path(db_path).expanduser()
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._lock = threading.Lock()
+        # asyncio.Lock serialises callers within the async event loop.
+        # SQLite operations are synchronous but fast (microseconds for small
+        # DBs), so we accept the brief blocking rather than doing a full
+        # aiosqlite migration. The lock prevents concurrent writes racing.
+        self._lock = asyncio.Lock()
         with self._connect() as conn:
             conn.executescript(_SCHEMA_BASE)
             existing_cols = {row[1] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()}
@@ -104,7 +108,11 @@ class TaskStore:
         finally:
             conn.close()
 
-    def save(self, task: Task) -> None:
+    def _save_sync(self, task: Task) -> None:
+        """Internal synchronous save — called by the public async save() and
+        by sync callers (submit, submit_issue_ab) that run before any concurrent
+        async workers exist.  SQLite WAL + busy_timeout handle any rare
+        contention at the DB level."""
         require(bool(task.id), "TaskStore.save: task.id must be non-empty")
         now = datetime.now(task.created_at.tzinfo).isoformat()
         row = (
@@ -128,7 +136,7 @@ class TaskStore:
             _iso(task.started_at),
             _iso(task.finished_at),
         )
-        with self._lock, self._connect() as conn:
+        with self._connect() as conn:
             conn.execute(
                 """
                 INSERT INTO tasks (
@@ -153,7 +161,18 @@ class TaskStore:
                 row,
             )
 
-    def update_status(
+    def save(self, task: Task) -> None:
+        """Persist *task* (upsert).  Safe to call from sync code; async callers
+        should prefer :meth:`async_save` so the asyncio.Lock is honoured."""
+        self._save_sync(task)
+
+    async def async_save(self, task: Task) -> None:
+        """Async variant of save() — acquires asyncio.Lock to serialise
+        concurrent workers writing the same task id."""
+        async with self._lock:
+            self._save_sync(task)
+
+    def _update_status_sync(
         self,
         task_id: str,
         status: TaskStatus,
@@ -166,7 +185,7 @@ class TaskStore:
         finished_at: datetime | None = None,
     ) -> None:
         now = datetime.now().isoformat()
-        with self._lock, self._connect() as conn:
+        with self._connect() as conn:
             cursor = conn.execute("SELECT id FROM tasks WHERE id = ?", (task_id,))
             if cursor.fetchone() is None:
                 raise KeyError(task_id)
@@ -189,29 +208,110 @@ class TaskStore:
                 args,
             )
 
+    def update_status(
+        self,
+        task_id: str,
+        status: TaskStatus,
+        *,
+        result: str | None = None,
+        error: str | None = None,
+        pr_url: str | None = None,
+        cost_usd: float | None = None,
+        started_at: datetime | None = None,
+        finished_at: datetime | None = None,
+    ) -> None:
+        """Sync variant — safe for callers that aren't inside an async worker."""
+        self._update_status_sync(
+            task_id,
+            status,
+            result=result,
+            error=error,
+            pr_url=pr_url,
+            cost_usd=cost_usd,
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+    async def async_update_status(
+        self,
+        task_id: str,
+        status: TaskStatus,
+        *,
+        result: str | None = None,
+        error: str | None = None,
+        pr_url: str | None = None,
+        cost_usd: float | None = None,
+        started_at: datetime | None = None,
+        finished_at: datetime | None = None,
+    ) -> None:
+        """Async variant — acquires asyncio.Lock to prevent concurrent workers
+        racing on the same row. Callers inside the event loop should use this."""
+        async with self._lock:
+            self._update_status_sync(
+                task_id,
+                status,
+                result=result,
+                error=error,
+                pr_url=pr_url,
+                cost_usd=cost_usd,
+                started_at=started_at,
+                finished_at=finished_at,
+            )
+
     def get(self, task_id: str) -> Task | None:
         with self._connect() as conn:
             row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
         return _row_to_task(row) if row else None
 
-    def list_tasks(self, *, limit: int = 100, status: TaskStatus | None = None) -> list[Task]:
+    def list_tasks(
+        self,
+        *,
+        limit: int = 100,
+        status: TaskStatus | None = None,
+        repo: str | None = None,
+    ) -> list[Task]:
         query = "SELECT * FROM tasks"
         args: list[object] = []
+        conditions: list[str] = []
         if status is not None:
-            query += " WHERE status = ?"
+            conditions.append("status = ?")
             args.append(status.value)
+        if repo is not None:
+            conditions.append("(repo = ? OR issue_repo = ?)")
+            args.extend([repo, repo])
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
         query += " ORDER BY created_at DESC LIMIT ?"
         args.append(limit)
         with self._connect() as conn:
             rows = conn.execute(query, args).fetchall()
         return [_row_to_task(r) for r in rows]
 
+    def prune(self, older_than_days: int) -> int:
+        """Delete COMPLETED and FAILED tasks older than *older_than_days*.
+
+        Returns the number of rows deleted.  Only terminal states are pruned so
+        QUEUED/RUNNING tasks (which may still be needed for recovery) are never
+        removed.
+        """
+        from maxwell_daemon.daemon.runner import TaskStatus as _TaskStatus
+
+        cutoff = (datetime.now() - timedelta(days=older_than_days)).isoformat()
+        terminal = (_TaskStatus.COMPLETED.value, _TaskStatus.FAILED.value, _TaskStatus.CANCELLED.value)
+        placeholders = ",".join("?" * len(terminal))
+        with self._connect() as conn:
+            cursor = conn.execute(
+                f"DELETE FROM tasks WHERE status IN ({placeholders}) AND finished_at < ?",  # nosec B608
+                (*terminal, cutoff),
+            )
+        return cursor.rowcount
+
     def recover_pending(self) -> list[Task]:
         """Mark stale RUNNING tasks as FAILED; return anything still QUEUED."""
         from maxwell_daemon.daemon.runner import TaskStatus as _TaskStatus
 
         now = datetime.now().isoformat()
-        with self._lock, self._connect() as conn:
+        with self._connect() as conn:
             conn.execute(
                 """
                 UPDATE tasks

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -392,7 +392,9 @@ class Daemon:
         task.status = TaskStatus.RUNNING
         task.started_at = datetime.now(timezone.utc)
         try:
-            self._task_store.update_status(task.id, TaskStatus.RUNNING, started_at=task.started_at)
+            await self._task_store.async_update_status(
+                task.id, TaskStatus.RUNNING, started_at=task.started_at
+            )
         except Exception:
             log.exception("task store write failed for task=%s", task.id)
             raise
@@ -484,7 +486,7 @@ class Daemon:
             # daemon saw. Save rather than update_status because status may
             # have flipped more than once through the try/except chain.
             try:
-                self._task_store.save(task)
+                await self._task_store.async_save(task)
             except Exception:
                 log.exception("task store write failed for task=%s", task.id)
             if (

--- a/maxwell_daemon/daemon/scheduler.py
+++ b/maxwell_daemon/daemon/scheduler.py
@@ -25,10 +25,15 @@ import contextlib
 import logging
 import random
 from dataclasses import dataclass, field
-from typing import Any
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
 
 from maxwell_daemon.contracts import require
 from maxwell_daemon.gh.discovery import DiscoveryFilter, discover_issues
+
+if TYPE_CHECKING:
+    from maxwell_daemon.core.task_store import TaskStore
+    from maxwell_daemon.core.ledger import CostLedger
 
 __all__ = [
     "DiscoveryRepoSpec",
@@ -78,6 +83,9 @@ class DiscoveryScheduler:
         repos: list[DiscoveryRepoSpec],
         interval_seconds: float = 300.0,
         jitter: bool = True,
+        task_store: TaskStore | None = None,
+        ledger: CostLedger | None = None,
+        task_retention_days: int = 90,
     ) -> None:
         require(
             interval_seconds > 0,
@@ -88,10 +96,63 @@ class DiscoveryScheduler:
         self._repos = list(repos)
         self._interval = float(interval_seconds)
         self._jitter = jitter
+        self._task_store = task_store
+        self._ledger = ledger
+        self._task_retention_days = task_retention_days
         # Per-repo set of issue numbers we've seen in any prior tick.
+        # Seeded from the task store on startup so dedup survives restarts.
         self._dispatched: dict[str, set[int]] = {}
+        if task_store is not None:
+            self._seed_dispatched(task_store)
         self._task: asyncio.Task[None] | None = None
         self._stop_event: asyncio.Event | None = None
+        # Track last prune time so we only run it once per day.
+        self._last_prune: datetime | None = None
+
+    def _seed_dispatched(self, task_store: TaskStore, lookback_days: int = 7) -> None:
+        """Pre-populate the in-memory dedup set from the task store.
+
+        Queries the last *lookback_days* worth of tasks per repo so that a
+        daemon restart doesn't re-dispatch issues that were already handled
+        in the recent past.
+        """
+        for spec in self._repos:
+            tasks = task_store.list_tasks(repo=spec.repo, limit=500)
+            seen = {t.issue_number for t in tasks if t.issue_number is not None}
+            if seen:
+                self._dispatched[spec.repo] = seen
+                log.debug(
+                    "seeded dedup for repo=%s with %d issue(s)", spec.repo, len(seen)
+                )
+
+    def _maybe_prune(self) -> None:
+        """Run a prune pass at most once per day across task store and ledger."""
+        if self._task_store is None and self._ledger is None:
+            return
+        now = datetime.now(timezone.utc)
+        if self._last_prune is not None:
+            elapsed = (now - self._last_prune).total_seconds()
+            if elapsed < 86400:  # 24 hours
+                return
+        if self._task_store is not None:
+            try:
+                deleted = self._task_store.prune(self._task_retention_days)
+                if deleted:
+                    log.info("pruned %d old task(s) (retention=%dd)", deleted, self._task_retention_days)
+            except Exception:
+                log.warning("task store prune failed", exc_info=True)
+        if self._ledger is not None:
+            try:
+                deleted = self._ledger.prune(self._task_retention_days)
+                if deleted:
+                    log.info(
+                        "pruned %d old ledger record(s) (retention=%dd)",
+                        deleted,
+                        self._task_retention_days,
+                    )
+            except Exception:
+                log.warning("ledger prune failed", exc_info=True)
+        self._last_prune = now
 
     async def run_once(self) -> DiscoveryTick:
         """Poll every configured repo exactly once and submit new issues."""
@@ -173,6 +234,7 @@ class DiscoveryScheduler:
                 await self.run_once()
             except Exception:
                 log.warning("discovery tick raised; continuing", exc_info=True)
+            self._maybe_prune()
             try:
                 await asyncio.wait_for(self._stop_event.wait(), timeout=self._interval)
                 return  # stop signalled during the wait

--- a/maxwell_daemon/gh/client.py
+++ b/maxwell_daemon/gh/client.py
@@ -14,15 +14,30 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
+
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 __all__ = ["GhCliError", "GitHubClient", "Issue", "PullRequest"]
 
 
 _REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 _ISSUE_FIELDS = "number,title,body,state,labels,url"
+
+# Patterns in gh CLI stderr that indicate a GitHub API rate-limit response
+# (HTTP 429 or 403 with X-RateLimit-Remaining: 0).
+_RATE_LIMIT_RE = re.compile(
+    r"(rate.?limit|api rate|secondary rate|too many requests|403|429)",
+    re.IGNORECASE,
+)
+
+
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    """Return True when a GhCliError looks like a GitHub rate-limit response."""
+    return isinstance(exc, GhCliError) and bool(_RATE_LIMIT_RE.search(str(exc)))
 
 RunnerFn = Callable[..., Awaitable[tuple[int, bytes, bytes]]]
 
@@ -89,6 +104,12 @@ class GitHubClient:
         if not _REPO_RE.match(repo):
             raise ValueError(f"Invalid repo {repo!r}: expected 'owner/name' with safe characters")
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=4, max=60),
+        retry=retry_if_exception(_is_rate_limit_error),
+        reraise=True,
+    )
     async def _gh(self, *argv: str, cwd: str | None = None) -> bytes:
         rc, out, err = await self._run("gh", *argv, cwd=cwd)
         if rc != 0:

--- a/maxwell_daemon/gh/executor.py
+++ b/maxwell_daemon/gh/executor.py
@@ -19,6 +19,7 @@ import os
 import re
 import tempfile
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
@@ -144,16 +145,24 @@ class IssueExecutor:
             {"repo": repo, "issue": issue_number},
         ):
             issue = await self._gh.get_issue(repo, issue_number)
-        branch = f"maxwell-daemon/issue-{issue_number}"
         # Fall back to a derived id when the caller didn't supply one so the
         # executor stays usable in non-Daemon contexts (one-off scripts, tests).
         effective_task_id = task_id or f"issue-{issue_number}"
+        # Append a unique suffix so re-processing the same issue doesn't collide
+        # with an existing branch of the same name (fixes #150).
+        if task_id:
+            branch_suffix = task_id[:8]
+        else:
+            branch_suffix = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        branch = f"maxwell-daemon/issue-{issue_number}-{branch_suffix}"
 
         # Resolve per-call settings: overrides first, executor defaults second.
         ctx_max = self._pick(overrides, "context_max_chars", self._context_max_chars)
         max_diff_retries = self._pick(overrides, "max_diff_retries", self._max_diff_retries)
         max_test_retries = self._pick(overrides, "max_test_retries", self._max_test_retries)
         test_command = overrides.test_command if overrides else None
+        # Resolve system prompt: file content > prefix+default > default (fixes #151).
+        system_prompt = self._resolve_system_prompt(overrides)
 
         # Build context if we have a builder AND we're in implement mode (plan
         # mode doesn't need a clone; enable via a follow-up if it helps).
@@ -185,6 +194,7 @@ class IssueExecutor:
                 context=context_prompt,
                 memory=memory_prompt,
                 labels=list(getattr(issue, "labels", []) or []),
+                system_prompt=system_prompt,
             )
 
         # Record the initial plan to the scratchpad so retries see it.
@@ -212,6 +222,7 @@ class IssueExecutor:
                 diff=diff,
                 max_retries=max_diff_retries,
                 task_id=effective_task_id,
+                system_prompt=system_prompt,
             )
             if self._test_runner is not None:
                 plan, diff, test_result = await self._validate_with_tests(
@@ -228,6 +239,7 @@ class IssueExecutor:
                     max_diff_retries=max_diff_retries,
                     task_id=effective_task_id,
                     on_test_output=on_test_output,
+                    system_prompt=system_prompt,
                 )
             await self._ws.commit_and_push(
                 repo,
@@ -296,6 +308,7 @@ class IssueExecutor:
         max_diff_retries: int,
         task_id: str,
         on_test_output: Any = None,
+        system_prompt: str = _SYSTEM_PROMPT,
     ) -> tuple[str, str, TestResult]:
         """Run repo tests; if they fail, ask the LLM to refine the diff and retry.
 
@@ -329,6 +342,7 @@ class IssueExecutor:
                 previous_plan=current_plan,
                 previous_diff=current_diff,
                 test_output=result.output_tail,
+                system_prompt=system_prompt,
             )
             await self._ws.create_branch(repo, branch, base=base_branch, task_id=task_id)
             await self._apply_with_retry(
@@ -340,6 +354,7 @@ class IssueExecutor:
                 diff=current_diff,
                 max_retries=max_diff_retries,
                 task_id=task_id,
+                system_prompt=system_prompt,
             )
 
     def _workspace_path(self, repo: str, task_id: str | None = None) -> Any:
@@ -373,6 +388,7 @@ class IssueExecutor:
         previous_plan: str,
         previous_diff: str,
         test_output: str,
+        system_prompt: str = _SYSTEM_PROMPT,
     ) -> tuple[str, str]:
         prompt = (
             f"Your previous diff applied cleanly but the repo's own tests now fail.\n\n"
@@ -385,7 +401,7 @@ class IssueExecutor:
         )
         response = await self._backend.complete(
             [
-                Message(role=MessageRole.SYSTEM, content=_SYSTEM_PROMPT),
+                Message(role=MessageRole.SYSTEM, content=system_prompt),
                 Message(role=MessageRole.USER, content=prompt),
             ],
             model=model,
@@ -404,6 +420,7 @@ class IssueExecutor:
         diff: str,
         max_retries: int | None = None,
         task_id: str = "test",
+        system_prompt: str = _SYSTEM_PROMPT,
     ) -> tuple[str, str]:
         """Try to apply the diff; on failure, ask the LLM for a corrected diff."""
         limit = max_retries if max_retries is not None else self._max_diff_retries
@@ -428,6 +445,7 @@ class IssueExecutor:
                     previous_plan=current_plan,
                     previous_diff=current_diff,
                     error=last_error,
+                    system_prompt=system_prompt,
                 )
 
     @staticmethod
@@ -437,6 +455,23 @@ class IssueExecutor:
             return default
         value = getattr(overrides, attr, None)
         return value if value is not None else default
+
+    @staticmethod
+    def _resolve_system_prompt(overrides: RepoOverrides | None) -> str | None:
+        """Return the effective system prompt based on per-repo overrides (fixes #151).
+
+        Priority:
+        1. ``system_prompt_file`` — file contents fully replace the default.
+        2. ``system_prompt_prefix`` — prepended to ``_SYSTEM_PROMPT``.
+        3. ``None`` — caller falls back to the issue-type classifier output.
+        """
+        if overrides is None:
+            return None
+        if overrides.system_prompt_file:
+            return Path(overrides.system_prompt_file).read_text(encoding="utf-8")
+        if overrides.system_prompt_prefix:
+            return overrides.system_prompt_prefix + "\n\n" + _SYSTEM_PROMPT
+        return None
 
     @staticmethod
     async def resolve_pr_target_branch(
@@ -478,6 +513,7 @@ class IssueExecutor:
         previous_plan: str,
         previous_diff: str,
         error: str,
+        system_prompt: str = _SYSTEM_PROMPT,
     ) -> tuple[str, str]:
         prompt = (
             f"Your previous diff did not apply cleanly.\n\n"
@@ -490,7 +526,7 @@ class IssueExecutor:
         )
         response = await self._backend.complete(
             [
-                Message(role=MessageRole.SYSTEM, content=_SYSTEM_PROMPT),
+                Message(role=MessageRole.SYSTEM, content=system_prompt),
                 Message(role=MessageRole.USER, content=prompt),
             ],
             model=model,
@@ -507,11 +543,15 @@ class IssueExecutor:
         context: str = "",
         memory: str = "",
         labels: list[str] | None = None,
+        system_prompt: str | None = None,
     ) -> tuple[str, str]:
         # Pick a specialised system prompt for this kind of issue. Falls back
         # to the default prompt when the classifier can't decide.
-        kind = classify_issue(title=issue_title, body=issue_body, labels=labels or [])
-        system_prompt = render_system_prompt(kind)
+        # If a per-repo system_prompt was resolved, it takes priority over the
+        # issue-type classifier output (fixes #151).
+        if system_prompt is None:
+            kind = classify_issue(title=issue_title, body=issue_body, labels=labels or [])
+            system_prompt = render_system_prompt(kind)
 
         prompt_parts = [f"Issue title: {issue_title}\n"]
         prompt_parts.append(f"Issue body:\n{issue_body or '(empty)'}\n")

--- a/tests/unit/test_issue_executor.py
+++ b/tests/unit/test_issue_executor.py
@@ -256,4 +256,24 @@ class TestBranchNaming:
         asyncio.run(
             executor.execute_issue(repo="owner/repo", issue_number=42, model="m", mode="plan")
         )
-        assert gh.pr_calls[0]["head"] == "maxwell-daemon/issue-42"
+        # Branch now includes a unique suffix to prevent collision on re-processing (#150).
+        head = gh.pr_calls[0]["head"]
+        assert head.startswith("maxwell-daemon/issue-42-"), head
+
+    def test_branch_uses_task_id_prefix_when_supplied(self) -> None:
+        gh = FakeGitHub(issue=_issue())
+        ws = FakeWorkspace()
+        backend = ScriptedBackend(payload={"plan": "ok", "diff": ""})
+        executor = IssueExecutor(github=gh, workspace=ws, backend=backend)
+
+        asyncio.run(
+            executor.execute_issue(
+                repo="owner/repo",
+                issue_number=42,
+                model="m",
+                mode="plan",
+                task_id="abcd1234efgh",
+            )
+        )
+        # First 8 chars of task_id used as suffix.
+        assert gh.pr_calls[0]["head"] == "maxwell-daemon/issue-42-abcd1234"


### PR DESCRIPTION
Replaces threading.Lock with asyncio.Lock in TaskStore and CostLedger. Adds prune() methods with configurable retention days. Seeds DiscoveryScheduler dedup set from TaskStore on startup to survive restarts.

Closes #146
Closes #148
Closes #149