### PR TITLE
fix: persistent discovery dedup, branch collision guard, GitHub rate limit handling

### DIFF
--- a/maxwell_daemon/daemon/scheduler.py
+++ b/maxwell_daemon/daemon/scheduler.py
@@ -22,9 +22,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
 import random
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from maxwell_daemon.contracts import require
@@ -58,12 +60,15 @@ class DiscoveryTick:
     repos: tuple[str, ...]
 
 
+_DEFAULT_DEDUP_PATH = Path.home() / ".local/share/maxwell-daemon/discovery_dedup.json"
+
+
 class DiscoveryScheduler:
     """Runs :func:`discover_issues` across every repo on an interval.
 
-    Deduplication persists *in-memory* across ticks within one scheduler
-    lifetime. Restart loses the set; the daemon's durable task store is
-    the second line of defence (already-active tasks won't re-enqueue).
+    Deduplication is persisted to a JSON file (``dedup_path``) so it
+    survives daemon restarts — preventing duplicate task dispatch for
+    issues already queued in a prior run (#149).
 
     The ``start()``/``stop()`` pair wraps the background task. Exceptions
     from any one tick are logged and swallowed so a transient outage
@@ -78,6 +83,7 @@ class DiscoveryScheduler:
         repos: list[DiscoveryRepoSpec],
         interval_seconds: float = 300.0,
         jitter: bool = True,
+        dedup_path: Path | None = None,
     ) -> None:
         require(
             interval_seconds > 0,
@@ -88,10 +94,40 @@ class DiscoveryScheduler:
         self._repos = list(repos)
         self._interval = float(interval_seconds)
         self._jitter = jitter
+        self._dedup_path: Path | None = (
+            dedup_path if dedup_path is not None else _DEFAULT_DEDUP_PATH
+        )
         # Per-repo set of issue numbers we've seen in any prior tick.
-        self._dispatched: dict[str, set[int]] = {}
+        # Loaded from disk on construction so restarts don't re-dispatch.
+        self._dispatched: dict[str, set[int]] = self._load_dedup()
         self._task: asyncio.Task[None] | None = None
         self._stop_event: asyncio.Event | None = None
+
+    # ------------------------------------------------------------------ #
+    # Dedup persistence
+    # ------------------------------------------------------------------ #
+
+    def _load_dedup(self) -> dict[str, set[int]]:
+        """Load the persisted dedup map from disk, returning an empty dict on any error."""
+        if self._dedup_path is None or not self._dedup_path.exists():
+            return {}
+        try:
+            raw = json.loads(self._dedup_path.read_text())
+            return {repo: set(nums) for repo, nums in raw.items() if isinstance(nums, list)}
+        except Exception:
+            log.warning("discovery dedup file unreadable; starting fresh", exc_info=True)
+            return {}
+
+    def _save_dedup(self) -> None:
+        """Persist the current dedup map to disk.  Failures are logged, not raised."""
+        if self._dedup_path is None:
+            return
+        try:
+            self._dedup_path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {repo: sorted(nums) for repo, nums in self._dispatched.items()}
+            self._dedup_path.write_text(json.dumps(payload))
+        except Exception:
+            log.warning("failed to persist discovery dedup", exc_info=True)
 
     async def run_once(self) -> DiscoveryTick:
         """Poll every configured repo exactly once and submit new issues."""
@@ -127,6 +163,10 @@ class DiscoveryScheduler:
             total_scanned += result.scanned
             total_dispatched += result.dispatched
             total_skipped += result.skipped
+
+        # Persist dedup state so a restart doesn't re-dispatch already-seen issues.
+        if total_dispatched:
+            self._save_dedup()
 
         return DiscoveryTick(
             scanned=total_scanned,

--- a/maxwell_daemon/gh/client.py
+++ b/maxwell_daemon/gh/client.py
@@ -13,12 +13,16 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import re
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
-__all__ = ["GhCliError", "GitHubClient", "Issue", "PullRequest"]
+__all__ = ["GhCliError", "GitHubClient", "GitHubRateLimitError", "Issue", "PullRequest"]
+
+log = logging.getLogger(__name__)
 
 
 _REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
@@ -29,6 +33,31 @@ RunnerFn = Callable[..., Awaitable[tuple[int, bytes, bytes]]]
 
 class GhCliError(RuntimeError):
     """Raised when a `gh` invocation exits non-zero."""
+
+
+class GitHubRateLimitError(GhCliError):
+    """Raised when the GitHub API rate limit is exhausted and cannot be waited out."""
+
+    def __init__(self, message: str, *, reset_at: float | None = None) -> None:
+        super().__init__(message)
+        self.reset_at = reset_at  # Unix timestamp when the limit resets, if known
+
+
+# Exit codes emitted by `gh` when GitHub returns 403 or 429 (rate-limited).
+_RATE_LIMIT_EXIT_CODES: frozenset[int] = frozenset({4})  # gh uses rc=4 for HTTP 4xx
+# Error substrings that indicate a rate-limit response rather than an auth error.
+_RATE_LIMIT_MARKERS: tuple[str, ...] = (
+    "rate limit",
+    "rate_limit",
+    "429",
+    "403",
+    "secondary rate",
+    "abuse detection",
+)
+# Maximum wall-clock seconds we are willing to sleep waiting for a reset.
+_MAX_RATE_LIMIT_WAIT_SECONDS = 120.0
+# Backoff schedule for transient 403/429 responses.
+_BACKOFF_SECONDS: tuple[float, ...] = (1.0, 2.0, 4.0, 8.0)
 
 
 @dataclass(slots=True, frozen=True)
@@ -89,13 +118,92 @@ class GitHubClient:
         if not _REPO_RE.match(repo):
             raise ValueError(f"Invalid repo {repo!r}: expected 'owner/name' with safe characters")
 
+    @staticmethod
+    def _is_rate_limit_error(rc: int, err: bytes) -> bool:
+        """Heuristically detect a GitHub rate-limit response from `gh` output."""
+        if rc == 0:
+            return False
+        err_text = err.decode(errors="replace").lower()
+        return any(marker in err_text for marker in _RATE_LIMIT_MARKERS)
+
     async def _gh(self, *argv: str, cwd: str | None = None) -> bytes:
+        """Run a ``gh`` sub-command, transparently retrying on rate-limit responses.
+
+        When GitHub returns a rate-limit error (403 / 429 / secondary-rate) the
+        method checks how long until the limit resets (via ``gh api rate_limit``
+        if available, otherwise falls back to exponential back-off) and sleeps
+        up to :data:`_MAX_RATE_LIMIT_WAIT_SECONDS` before retrying.  A
+        :class:`GitHubRateLimitError` is raised only when the remaining wait
+        exceeds that ceiling.
+        """
+        for attempt, backoff in enumerate(_BACKOFF_SECONDS):
+            rc, out, err = await self._run("gh", *argv, cwd=cwd)
+            if rc == 0:
+                return out
+
+            if self._is_rate_limit_error(rc, err):
+                # Try to learn the reset timestamp from the rate_limit API.
+                reset_at: float | None = await self._fetch_rate_limit_reset()
+                if reset_at is not None:
+                    wait = reset_at - time.time()
+                    if wait > _MAX_RATE_LIMIT_WAIT_SECONDS:
+                        raise GitHubRateLimitError(
+                            f"GitHub rate limit exhausted; resets in {wait:.0f}s "
+                            f"(ceiling is {_MAX_RATE_LIMIT_WAIT_SECONDS}s)",
+                            reset_at=reset_at,
+                        )
+                    if wait > 0:
+                        log.warning(
+                            "GitHub rate limit hit; sleeping %.1fs until reset (attempt %d/%d)",
+                            wait,
+                            attempt + 1,
+                            len(_BACKOFF_SECONDS),
+                        )
+                        await asyncio.sleep(wait)
+                    continue  # retry immediately after sleeping
+
+                # No reset info — fall back to exponential back-off.
+                if attempt + 1 >= len(_BACKOFF_SECONDS):
+                    raise GitHubRateLimitError(
+                        f"gh {' '.join(argv)} rate-limited after {len(_BACKOFF_SECONDS)} retries: "
+                        f"{err.decode(errors='replace').strip()}"
+                    )
+                log.warning(
+                    "GitHub rate limit hit; backing off %.1fs (attempt %d/%d)",
+                    backoff,
+                    attempt + 1,
+                    len(_BACKOFF_SECONDS),
+                )
+                await asyncio.sleep(backoff)
+                continue
+
+            raise GhCliError(
+                f"gh {' '.join(argv)} failed (rc={rc}): {err.decode(errors='replace').strip()}"
+            )
+
+        # Exhausted all backoff attempts (should not normally be reached).
         rc, out, err = await self._run("gh", *argv, cwd=cwd)
         if rc != 0:
             raise GhCliError(
                 f"gh {' '.join(argv)} failed (rc={rc}): {err.decode(errors='replace').strip()}"
             )
         return out
+
+    async def _fetch_rate_limit_reset(self) -> float | None:
+        """Ask GitHub for the rate-limit reset timestamp.
+
+        Returns a Unix timestamp (float) when the core limit resets, or
+        ``None`` if the call fails or the output is unparseable.
+        """
+        try:
+            rc, out, _ = await self._run("gh", "api", "rate_limit")
+            if rc != 0 or not out:
+                return None
+            data = json.loads(out)
+            reset = data.get("resources", {}).get("core", {}).get("reset")
+            return float(reset) if reset is not None else None
+        except Exception:
+            return None
 
     async def check_auth(self) -> bool:
         rc, _, _ = await self._run("gh", "auth", "status")

--- a/maxwell_daemon/gh/workspace.py
+++ b/maxwell_daemon/gh/workspace.py
@@ -107,13 +107,35 @@ class Workspace:
         await self._run_git("clone", "--depth", str(depth), url, str(target))
         return target
 
+    async def _branch_exists_on_remote(self, branch: str, *, cwd: Path) -> bool:
+        """Return True if *branch* already exists on the remote.
+
+        Uses ``git ls-remote --heads origin <branch>`` which exits 0 regardless
+        of whether the branch exists; the output is empty when it does not.
+        """
+        rc, out, _ = await self._run("git", "ls-remote", "--heads", "origin", branch, cwd=str(cwd))
+        return rc == 0 and bool(out.strip())
+
     async def create_branch(
         self, repo: str, branch: str, *, base: str = "main", task_id: str
     ) -> None:
+        """Check out *base* and create *branch*.
+
+        If *branch* already exists on the remote the existing branch is checked
+        out and updated rather than attempting ``checkout -b``, which would fail
+        with a "branch already exists" error when the same issue is processed
+        twice (e.g. before persistent dedup takes effect, or under a race).
+        """
         target = self.path_for(repo, task_id=task_id)
         await self._run_git("checkout", base, cwd=target)
         await self._run_git("pull", "--ff-only", "origin", base, cwd=target)
-        await self._run_git("checkout", "-B", branch, cwd=target)
+
+        if await self._branch_exists_on_remote(branch, cwd=target):
+            # Branch already exists: switch to it and fast-forward.
+            await self._run_git("checkout", branch, cwd=target)
+            await self._run_git("pull", "--ff-only", "origin", branch, cwd=target)
+        else:
+            await self._run_git("checkout", "-B", branch, cwd=target)
 
     async def apply_diff(self, repo: str, diff: str, *, task_id: str) -> None:
         target = self.path_for(repo, task_id=task_id)

--- a/tests/unit/test_discovery_scheduler.py
+++ b/tests/unit/test_discovery_scheduler.py
@@ -9,7 +9,9 @@ All time is simulated via an injected clock to keep tests deterministic.
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -88,7 +90,7 @@ class TestShapes:
 
 
 class TestRunOnce:
-    async def test_dispatches_new_issues_from_one_repo(self) -> None:
+    async def test_dispatches_new_issues_from_one_repo(self, tmp_path: Path) -> None:
         gh = _FakeGitHub({"a/b": [_issue(1, labels=["deliver"]), _issue(2, labels=["deliver"])]})
         daemon = _FakeDaemon()
         sched = DiscoveryScheduler(
@@ -96,30 +98,33 @@ class TestRunOnce:
             daemon=daemon,
             repos=[DiscoveryRepoSpec(repo="a/b", labels={"deliver"})],
             interval_seconds=60,
+            dedup_path=tmp_path / "dedup.json",
         )
         tick = await sched.run_once()
         assert tick.dispatched == 2
         assert [s["issue_number"] for s in daemon.submitted] == [1, 2]
 
-    async def test_label_filter_drops_non_matching(self) -> None:
+    async def test_label_filter_drops_non_matching(self, tmp_path: Path) -> None:
         gh = _FakeGitHub({"a/b": [_issue(1, labels=["deliver"]), _issue(2, labels=["other"])]})
         daemon = _FakeDaemon()
         sched = DiscoveryScheduler(
             github=gh,
             daemon=daemon,
             repos=[DiscoveryRepoSpec(repo="a/b", labels={"deliver"})],
+            dedup_path=tmp_path / "dedup.json",
         )
         tick = await sched.run_once()
         assert tick.dispatched == 1
         assert daemon.submitted[0]["issue_number"] == 1
 
-    async def test_already_dispatched_is_skipped_next_run(self) -> None:
+    async def test_already_dispatched_is_skipped_next_run(self, tmp_path: Path) -> None:
         gh = _FakeGitHub({"a/b": [_issue(1, labels=["deliver"])]})
         daemon = _FakeDaemon()
         sched = DiscoveryScheduler(
             github=gh,
             daemon=daemon,
             repos=[DiscoveryRepoSpec(repo="a/b", labels={"deliver"})],
+            dedup_path=tmp_path / "dedup.json",
         )
         first = await sched.run_once()
         second = await sched.run_once()
@@ -127,7 +132,7 @@ class TestRunOnce:
         assert second.dispatched == 0
         assert len(daemon.submitted) == 1
 
-    async def test_fans_out_across_multiple_repos(self) -> None:
+    async def test_fans_out_across_multiple_repos(self, tmp_path: Path) -> None:
         gh = _FakeGitHub(
             {
                 "a/b": [_issue(1, labels=["deliver"])],
@@ -142,13 +147,14 @@ class TestRunOnce:
                 DiscoveryRepoSpec(repo="a/b", labels={"deliver"}),
                 DiscoveryRepoSpec(repo="c/d", labels={"deliver"}),
             ],
+            dedup_path=tmp_path / "dedup.json",
         )
         tick = await sched.run_once()
         assert tick.dispatched == 2
         submitted_repos = {s["repo"] for s in daemon.submitted}
         assert submitted_repos == {"a/b", "c/d"}
 
-    async def test_broken_repo_does_not_kill_tick(self) -> None:
+    async def test_broken_repo_does_not_kill_tick(self, tmp_path: Path) -> None:
         class _Flaky:
             async def list_issues(
                 self, repo: str, *, state: str = "open", limit: int = 50
@@ -165,18 +171,61 @@ class TestRunOnce:
                 DiscoveryRepoSpec(repo="bad/repo", labels={"deliver"}),
                 DiscoveryRepoSpec(repo="ok/repo", labels={"deliver"}),
             ],
+            dedup_path=tmp_path / "dedup.json",
         )
         tick = await sched.run_once()
         # Broken repo didn't prevent ok/repo from dispatching.
         assert tick.dispatched == 1
         assert daemon.submitted[0]["repo"] == "ok/repo"
 
+    async def test_dedup_persisted_to_disk(self, tmp_path: Path) -> None:
+        """Dispatched issue numbers are written to the dedup file (#149)."""
+        dedup_file = tmp_path / "dedup.json"
+        gh = _FakeGitHub({"a/b": [_issue(1, labels=["deliver"]), _issue(2, labels=["deliver"])]})
+        daemon = _FakeDaemon()
+        sched = DiscoveryScheduler(
+            github=gh,
+            daemon=daemon,
+            repos=[DiscoveryRepoSpec(repo="a/b", labels={"deliver"})],
+            dedup_path=dedup_file,
+        )
+        await sched.run_once()
+        assert dedup_file.exists(), "dedup file must be written after dispatch"
+        persisted = json.loads(dedup_file.read_text())
+        assert set(persisted.get("a/b", [])) == {1, 2}
+
+    async def test_dedup_loaded_on_restart(self, tmp_path: Path) -> None:
+        """A new scheduler instance loads persisted dedup and skips already-seen issues (#149)."""
+        dedup_file = tmp_path / "dedup.json"
+        gh = _FakeGitHub({"a/b": [_issue(1, labels=["deliver"])]})
+
+        # First "run" — dispatches issue 1 and persists the dedup file.
+        sched1 = DiscoveryScheduler(
+            github=gh,
+            daemon=_FakeDaemon(),
+            repos=[DiscoveryRepoSpec(repo="a/b", labels={"deliver"})],
+            dedup_path=dedup_file,
+        )
+        await sched1.run_once()
+
+        # Simulate a restart: create a fresh scheduler with the same dedup file.
+        daemon2 = _FakeDaemon()
+        sched2 = DiscoveryScheduler(
+            github=gh,
+            daemon=daemon2,
+            repos=[DiscoveryRepoSpec(repo="a/b", labels={"deliver"})],
+            dedup_path=dedup_file,
+        )
+        tick = await sched2.run_once()
+        assert tick.dispatched == 0, "issue already dispatched in previous run must not re-dispatch"
+        assert len(daemon2.submitted) == 0
+
 
 # ── Start/stop lifecycle ─────────────────────────────────────────────────────
 
 
 class TestLifecycle:
-    async def test_start_schedules_periodic_ticks(self) -> None:
+    async def test_start_schedules_periodic_ticks(self, tmp_path: Path) -> None:
         """Start the scheduler, wait long enough for 1-2 ticks, stop, verify calls."""
         gh = _FakeGitHub({"a/b": [_issue(1, labels=["deliver"])]})
         daemon = _FakeDaemon()
@@ -185,6 +234,7 @@ class TestLifecycle:
             daemon=daemon,
             repos=[DiscoveryRepoSpec(repo="a/b", labels={"deliver"})],
             interval_seconds=0.01,  # tiny interval for test
+            dedup_path=tmp_path / "dedup.json",
         )
         await sched.start()
         await asyncio.sleep(0.05)
