### PR TITLE
fix: close AsyncClient instances (#154)

### DIFF
--- a/maxwell_daemon/fleet/client.py
+++ b/maxwell_daemon/fleet/client.py
@@ -19,6 +19,7 @@ See GitHub issue #104.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
@@ -80,6 +81,11 @@ class RemoteDaemonClient:
 
     The ``http_client`` is injected. Pass ``None`` to use a fresh
     :class:`httpx.AsyncClient` with the configured timeout.
+
+    The client owns a long-lived HTTP connection pool. Callers are
+    responsible for closing it via :meth:`aclose` (or the async
+    context-manager protocol) during shutdown to avoid leaking sockets
+    (see issue #154).
     """
 
     def __init__(
@@ -145,6 +151,34 @@ class RemoteDaemonClient:
         except Exception:
             return False
         return response.status_code == 200
+
+    async def aclose(self) -> None:
+        """Release the underlying HTTP client's connection pool.
+
+        Without an explicit close, the default :class:`httpx.AsyncClient`
+        created by :func:`_make_default_http` leaks its TCP connection pool
+        and SSL contexts — producing ``ResourceWarning: unclosed <ssl.SSLSocket>``
+        on shutdown and, under high task volume, accumulating connections
+        until OS file-descriptor limits are hit (see issue #154).
+
+        Callers that own a :class:`RemoteDaemonClient` should ``await`` this
+        during shutdown; an injected HTTP client that doesn't expose a close
+        method is tolerated silently so tests that hand in a fake don't have
+        to stub one.
+        """
+        close = getattr(self._http, "aclose", None) or getattr(self._http, "close", None)
+        if close is None:
+            return
+        with contextlib.suppress(Exception):
+            result = close()
+            if hasattr(result, "__await__"):
+                await result
+
+    async def __aenter__(self) -> RemoteDaemonClient:
+        return self
+
+    async def __aexit__(self, *exc_info: Any) -> None:
+        await self.aclose()
 
     async def refresh_all(self, machines: tuple[MachineState, ...]) -> tuple[MachineState, ...]:
         """Probe every machine in parallel, return snapshots with ``healthy`` updated.
@@ -213,5 +247,14 @@ def _make_default_http(timeout_seconds: float) -> HTTPClientProtocol:
 
         async def get(self, url: str, *, headers: dict[str, str]) -> HTTPResponseProtocol:
             return await self._client.get(url, headers=headers)
+
+        async def aclose(self) -> None:
+            """Close the underlying ``httpx.AsyncClient`` to release sockets.
+
+            Paired with :meth:`RemoteDaemonClient.aclose` so the default
+            adapter doesn't leak connection pools when the client is
+            long-lived (see issue #154).
+            """
+            await self._client.aclose()
 
     return _HttpxAdapter(timeout_seconds)

--- a/tests/unit/test_fleet_remote_client.py
+++ b/tests/unit/test_fleet_remote_client.py
@@ -320,3 +320,73 @@ class TestRemoteTaskResultFrozen:
         r = RemoteTaskResult(task_id="t1", machine_name="m1", status="submitted")
         with pytest.raises(dc.FrozenInstanceError):
             r.status = "error"  # type: ignore[misc]
+
+
+class TestAclose:
+    """Regression tests for issue #154 — ``RemoteDaemonClient`` must release
+    the underlying :class:`httpx.AsyncClient` on shutdown, otherwise the TCP
+    connection pool and SSL contexts leak until the OS fd limit is hit."""
+
+    async def test_aclose_awaits_underlying_http_client(self) -> None:
+        """When the injected HTTP client has an async ``aclose``, we await it."""
+
+        class ClosableHTTP(FakeHTTPClient):
+            def __init__(self) -> None:
+                super().__init__()
+                self.aclose_calls = 0
+
+            async def aclose(self) -> None:
+                self.aclose_calls += 1
+
+        http = ClosableHTTP()
+        client = RemoteDaemonClient(http_client=http)
+        await client.aclose()
+        assert http.aclose_calls == 1
+
+    async def test_aclose_tolerates_http_client_without_close(self) -> None:
+        """Injected fakes need not implement close; aclose is a no-op."""
+        http = FakeHTTPClient()
+        client = RemoteDaemonClient(http_client=http)
+        # Should not raise.
+        await client.aclose()
+
+    async def test_aclose_suppresses_underlying_close_errors(self) -> None:
+        """A misbehaving close shouldn't bubble up and abort shutdown."""
+
+        class ExplodingHTTP(FakeHTTPClient):
+            async def aclose(self) -> None:
+                raise RuntimeError("boom")
+
+        http = ExplodingHTTP()
+        client = RemoteDaemonClient(http_client=http)
+        await client.aclose()  # must not raise
+
+    async def test_async_context_manager_closes_on_exit(self) -> None:
+        """``async with RemoteDaemonClient(...)`` must close on exit."""
+
+        class ClosableHTTP(FakeHTTPClient):
+            def __init__(self) -> None:
+                super().__init__()
+                self.aclose_calls = 0
+
+            async def aclose(self) -> None:
+                self.aclose_calls += 1
+
+        http = ClosableHTTP()
+        async with RemoteDaemonClient(http_client=http) as client:
+            assert client is not None
+        assert http.aclose_calls == 1
+
+    async def test_default_httpx_adapter_exposes_aclose(self) -> None:
+        """The default adapter created by ``_make_default_http`` must be
+        closable so the built-in ``httpx.AsyncClient`` doesn't leak."""
+        from maxwell_daemon.fleet.client import _make_default_http
+
+        adapter = _make_default_http(timeout_seconds=1.0)
+        # The adapter's close should drain the underlying httpx.AsyncClient.
+        close = getattr(adapter, "aclose", None)
+        assert close is not None, "default adapter must expose aclose()"
+        await close()
+        # httpx marks the client as closed after aclose(); verify it.
+        underlying = adapter._client  # type: ignore[attr-defined]
+        assert underlying.is_closed is True


### PR DESCRIPTION
## Summary

`RemoteDaemonClient` in `maxwell_daemon/fleet/client.py` constructed an `httpx.AsyncClient` (via its default `_HttpxAdapter`) but never released it. Under high task volume this leaked TCP connection pools and SSL contexts until the OS file-descriptor limit was hit; on shutdown it produced `ResourceWarning: unclosed <ssl.SSLSocket>`, and in tests it surfaced as `Event loop is closed` errors between cases.

## Lifecycle pattern

- Added `async def aclose(self)` on `RemoteDaemonClient` that delegates to the injected HTTP client's `aclose`/`close` (tolerating fakes that don't implement one).
- Added `__aenter__` / `__aexit__` so callers can also use `async with RemoteDaemonClient(...) as client:` for short-lived scopes.
- Added `aclose()` on the built-in `_HttpxAdapter` that drains the underlying `httpx.AsyncClient`.
- Updated the class docstring to state the ownership contract.

`AgentLoopBackend` already had an `aclose()` (around line 615 of `backends/agent_loop.py`) and is already wired into shutdown via `BackendRouter.aclose_all()` called from `Daemon.stop()` — no change needed there.

## Files changed

- `maxwell_daemon/fleet/client.py` — add `aclose` on the client, async-context-manager methods, and `aclose` on the default adapter.
- `tests/unit/test_fleet_remote_client.py` — regression tests for the new close paths.

## Test plan

- [x] `pytest tests/unit/test_fleet_remote_client.py` — 35 passed (5 new)
- [x] `pytest tests/unit/test_backend_agent_loop.py` — 26 passed (pre-existing `aclose` coverage intact)
- [x] `ruff check` on modified files — clean
- [x] `mypy maxwell_daemon/fleet/client.py` — clean

Closes #154

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
