### PR TITLE
fix: emit YAML config, wire JWTConfig, and 503 on missing asyncssh

### DIFF
--- a/deploy/ansible/roles/maxwell_daemon/templates/config.toml.j2
+++ b/deploy/ansible/roles/maxwell_daemon/templates/config.toml.j2
@@ -1,29 +1,32 @@
 # maxwell-daemon configuration — managed by Ansible, do not edit by hand.
+# Rendered as YAML; loaded by maxwell-daemon serve --config via yaml.safe_load.
 
-[server]
-host = "127.0.0.1"
-port = {{ conductor_port }}
+version: "1"
+
+api:
+  host: "127.0.0.1"
+  port: {{ conductor_port }}
 {% if conductor_tls_cert %}
-tls_cert = "{{ conductor_tls_cert }}"
-tls_key  = "{{ conductor_tls_key }}"
+  tls_cert: "{{ conductor_tls_cert }}"
+  tls_key: "{{ conductor_tls_key }}"
+{% endif %}
+{% if conductor_jwt_secret %}
+  jwt_secret: "{{ conductor_jwt_secret }}"
 {% endif %}
 
-[auth]
-jwt_secret = "{{ conductor_jwt_secret }}"
+agent:
+  default_backend: "{{ conductor_backend }}"
 
-[storage]
-data_dir = "{{ conductor_data_dir }}"
-log_dir  = "{{ conductor_log_dir }}"
-
-[backends]
-default = "{{ conductor_backend }}"
-
+backends:
 {% if conductor_anthropic_api_key %}
-[backends.anthropic]
-api_key = "{{ conductor_anthropic_api_key }}"
+  anthropic:
+    type: claude
+    model: claude-sonnet-4-6
+    api_key: "{{ conductor_anthropic_api_key }}"
 {% endif %}
-
 {% if conductor_openai_api_key %}
-[backends.openai]
-api_key = "{{ conductor_openai_api_key }}"
+  openai:
+    type: openai
+    model: gpt-4o
+    api_key: "{{ conductor_openai_api_key }}"
 {% endif %}

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -159,6 +159,21 @@ class CostSummary(BaseModel):
     by_backend: dict[str, float]
 
 
+class SSHConnectRequest(BaseModel):
+    host: str
+    port: int = 22
+    user: str
+    password: str | None = None
+
+
+class SSHRunRequest(BaseModel):
+    host: str
+    port: int = 22
+    user: str
+    command: str
+    timeout_seconds: float = 30.0
+
+
 def _auth_dep(token: str | None) -> Any:
     async def _check(authorization: Annotated[str | None, Header()] = None) -> None:
         if token is None:
@@ -932,12 +947,6 @@ def create_app(
         SSHKeyStore().remove(machine)
         return {"machine": machine, "deleted": True}
 
-    class SSHConnectRequest(BaseModel):
-        host: str
-        port: int = 22
-        user: str
-        password: str | None = None
-
     @app.post("/api/v1/ssh/connect", dependencies=[Depends(auth), Depends(_require_admin())])
     async def ssh_connect(payload: SSHConnectRequest) -> Any:
         """Open (or reuse) an SSH session and return its summary."""
@@ -956,13 +965,6 @@ def create_app(
             "user": payload.user,
             "age_seconds": round(session.age_seconds, 1),
         }
-
-    class SSHRunRequest(BaseModel):
-        host: str
-        port: int = 22
-        user: str
-        command: str
-        timeout_seconds: float = 30.0
 
     @app.post("/api/v1/ssh/run", dependencies=[Depends(auth), Depends(_require_admin())])
     async def ssh_run(payload: SSHRunRequest) -> Any:

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -876,11 +876,13 @@ def create_app(
     def _ssh_pool() -> Any:
         if "pool" not in _ssh_pool_ref:
             try:
+                import asyncssh as _asyncssh  # noqa: F401 — presence check only
+
                 from maxwell_daemon.ssh.session import SSHSessionPool
 
                 _ssh_pool_ref["pool"] = SSHSessionPool()
             except ImportError:
-                return None
+                _ssh_pool_ref["pool"] = None
         return _ssh_pool_ref.get("pool")
 
     def _ssh_unavailable() -> Any:

--- a/maxwell_daemon/cli/main.py
+++ b/maxwell_daemon/cli/main.py
@@ -319,7 +319,13 @@ def serve(
     asyncio.run(_boot())
 
     try:
-        fastapi_app = create_app(daemon, auth_token=cfg.api.auth_token)
+        from maxwell_daemon.auth import JWTConfig
+
+        jwt_config: JWTConfig | None = None
+        if cfg.api.jwt_secret is not None:
+            jwt_config = JWTConfig(cfg.api.jwt_secret.get_secret_value())
+
+        fastapi_app = create_app(daemon, auth_token=cfg.api.auth_token, jwt_config=jwt_config)
         console.print(f"[green]✓[/green] Maxwell-Daemon serving on http://{host}:{port}")
         uvicorn.run(fastapi_app, host=host, port=port, log_level="info")
     finally:

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -184,7 +184,7 @@ class APIConfig(BaseModel):
         description="HMAC-SHA256 secret for JWT token issuance and validation. "
         "When set, /api/v1/auth/token becomes usable. "
         "Supports ${ENV_VAR} substitution. "
-        "Generate with: python -c \"import secrets; print(secrets.token_hex(32))\"",
+        'Generate with: python -c "import secrets; print(secrets.token_hex(32))"',
     )
     tls_cert: Path | None = None
     tls_key: Path | None = None

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -179,6 +179,13 @@ class APIConfig(BaseModel):
     host: str = "127.0.0.1"
     port: int = Field(8080, ge=1, le=65535)
     auth_token: str | None = None
+    jwt_secret: SecretStr | None = Field(
+        None,
+        description="HMAC-SHA256 secret for JWT token issuance and validation. "
+        "When set, /api/v1/auth/token becomes usable. "
+        "Supports ${ENV_VAR} substitution. "
+        "Generate with: python -c \"import secrets; print(secrets.token_hex(32))\"",
+    )
     tls_cert: Path | None = None
     tls_key: Path | None = None
     # Rate limiting. Absent = disabled entirely.

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -416,29 +416,23 @@ class TestSSHEndpointsWithoutAsyncSSH:
     the None sentinel is set correctly and the 503 guard fires.
     """
 
-    def test_ssh_sessions_returns_503_when_asyncssh_absent(
-        self, daemon: Daemon
-    ) -> None:
+    def test_ssh_sessions_returns_503_when_asyncssh_absent(self, daemon: Daemon) -> None:
         import sys
         from unittest.mock import patch
 
         # Simulate asyncssh being absent by making it unimportable.
-        with patch.dict(sys.modules, {"asyncssh": None}):
-            with TestClient(create_app(daemon)) as c:
-                r = c.get("/api/v1/ssh/sessions")
+        with patch.dict(sys.modules, {"asyncssh": None}), TestClient(create_app(daemon)) as c:
+            r = c.get("/api/v1/ssh/sessions")
         assert r.status_code == 503
         assert "SSH support not installed" in r.json()["detail"]
 
-    def test_ssh_connect_returns_503_when_asyncssh_absent(
-        self, daemon: Daemon
-    ) -> None:
+    def test_ssh_connect_returns_503_when_asyncssh_absent(self, daemon: Daemon) -> None:
         import sys
         from unittest.mock import patch
 
-        with patch.dict(sys.modules, {"asyncssh": None}):
-            with TestClient(create_app(daemon)) as c:
-                r = c.post(
-                    "/api/v1/ssh/connect",
-                    json={"host": "srv", "user": "ubuntu"},
-                )
+        with patch.dict(sys.modules, {"asyncssh": None}), TestClient(create_app(daemon)) as c:
+            r = c.post(
+                "/api/v1/ssh/connect",
+                json={"host": "srv", "user": "ubuntu"},
+            )
         assert r.status_code == 503

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -405,3 +405,40 @@ class TestAuth:
             headers={"Authorization": "Bearer secret-abc"},  # nosec B106 — test fixture token matching auth_client fixture
         )
         assert r.status_code == 200
+
+
+class TestSSHEndpointsWithoutAsyncSSH:
+    """Issue #231 — SSH endpoints must return 503 when asyncssh is absent.
+
+    The old guard only caught ImportError from importing SSHSessionPool, but
+    maxwell_daemon.ssh.session imports successfully regardless of asyncssh.
+    The fix adds an explicit ``import asyncssh`` check inside _ssh_pool() so
+    the None sentinel is set correctly and the 503 guard fires.
+    """
+
+    def test_ssh_sessions_returns_503_when_asyncssh_absent(
+        self, daemon: Daemon
+    ) -> None:
+        import sys
+        from unittest.mock import patch
+
+        # Simulate asyncssh being absent by making it unimportable.
+        with patch.dict(sys.modules, {"asyncssh": None}):
+            with TestClient(create_app(daemon)) as c:
+                r = c.get("/api/v1/ssh/sessions")
+        assert r.status_code == 503
+        assert "SSH support not installed" in r.json()["detail"]
+
+    def test_ssh_connect_returns_503_when_asyncssh_absent(
+        self, daemon: Daemon
+    ) -> None:
+        import sys
+        from unittest.mock import patch
+
+        with patch.dict(sys.modules, {"asyncssh": None}):
+            with TestClient(create_app(daemon)) as c:
+                r = c.post(
+                    "/api/v1/ssh/connect",
+                    json={"host": "srv", "user": "ubuntu"},
+                )
+        assert r.status_code == 503

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -114,6 +114,52 @@ class TestConfigLoad:
             )
 
 
+class TestAPIConfigJWTSecret:
+    """Issue #230 — jwt_secret field on APIConfig / MaxwellDaemonConfig."""
+
+    def test_jwt_secret_defaults_to_none(self) -> None:
+        cfg = MaxwellDaemonConfig.model_validate(
+            {"backends": {"claude": {"type": "claude", "model": "claude-sonnet-4-6"}}}
+        )
+        assert cfg.api.jwt_secret is None
+
+    def test_jwt_secret_accepted_as_string(self) -> None:
+        cfg = MaxwellDaemonConfig.model_validate(
+            {
+                "backends": {"claude": {"type": "claude", "model": "claude-sonnet-4-6"}},
+                "api": {"jwt_secret": "my-secret-value"},
+            }
+        )
+        assert cfg.api.jwt_secret is not None
+        assert cfg.api.jwt_secret.get_secret_value() == "my-secret-value"
+
+    def test_jwt_secret_is_secret_str(self) -> None:
+        """Ensure the value doesn't leak via repr or str."""
+        cfg = MaxwellDaemonConfig.model_validate(
+            {
+                "backends": {"claude": {"type": "claude", "model": "claude-sonnet-4-6"}},
+                "api": {"jwt_secret": "super-secret-key"},
+            }
+        )
+        assert "super-secret-key" not in repr(cfg.api)
+        assert "super-secret-key" not in str(cfg.api)
+
+    def test_jwt_secret_loaded_from_yaml(self, tmp_path: Path) -> None:
+        """jwt_secret is read correctly from YAML written directly (Ansible/hand-edit path)."""
+        path = tmp_path / "maxwell-daemon.yaml"
+        path.write_text(
+            "backends:\n"
+            "  claude:\n"
+            "    type: claude\n"
+            "    model: claude-sonnet-4-6\n"
+            "api:\n"
+            "  jwt_secret: roundtrip-secret\n"
+        )
+        loaded = load_config(path)
+        assert loaded.api.jwt_secret is not None
+        assert loaded.api.jwt_secret.get_secret_value() == "roundtrip-secret"
+
+
 class TestDefaultConfigPath:
     def test_maxwell_config_env_overrides_default(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

- **#228 (P0)**: Converts `deploy/ansible/roles/maxwell_daemon/templates/config.toml.j2` from TOML section syntax to valid YAML. The `maxwell-daemon serve --config` command loads its config file via `yaml.safe_load`; a TOML file caused immediate parse failure and systemd service exit on startup.
- **#230 (P1)**: Adds `api.jwt_secret` (`SecretStr`) field to `APIConfig` in `models.py` and wires a `JWTConfig` instance into `create_app` in `cli/main.py`. Previously `create_app` was always called without `jwt_config`, making `/api/v1/auth/token` return 503 unconditionally in production.
- **#231 (P1)**: Fixes `_ssh_pool()` in `server.py` to probe `import asyncssh` explicitly before constructing `SSHSessionPool`. `maxwell_daemon.ssh.session` imports successfully even when `asyncssh` is absent (imports are lazy), so the old bare `except ImportError` guard never fired — leaving SSH endpoints to return 500 instead of the intended 503. Also caches the `None` sentinel so the absent-check runs only once per process.

## Test plan

- [ ] `tests/unit/test_config.py::TestAPIConfigJWTSecret` — four new tests covering `jwt_secret` default, acceptance, secret masking (`SecretStr`), and YAML load path
- [ ] `tests/unit/test_api.py::TestSSHEndpointsWithoutAsyncSSH` — two new tests patching `asyncssh` out of `sys.modules` and asserting `/api/v1/ssh/sessions` and `/api/v1/ssh/connect` both return 503
- [ ] Existing test suites (`test_config.py`, `test_api.py`, `test_rbac.py`, `test_ssh.py`) should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)