@@ -193,22 +243,24 @@ class TestLifecycle:
         assert daemon.submitted
         assert daemon.submitted[0]["issue_number"] == 1
 
-    async def test_stop_is_idempotent(self) -> None:
+    async def test_stop_is_idempotent(self, tmp_path: Path) -> None:
         sched = DiscoveryScheduler(
             github=_FakeGitHub({}),
             daemon=_FakeDaemon(),
             repos=[],
             interval_seconds=60,
+            dedup_path=tmp_path / "dedup.json",
         )
         await sched.stop()  # Safe even if never started.
         await sched.stop()  # Double-stop must not explode.
 
-    async def test_start_twice_is_idempotent(self) -> None:
+    async def test_start_twice_is_idempotent(self, tmp_path: Path) -> None:
         sched = DiscoveryScheduler(
             github=_FakeGitHub({}),
             daemon=_FakeDaemon(),
             repos=[],
             interval_seconds=0.01,
+            dedup_path=tmp_path / "dedup.json",
         )
         await sched.start()
         await sched.start()  # second start is a no-op, not an error
@@ -219,7 +271,7 @@ class TestLifecycle:
 
 
 class TestPreconditions:
-    def test_rejects_zero_interval(self) -> None:
+    def test_rejects_zero_interval(self, tmp_path: Path) -> None:
         from maxwell_daemon.contracts import PreconditionError
 
         with pytest.raises(PreconditionError, match="interval"):
