### PR TITLE
fix(audit): validate prev_hash on first chain entry (#233)

### DIFF
--- a/maxwell_daemon/audit.py
+++ b/maxwell_daemon/audit.py
@@ -362,7 +362,7 @@ def verify_chain(path: Path) -> list[dict[str, Any]]:
             expected_hash = hashlib.sha256(payload.encode()).hexdigest()
             if stored_hash != expected_hash:
                 violations.append({"line": lineno, "error": "entry_hash mismatch", "entry": obj})
-            if stored_prev != prev_hash and lineno > 1:
+            if stored_prev != prev_hash:
                 violations.append(
                     {
                         "line": lineno,

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -204,6 +204,19 @@ class TestVerifyChain:
         violations = verify_chain(log_path)
         assert any("chain broken" in v["error"] for v in violations)
 
+    def test_tampered_first_entry_prev_hash_detected(
+        self, logger: AuditLogger, log_path: Path
+    ) -> None:
+        """Issue #233: verify_chain must flag a non-genesis prev_hash on line 1."""
+        logger.log_api_call(method="GET", path="/a", status=200)
+        lines = log_path.read_text().splitlines()
+        obj = json.loads(lines[0])
+        obj["prev_hash"] = "a" * 64  # tamper: replace genesis sentinel
+        lines[0] = json.dumps(obj)
+        log_path.write_text("\n".join(lines) + "\n")
+        violations = verify_chain(log_path)
+        assert any(v["line"] == 1 and "chain broken" in v["error"] for v in violations)
+
 
 class TestAuditApiEndpoints:
     """Integration tests for /api/v1/audit and /api/v1/audit/verify."""


### PR DESCRIPTION
## Summary

- `verify_chain` skipped the chain-link check for the first log entry due to a `lineno > 1` guard, allowing a tampered `prev_hash` sentinel to go undetected on line 1.
- Removing that guard means the genesis hash (`"0" * 64`) is now enforced on the very first entry, closing the tamper window.
- Adds a regression test that writes a non-genesis `prev_hash` on line 1 and asserts a violation is reported.

Closes #233. Related to PR #130.

## Test plan
- [ ] `tests/unit/test_audit.py::TestVerifyChain::test_tampered_first_entry_prev_hash_detected` — new test that would have failed before this fix
- [ ] Existing `TestVerifyChain` tests continue to pass
- [ ] `verify_chain` on a clean log still returns `[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)