### PR TITLE
fix(auth): replace bare assert with require() in GitHubAuth

### DIFF
--- a/maxwell_daemon/github_auth.py
+++ b/maxwell_daemon/github_auth.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from maxwell_daemon.contracts import require
+
 
 @dataclass
 class _AppTokenCache:
@@ -162,7 +164,7 @@ class GitHubAuth:
         except ImportError as exc:
             raise ImportError("httpx is required for GitHub App auth.") from exc
 
-        assert self._private_key_pem is not None, "private_key_pem must be set for App auth"
+        require(self._private_key_pem is not None, "private_key_pem must be set for App auth")
         now = int(time.time())
         payload = {"iat": now - 60, "exp": now + 600, "iss": str(self._app_id)}
         if self._private_key_pem is None:
@@ -206,7 +208,7 @@ class GitHubAuth:
 
         now = int(time.time())
         payload = {"iat": now - 60, "exp": now + 600, "iss": str(self._app_id)}
-        assert self._private_key_pem is not None
+        require(self._private_key_pem is not None, "private_key_pem must be set for App auth")
         jwt_token = _jwt.encode(payload, self._private_key_pem, algorithm="RS256")
 
         async with _httpx.AsyncClient(timeout=15) as client:


### PR DESCRIPTION
## Summary

- Replaces two bare `assert self._private_key_pem is not None` calls in `github_auth.py` with `require()` from `maxwell_daemon.contracts`
- Bare `assert` statements are compiled away under `python -O` / `PYTHONOPTIMIZE=1`, silently removing runtime invariant checks in optimised deployments
- The `require()` function raises `PreconditionError` regardless of optimization flags

## Test plan

- [ ] Existing `test_github_auth.py` tests verify the error path
- [ ] CI lint, typecheck, and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)