### PR TITLE
refactor: reduce deep object traversal chains (#223)

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -614,7 +614,7 @@ def create_app(
 
         # In coordinator mode, include per-machine health summary from the fleet config.
         machines_summary: list[dict[str, Any]] = []
-        if daemon._config.role == "coordinator" and daemon._config.fleet.machines:
+        if daemon._config.role == "coordinator" and daemon._config.fleet_machines:
             from maxwell_daemon.fleet.client import RemoteDaemonClient
             from maxwell_daemon.fleet.dispatcher import MachineState
 
@@ -626,9 +626,9 @@ def create_app(
                     capacity=m.capacity,
                     tags=tuple(m.tags),
                 )
-                for m in daemon._config.fleet.machines
+                for m in daemon._config.fleet_machines
             )
-            fleet_client = RemoteDaemonClient(auth_token=daemon._config.api.auth_token)
+            fleet_client = RemoteDaemonClient(auth_token=daemon._config.api_auth_token)
             try:
                 probed = await fleet_client.refresh_all(initial)
             except Exception:
@@ -793,11 +793,7 @@ def create_app(
         signature = request.headers.get("x-hub-signature-256", "")
         event_type = request.headers.get("x-github-event", "")
 
-        config_secret = (
-            daemon._config.github.webhook_secret.get_secret_value()
-            if daemon._config.github.webhook_secret is not None
-            else None
-        )
+        config_secret = daemon._config.github_webhook_secret_value()
         if config_secret is None:
             return JSONResponse(
                 {"detail": "webhooks disabled", "disabled": True},
@@ -825,12 +821,12 @@ def create_app(
                 label=r.label,
                 trigger=r.trigger,
             )
-            for r in daemon._config.github.routes
+            for r in daemon._config.github_routes
         ]
         router = WebhookRouter(
             WebhookConfig(
                 secret=config_secret,
-                allowed_repos=daemon._config.github.allowed_repos,
+                allowed_repos=daemon._config.github_allowed_repos,
                 routes=routes,
             ),
             daemon=daemon,

--- a/maxwell_daemon/backends/claude.py
+++ b/maxwell_daemon/backends/claude.py
@@ -90,14 +90,18 @@ class ClaudeBackend(ILLMBackend):
         text_parts = [
             getattr(b, "text", "") for b in resp.content if getattr(b, "type", None) == "text"
         ]
+        # Extract usage fields once to avoid repeating the resp.usage chain.
+        usage = resp.usage
+        input_tokens = usage.input_tokens
+        output_tokens = usage.output_tokens
         return BackendResponse(
             content="".join(text_parts),
             finish_reason=resp.stop_reason or "stop",
             usage=TokenUsage(
-                prompt_tokens=resp.usage.input_tokens,
-                completion_tokens=resp.usage.output_tokens,
-                total_tokens=resp.usage.input_tokens + resp.usage.output_tokens,
-                cached_tokens=getattr(resp.usage, "cache_read_input_tokens", 0) or 0,
+                prompt_tokens=input_tokens,
+                completion_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+                cached_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
             ),
             model=resp.model,
             backend=self.name,

--- a/maxwell_daemon/cli/main.py
+++ b/maxwell_daemon/cli/main.py
@@ -125,7 +125,7 @@ def status(
             rt.add_row(r.name, str(r.path), str(r.slots), r.backend or "(default)")
         console.print(rt)
 
-    console.print(f"\nDefault backend: [bold]{cfg.agent.default_backend}[/bold]")
+    console.print(f"\nDefault backend: [bold]{cfg.default_backend_name}[/bold]")
     console.print(f"Available adapters: {', '.join(registry.available())}")
 
 
@@ -319,7 +319,7 @@ def serve(
     asyncio.run(_boot())
 
     try:
-        fastapi_app = create_app(daemon, auth_token=cfg.api.auth_token)
+        fastapi_app = create_app(daemon, auth_token=cfg.api_auth_token)
         console.print(f"[green]✓[/green] Maxwell-Daemon serving on http://{host}:{port}")
         uvicorn.run(fastapi_app, host=host, port=port, log_level="info")
     finally:

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -238,3 +238,48 @@ class MaxwellDaemonConfig(BaseModel):
                 f"default_backend '{name}' not found in backends: {sorted(self.backends)}"
             )
         return self.backends[name]
+
+    # ── Config boundary accessors (Law of Demeter) ────────────────────────────
+    # Callers should prefer these over traversing sub-objects directly so that
+    # internal config layout changes don't ripple through all consumers.
+
+    @property
+    def default_backend_name(self) -> str:
+        """Shortcut for ``agent.default_backend``."""
+        return self.agent.default_backend
+
+    @property
+    def api_auth_token(self) -> str | None:
+        """Shortcut for ``api.auth_token``."""
+        return self.api.auth_token
+
+    @property
+    def fleet_coordinator_poll_seconds(self) -> int:
+        """Shortcut for ``fleet.coordinator_poll_seconds``."""
+        return self.fleet.coordinator_poll_seconds
+
+    @property
+    def fleet_heartbeat_seconds(self) -> int:
+        """Shortcut for ``fleet.heartbeat_seconds``."""
+        return self.fleet.heartbeat_seconds
+
+    @property
+    def fleet_machines(self) -> list[MachineConfig]:
+        """Shortcut for ``fleet.machines``."""
+        return self.fleet.machines
+
+    @property
+    def github_routes(self) -> list[WebhookRouteConfig]:
+        """Shortcut for ``github.routes``."""
+        return self.github.routes
+
+    @property
+    def github_allowed_repos(self) -> list[str]:
+        """Shortcut for ``github.allowed_repos``."""
+        return self.github.allowed_repos
+
+    def github_webhook_secret_value(self) -> str | None:
+        """Return the raw webhook secret string, or None if unset."""
+        if self.github.webhook_secret is None:
+            return None
+        return self.github.webhook_secret.get_secret_value()

--- a/maxwell_daemon/core/router.py
+++ b/maxwell_daemon/core/router.py
@@ -67,7 +67,7 @@ class BackendRouter:
         budget_percent: float | None = None,
     ) -> RouteDecision:
         chosen, reason = self._choose_name(repo, backend_override, budget_percent)
-        cfg = self._config.backends[chosen]
+        cfg = self._all_backend_configs()[chosen]
         if not cfg.enabled:
             raise RuntimeError(f"Backend '{chosen}' is disabled in config")
 
@@ -91,7 +91,7 @@ class BackendRouter:
         budget_percent: float | None = None,
     ) -> tuple[str, str]:
         if override:
-            if override not in self._config.backends:
+            if override not in self._all_backend_configs():
                 raise ValueError(f"Unknown backend override: {override}")
             return override, f"explicit override: {override}"
 
@@ -103,7 +103,7 @@ class BackendRouter:
                     candidate, f"repo override for {repo}", budget_percent
                 )
 
-        candidate = self._config.agent.default_backend
+        candidate = self._default_backend_name()
         return self._apply_budget_fallback(candidate, "global default", budget_percent)
 
     def _apply_budget_fallback(
@@ -116,7 +116,7 @@ class BackendRouter:
         if budget_percent is None:
             return candidate, reason
 
-        cfg = self._config.backends.get(candidate)
+        cfg = self._backend_config(candidate)
         if cfg is None:
             return candidate, reason
 
@@ -131,7 +131,23 @@ class BackendRouter:
         return candidate, reason
 
     def available_backends(self) -> list[str]:
-        return [name for name, cfg in self._config.backends.items() if cfg.enabled]
+        return [name for name, cfg in self._all_backend_configs().items() if cfg.enabled]
+
+    # ── Config boundary accessors ─────────────────────────────────────────────
+    # These methods prevent callers from traversing the config object graph
+    # directly (Law of Demeter).  All config-graph traversal is centralised here.
+
+    def _default_backend_name(self) -> str:
+        """Return the configured default backend name."""
+        return self._config.agent.default_backend
+
+    def _backend_config(self, name: str) -> BackendConfig | None:
+        """Return the BackendConfig for *name*, or None if unknown."""
+        return self._config.backends.get(name)
+
+    def _all_backend_configs(self) -> dict[str, BackendConfig]:
+        """Return all backend configs keyed by name."""
+        return self._config.backends
 
     async def aclose_all(self) -> None:
         """Close all instantiated backends."""

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -552,7 +552,7 @@ class Daemon:
 
     async def _coordinator_loop(self) -> None:
         """Periodically flush QUEUED tasks to remote workers via FleetDispatcher."""
-        poll_seconds = self._config.fleet.coordinator_poll_seconds
+        poll_seconds = self._config.fleet_coordinator_poll_seconds
         while self._running:
             try:
                 await self._dispatch_to_fleet()
@@ -565,8 +565,8 @@ class Daemon:
         from maxwell_daemon.fleet.client import RemoteDaemonClient, RemoteDaemonError
         from maxwell_daemon.fleet.dispatcher import FleetDispatcher, MachineState, TaskRequirement
 
-        fleet_cfg = self._config.fleet
-        if not fleet_cfg.machines:
+        fleet_machines = self._config.fleet_machines
+        if not fleet_machines:
             return
 
         # Build initial MachineState snapshots from config.
@@ -578,11 +578,11 @@ class Daemon:
                 capacity=m.capacity,
                 tags=tuple(m.tags),
             )
-            for m in fleet_cfg.machines
+            for m in fleet_machines
         )
 
         client = RemoteDaemonClient(
-            auth_token=self._config.api.auth_token,
+            auth_token=self._config.api_auth_token,
         )
 
         # Probe all machines in parallel to get live health.
@@ -590,7 +590,7 @@ class Daemon:
 
         # Requeue tasks dispatched to machines that have gone offline.
         now = datetime.now(timezone.utc)
-        stale_threshold = fleet_cfg.heartbeat_seconds * 3
+        stale_threshold = self._config.fleet_heartbeat_seconds * 3
         with self._tasks_lock:
             tasks_snapshot = dict(self._tasks)
 
@@ -895,7 +895,7 @@ class Daemon:
         # backend has a tier_map, pick by issue complexity. Otherwise fall back
         # to whatever the router resolved.
         effective_model = decision.model
-        backend_cfg = self._config.backends.get(decision.backend_name)
+        backend_cfg = self._router._backend_config(decision.backend_name)
         if not task.model and backend_cfg is not None and backend_cfg.tier_map:
             from maxwell_daemon.core.model_selector import pick_model_for_issue
 


### PR DESCRIPTION
## Summary

Addresses Law of Demeter violations flagged in issue #223. Deep member-chain traversals that were repeated 2+ times have been replaced with boundary accessor methods or local variables.

**Hotspots addressed:**

- **`backends/claude.py`**: `resp.usage.input_tokens` and `.output_tokens` were repeated 3× in the `TokenUsage` constructor. Extracted to `usage`, `input_tokens`, `output_tokens` locals.
- **`config/models.py`**: Added `@property` shortcuts (`api_auth_token`, `fleet_coordinator_poll_seconds`, `fleet_heartbeat_seconds`, `fleet_machines`, `github_routes`, `github_allowed_repos`) and a `github_webhook_secret_value()` method to prevent callers from traversing the sub-object graph directly.
- **`core/router.py`**: Added `_default_backend_name()`, `_backend_config()`, and `_all_backend_configs()` boundary accessors. All internal routing code now uses these instead of `self._config.agent.default_backend` / `self._config.backends.*` directly.
- **`daemon/runner.py`**: Replaced `self._config.fleet.coordinator_poll_seconds`, `self._config.fleet.machines`, `self._config.fleet.heartbeat_seconds`, and `self._config.api.auth_token` with the new config accessors. Backend config lookup now goes through `self._router._backend_config()`.
- **`api/server.py`**: Replaced `daemon._config.fleet.machines`, `daemon._config.api.auth_token`, `daemon._config.github.webhook_secret.get_secret_value()`, `daemon._config.github.routes`, and `daemon._config.github.allowed_repos` with the new config accessors.
- **`cli/main.py`**: `cfg.agent.default_backend` → `cfg.default_backend_name`; `cfg.api.auth_token` → `cfg.api_auth_token`.

**Acceptable traversals left in place:**
- `openai.py`: `resp.choices[0]` and `resp.usage` are already extracted to named locals (`choice`, `usage`) — no further extraction needed.
- `core/ledger.py`: `rec.usage.*` accesses are in the storage layer where the `CostRecord` DTO is the boundary — this is intentional.
- `gh/workspace.py`: no deep traversals present; paths are computed from simple string/Path operations.

## Test plan

- [x] `python3 -m ruff check .` — passes
- [x] `python3 -m ruff format --check .` — passes
- [x] `python3 -m pytest tests/unit/ -q --no-header --no-cov` — 1502 passed
- [x] `python3 scripts/check_coverage_floor.py` — 91.75% ≥ 91.26% floor

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)