@@ -228,9 +280,10 @@ class TestPreconditions:
                 daemon=_FakeDaemon(),
                 repos=[],
                 interval_seconds=0,
+                dedup_path=tmp_path / "dedup.json",
             )
 
-    def test_rejects_negative_interval(self) -> None:
+    def test_rejects_negative_interval(self, tmp_path: Path) -> None:
         from maxwell_daemon.contracts import PreconditionError
 
         with pytest.raises(PreconditionError, match="interval"):
@@ -239,4 +292,5 @@ class TestPreconditions:
                 daemon=_FakeDaemon(),
                 repos=[],
                 interval_seconds=-1,
+                dedup_path=tmp_path / "dedup.json",
             )

--- a/tests/unit/test_gh_client.py
+++ b/tests/unit/test_gh_client.py
@@ -12,6 +12,7 @@ import json
 import pytest
 
 from maxwell_daemon.gh import GhCliError, GitHubClient, Issue, PullRequest
+from maxwell_daemon.gh.client import GitHubRateLimitError
 
 
 @pytest.fixture
@@ -272,3 +273,118 @@ class TestModels:
             "url": "u",
         }
         assert Issue.from_gh(payload).is_open is False
+
+
+class TestRateLimitHandling:
+    """GitHubClient retries on rate-limit responses and backs off (#152)."""
+
+    def _make_runner(self, responses: list[tuple[int, bytes, bytes]]) -> object:
+        """Return a runner that yields responses in sequence."""
+
+        class _SeqRunner:
+            def __init__(self, seq: list[tuple[int, bytes, bytes]]) -> None:
+                self._seq = list(seq)
+                self._idx = 0
+                self.calls: list[tuple[str, ...]] = []
+
+            async def __call__(
+                self, *argv: str, cwd: str | None = None
+            ) -> tuple[int, bytes, bytes]:
+                self.calls.append(argv)
+                if self._idx < len(self._seq):
+                    result = self._seq[self._idx]
+                    self._idx += 1
+                    return result
+                return (0, b"[]", b"")
+
+        return _SeqRunner(responses)
+
+    def test_rate_limit_marker_detected(self) -> None:
+        """_is_rate_limit_error returns True for recognisable rate-limit messages."""
+        assert GitHubClient._is_rate_limit_error(1, b"API rate limit exceeded") is True
+        assert GitHubClient._is_rate_limit_error(1, b"secondary rate limit") is True
+        assert GitHubClient._is_rate_limit_error(1, b"429 Too Many Requests") is True
+        assert GitHubClient._is_rate_limit_error(0, b"rate limit") is False  # rc=0 means success
+        assert GitHubClient._is_rate_limit_error(1, b"Repository not found") is False
+
+    def test_retries_once_on_rate_limit_with_backoff(self) -> None:
+        """Client retries after a rate-limit error and succeeds on the second attempt."""
+        import json as _json
+
+        issues_payload = _json.dumps(
+            [{"number": 1, "title": "t", "body": "", "state": "OPEN", "labels": [], "url": "u"}]
+        ).encode()
+
+        runner = self._make_runner(
+            [
+                # First call: rate-limited
+                (1, b"", b"API rate limit exceeded for installation"),
+                # rate_limit API probe (returns no reset info → backoff)
+                (1, b"", b""),
+                # Retry of the original command: success
+                (0, issues_payload, b""),
+            ]
+        )
+        client = GitHubClient(runner=runner)
+        issues = asyncio.run(client.list_issues("owner/repo"))
+        assert len(issues) == 1
+        assert issues[0].number == 1
+
+    def test_raises_rate_limit_error_after_all_retries_exhausted(self) -> None:
+        """GitHubRateLimitError is raised when every retry attempt is rate-limited."""
+        runner = self._make_runner(
+            [
+                (1, b"", b"API rate limit exceeded"),
+                (1, b"", b""),  # rate_limit probe fails
+                (1, b"", b"API rate limit exceeded"),
+                (1, b"", b""),  # rate_limit probe fails
+                (1, b"", b"API rate limit exceeded"),
+                (1, b"", b""),  # rate_limit probe fails
+                (1, b"", b"API rate limit exceeded"),
+                (1, b"", b""),  # rate_limit probe fails
+            ]
+        )
+        client = GitHubClient(runner=runner)
+        with pytest.raises(GitHubRateLimitError):
+            asyncio.run(client.list_issues("owner/repo"))
+
+    def test_non_rate_limit_error_raises_immediately(self) -> None:
+        """Errors that are not rate-limit related raise GhCliError without retrying."""
+        runner = self._make_runner(
+            [
+                (1, b"", b"Repository not found"),
+            ]
+        )
+        client = GitHubClient(runner=runner)
+        with pytest.raises(GhCliError, match="Repository not found"):
+            asyncio.run(client.list_issues("owner/repo"))
+        # Only one call made — no retries for non-rate-limit errors.
+        assert len(runner.calls) == 1  # type: ignore[attr-defined]
+
+    def test_rate_limit_reset_respected_when_available(self) -> None:
+        """When the rate_limit API returns a reset time, the client waits for it."""
+        import json as _json
+        import time
+
+        issues_payload = _json.dumps(
+            [{"number": 2, "title": "x", "body": "", "state": "OPEN", "labels": [], "url": "u"}]
+        ).encode()
+        # Reset is 1 second in the future — well within the ceiling.
+        reset_ts = int(time.time()) + 1
+        rate_limit_payload = _json.dumps(
+            {"resources": {"core": {"remaining": 0, "reset": reset_ts}}}
+        ).encode()
+
+        runner = self._make_runner(
+            [
+                # First call: rate-limited
+                (1, b"", b"rate limit exceeded"),
+                # rate_limit probe: returns reset timestamp
+                (0, rate_limit_payload, b""),
+                # Retry after sleeping: success
+                (0, issues_payload, b""),
+            ]
+        )
+        client = GitHubClient(runner=runner)
+        issues = asyncio.run(client.list_issues("owner/repo"))
+        assert len(issues) == 1

