### PR TITLE
fix(ansible): define conductor_venv default in standalone upgrade playbook

### DIFF
--- a/deploy/ansible/upgrade-conductor.yml
+++ b/deploy/ansible/upgrade-conductor.yml
@@ -7,6 +7,21 @@
 # Usage:
 #   ansible-playbook -i inventory/fleet.yml upgrade-conductor.yml \
 #     -e conductor_version=0.2.0
+#
+# Variables (may be set in inventory or on the command line):
+#   conductor_venv     (default: /opt/maxwell-daemon/venv)
+#   conductor_version  (default: latest)
+#   conductor_port     (default: 8080)
+
+- name: Set standalone upgrade defaults
+  hosts: conductor_agents:conductor_primary
+  gather_facts: false
+  tasks:
+    - name: Set default variables for standalone playbook runs
+      ansible.builtin.set_fact:
+        conductor_venv: "{{ conductor_venv | default('/opt/maxwell-daemon/venv') }}"
+        conductor_version: "{{ conductor_version | default('latest') }}"
+        conductor_port: "{{ conductor_port | default(8080) }}"
 
 - name: Rolling upgrade — agent nodes
   hosts: conductor_agents


### PR DESCRIPTION
## Summary

- Fixes #229: `upgrade-conductor.yml` referenced `conductor_venv` but had no default defined anywhere in the standalone playbook
- Adds a `Set standalone upgrade defaults` play at the top that provides fallbacks for `conductor_venv` (`/opt/maxwell-daemon/venv`), `conductor_version` (`latest`), and `conductor_port` (`8080`)
- Closes #229

Note: #236 was already resolved in PR #127 (changed `already_dispatched or set()` → `already_dispatched if already_dispatched is not None else set()`).

## Test plan

- [ ] Ansible playbook syntax check passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)