### PR TITLE
fix: document false-positive secret patterns in tests (#222)

### DIFF
--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -38,7 +38,7 @@ def client(daemon: Daemon) -> Iterator[TestClient]:
 
 @pytest.fixture
 def auth_client(daemon: Daemon) -> Iterator[TestClient]:
-    with TestClient(create_app(daemon, auth_token="secret-abc")) as c:
+    with TestClient(create_app(daemon, auth_token="secret-abc")) as c:  # nosec B106 — intentional test fixture, not a real credential
         yield c
 
 
@@ -156,7 +156,7 @@ class TestJwtAuthEndpoint:
     def test_whoami_returns_static_token_identity(self, auth_client: TestClient) -> None:
         r = auth_client.get(
             "/api/v1/auth/me",
-            headers={"Authorization": "Bearer secret-abc"},
+            headers={"Authorization": "Bearer secret-abc"},  # nosec B106 — test fixture token matching auth_client fixture
         )
 
         assert r.status_code == 200
@@ -359,6 +359,6 @@ class TestAuth:
     def test_accepts_correct_token(self, auth_client: TestClient) -> None:
         r = auth_client.get(
             "/api/v1/backends",
-            headers={"Authorization": "Bearer secret-abc"},
+            headers={"Authorization": "Bearer secret-abc"},  # nosec B106 — test fixture token matching auth_client fixture
         )
         assert r.status_code == 200

--- a/tests/unit/test_backend_claude.py
+++ b/tests/unit/test_backend_claude.py
@@ -18,7 +18,7 @@ from maxwell_daemon.backends.registry import registry
 
 @pytest.fixture(autouse=True)
 def _key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")  # nosec B105 — intentional test fixture; env var is monkeypatched, not a real key
 
 
 class TestConfiguration:
@@ -28,7 +28,7 @@ class TestConfiguration:
             ClaudeBackend()
 
     def test_accepts_explicit_key(self) -> None:
-        backend = ClaudeBackend(api_key="sk-test-explicit")
+        backend = ClaudeBackend(api_key="sk-test-explicit")  # nosec B106 — intentional test fixture, not a real API key
         assert backend is not None
 
 
@@ -150,7 +150,7 @@ class TestRequestPaths:
             lambda **_: fake_client,
         )
 
-        backend = ClaudeBackend(api_key="x")
+        backend = ClaudeBackend(api_key="x")  # nosec B106 — intentional test fixture; real client is monkeypatched
         out = await backend.complete(
             [
                 Message(role=MessageRole.SYSTEM, content="policy"),
@@ -182,7 +182,7 @@ class TestRequestPaths:
             "maxwell_daemon.backends.claude.anthropic.AsyncAnthropic",
             lambda **_: fake_client,
         )
-        backend = ClaudeBackend(api_key="x")
+        backend = ClaudeBackend(api_key="x")  # nosec B106 — intentional test fixture; real client is monkeypatched
 
         parts = [p async for p in backend.stream([], model="claude-haiku-4-5")]
         assert parts == ["part-1", "part-2"]


### PR DESCRIPTION
## Summary

- Investigated all secret-like assignments flagged by issue #222 in `tests/unit/test_api.py` and `tests/unit/test_backend_claude.py`
- **All 7 flagged patterns are false positives** — intentional test fixtures, not real credentials
- Added inline `# nosec` comments to each flagged line to document the intent for static scanners and future reviewers

## Flagged patterns and verdicts

| File | Line | Pattern | Verdict |
|------|------|---------|---------|
| `test_api.py` | 41 | `auth_token="secret-abc"` | False positive — test fixture token passed to `create_app()` |
| `test_api.py` | 158 | `"Bearer secret-abc"` | False positive — matches the above fixture token |
| `test_api.py` | 364 | `"Bearer secret-abc"` | False positive — matches the above fixture token |
| `test_backend_claude.py` | 21 | `"ANTHROPIC_API_KEY", "sk-ant-test"` | False positive — `monkeypatch.setenv`, never leaves test process |
| `test_backend_claude.py` | 31 | `api_key="sk-test-explicit"` | False positive — obviously fake key, no real API call |
| `test_backend_claude.py` | 153 | `api_key="x"` | False positive — single-char placeholder, real client is monkeypatched |
| `test_backend_claude.py` | 185 | `api_key="x"` | False positive — same as above |

## Bandit config already excludes tests/

`pyproject.toml` already has `[tool.bandit]` with `exclude_dirs = ["tests", "docs"]`. The inline `# nosec` comments add a second layer of documentation at the point of use.

## Test plan

- [x] `python3 -m ruff check .` — passes
- [x] `python3 -m ruff format --check .` — passes
- [x] `python3 -m pytest tests/unit/test_api.py tests/unit/test_backend_claude.py -q --no-header --no-cov` — 38 passed
- [ ] Full unit suite + coverage floor (CI will verify)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)