--- a/tests/unit/test_gh_workspace.py
+++ b/tests/unit/test_gh_workspace.py
@@ -87,6 +87,30 @@ class TestBranchLifecycle:
         assert ("git", "checkout", "main") in cmds
         assert ("git", "checkout", "-B", "maxwell-daemon/issue-42") in cmds
 
+    def test_create_branch_skips_checkout_b_when_remote_branch_exists(self, tmp_path: Path) -> None:
+        """When the branch already exists on the remote, checkout + pull instead of -B (#150)."""
+        (tmp_path / "repo" / "t-1" / ".git").mkdir(parents=True)
+        git = FakeGit()
+        branch = "maxwell-daemon/issue-42"
+        # Make ls-remote report the branch as already present on the remote.
+        git.respond(
+            "git",
+            "ls-remote",
+            "--heads",
+            "origin",
+            branch,
+            returncode=0,
+            stdout=b"abc123\trefs/heads/maxwell-daemon/issue-42\n",
+        )
+        ws = Workspace(root=tmp_path, runner=git)
+        asyncio.run(ws.create_branch("owner/repo", branch, base="main", task_id="t-1"))
+        cmds = [c[0] for c in git.calls]
+        # Should check out the existing branch, not create a new one.
+        assert ("git", "checkout", branch) in cmds
+        assert ("git", "pull", "--ff-only", "origin", branch) in cmds
+        # Must NOT attempt to create a new branch (would fail with "already exists").
+        assert ("git", "checkout", "-B", branch) not in cmds
+
     def test_commit_and_push(self, tmp_path: Path) -> None:
         (tmp_path / "repo" / "t-1" / ".git").mkdir(parents=True)
         git = FakeGit()


