### PR TITLE
fix(task_store): use timezone-aware datetimes (#147)

### DIFF
--- a/maxwell_daemon/core/task_store.py
+++ b/maxwell_daemon/core/task_store.py
@@ -35,7 +35,7 @@ import sqlite3
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -90,8 +90,19 @@ def _iso(value: datetime | None) -> str | None:
     return value.isoformat() if value is not None else None
 
 
+def _parse_iso_required(value: str) -> datetime:
+    # Legacy DBs may contain naive ISO strings written before this module
+    # became timezone-aware. Treat those as UTC so comparisons with
+    # ``datetime.now(timezone.utc)`` elsewhere in the codebase don't raise
+    # ``TypeError: can't compare offset-naive and offset-aware datetimes``.
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
 def _parse_iso(value: str | None) -> datetime | None:
-    return datetime.fromisoformat(value) if value else None
+    return _parse_iso_required(value) if value else None
 
 
 class TaskStore:
@@ -125,7 +136,11 @@ class TaskStore:
     # ── Sync internals ────────────────────────────────────────────────────────
 
     def _save_sync(self, task: Task) -> None:
-        now = datetime.now(task.created_at.tzinfo).isoformat()
+        # Prefer the task's own tzinfo so the updated_at stays in the same
+        # zone as created_at, but fall back to UTC if the task happens to be
+        # naive (e.g. loaded from a legacy DB row).
+        tz = task.created_at.tzinfo or timezone.utc
+        now = datetime.now(tz).isoformat()
         row = (
             task.id,
             task.created_at.isoformat(),
@@ -184,7 +199,7 @@ class TaskStore:
         started_at: datetime | None = None,
         finished_at: datetime | None = None,
     ) -> None:
-        now = datetime.now().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         with self._lock, self._connect() as conn:
             cursor = conn.execute("SELECT id FROM tasks WHERE id = ?", (task_id,))
             if cursor.fetchone() is None:
@@ -228,7 +243,7 @@ class TaskStore:
     def _recover_sync(self) -> list[Task]:
         from maxwell_daemon.daemon.runner import TaskStatus as _TaskStatus
 
-        now = datetime.now().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         with self._lock, self._connect() as conn:
             conn.execute(
                 """
@@ -369,7 +384,7 @@ def _row_to_task(row: sqlite3.Row) -> Task:
         error=row["error"],
         pr_url=row["pr_url"],
         cost_usd=row["cost_usd"],
-        created_at=datetime.fromisoformat(row["created_at"]),
+        created_at=_parse_iso_required(row["created_at"]),
         started_at=_parse_iso(row["started_at"]),
         finished_at=_parse_iso(row["finished_at"]),
     )

--- a/tests/unit/test_task_store.py
+++ b/tests/unit/test_task_store.py
@@ -160,6 +160,68 @@ class TestClose:
         assert store.get(task.id) is not None
 
 
+class TestTimezoneAwareTimestamps:
+    """Regression tests for issue #147.
+
+    ``update_status`` and ``recover_pending`` used to write naive
+    ``datetime.now()`` strings, which then failed to compare against aware
+    datetimes produced elsewhere in the codebase.
+    """
+
+    def test_update_status_writes_aware_timestamp(self, store: TaskStore) -> None:
+        task = _fresh_task()
+        store.save(task)
+        store.update_status(task.id, TaskStatus.RUNNING)
+
+        loaded = store.get(task.id)
+        assert loaded is not None
+        assert loaded.created_at.tzinfo is not None
+        # Must be comparable to an aware "now" without TypeError.
+        assert loaded.created_at <= datetime.now(timezone.utc)
+
+    def test_recover_pending_writes_aware_timestamp(self, store: TaskStore) -> None:
+        running = _fresh_task()
+        store.save(running)
+        store.update_status(running.id, TaskStatus.RUNNING)
+
+        store.recover_pending()
+        loaded = store.get(running.id)
+        assert loaded is not None
+        assert loaded.created_at.tzinfo is not None
+        # Cross-module comparison that used to raise TypeError.
+        assert loaded.created_at <= datetime.now(timezone.utc)
+
+    def test_legacy_naive_timestamps_are_read_as_utc(self, tmp_path: Path) -> None:
+        """DBs written before the fix contain naive ISO strings. Reads must
+        promote them to aware UTC so downstream comparisons still work."""
+        import sqlite3
+
+        db = tmp_path / "legacy.db"
+        store = TaskStore(db)
+        # Directly inject a row with a naive ISO timestamp to simulate legacy data.
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                """
+                INSERT INTO tasks (id, created_at, updated_at, kind, status, prompt)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    "legacy-id",
+                    "2024-01-01T12:00:00",  # naive, no +00:00 suffix
+                    "2024-01-01T12:00:00",
+                    TaskKind.PROMPT.value,
+                    TaskStatus.QUEUED.value,
+                    "legacy",
+                ),
+            )
+            conn.commit()
+
+        loaded = store.get("legacy-id")
+        assert loaded is not None
+        assert loaded.created_at.tzinfo is not None
+        assert loaded.created_at <= datetime.now(timezone.utc)
+
+
 class TestAsyncAPI:
     async def test_asave_and_aget(self, tmp_path: Path) -> None:
         store = TaskStore(tmp_path / "tasks.db")


### PR DESCRIPTION
## Summary

Fixes #147 — `maxwell_daemon/core/task_store.py` was writing naive timestamps via bare `datetime.now()`, which then raised `TypeError: can't compare offset-naive and offset-aware datetimes` when compared against the aware `datetime.now(timezone.utc)` values used across `ledger`, `audit`, and `memory.scratchpad`.

## Change

Normalize every `task_store` timestamp write to UTC-aware, and promote legacy naive ISO strings to aware UTC on read so existing databases keep working.

### Call sites touched
- `_save_sync` — fall back to `timezone.utc` when `task.created_at` is naive
- `_update_status_sync` — replaced naive `datetime.now()` with `datetime.now(timezone.utc)`
- `_recover_sync` — replaced naive `datetime.now()` with `datetime.now(timezone.utc)`
- `_parse_iso` / new `_parse_iso_required` — attach `timezone.utc` to legacy naive strings
- `_row_to_task` — route `created_at` through the legacy-safe parser

## Test plan

- [x] Added regression tests in `tests/unit/test_task_store.py::TestTimezoneAwareTimestamps` covering `update_status`, `recover_pending`, and legacy-DB reads
- [x] `pytest tests/unit/test_task_store.py` — 22 passed
- [x] `pytest tests/unit/test_task_store.py tests/unit/test_daemon_task_store_errors.py tests/unit/test_daemon_recovery.py tests/unit/test_daemon_thread_safety.py` — 30 passed
- [x] Full `pytest --no-cov` — 1297 passed, 1 skipped (`asyncssh` missing, unrelated)

Closes #147