### PR DESCRIPTION
## Summary

- **Closes #149** — `DiscoveryScheduler` persists its dispatched-issue set to a JSON file on every tick and loads it on startup, so daemon restarts no longer re-dispatch already-queued issues.
- **Closes #150** — `Workspace.create_branch` runs `git ls-remote --heads origin <branch>` before creating a branch; if the branch already exists on the remote it switches to it and fast-forwards instead of running `checkout -b` (which would fail with "branch already exists").
- **Closes #152** — `GitHubClient._gh` detects rate-limit responses (403/429/secondary-rate markers in `gh` stderr), queries the `rate_limit` API for the exact reset timestamp, sleeps until the limit resets (up to a 120 s ceiling), and falls back to exponential back-off when no reset info is available. `GitHubRateLimitError` is raised only when the wait would exceed the ceiling or all back-off attempts are exhausted.

## Test plan

- [ ] `tests/unit/test_discovery_scheduler.py` — new `test_dedup_persisted_to_disk` and `test_dedup_loaded_on_restart` tests verify JSON round-trip. All existing scheduler tests updated to pass isolated `dedup_path` fixtures.
- [ ] `tests/unit/test_gh_workspace.py` — new `test_create_branch_skips_checkout_b_when_remote_branch_exists` verifies collision guard path.
- [ ] `tests/unit/test_gh_client.py` — new `TestRateLimitHandling` class with 5 tests covering detection, retry, exhaustion, non-rate-limit passthrough, and reset-timestamp sleep.
- [ ] Run locally: `pytest tests/unit/test_discovery_scheduler.py tests/unit/test_gh_workspace.py tests/unit/test_gh_client.py` → 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)