### PR TITLE
fix: emit YAML config, wire JWTConfig, and 503 on SSH when asyncssh absent (#228 #230 #231)

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -159,6 +159,21 @@ class CostSummary(BaseModel):
     by_backend: dict[str, float]
 
 
+class SSHConnectRequest(BaseModel):
+    host: str
+    port: int = 22
+    user: str
+    password: str | None = None
+
+
+class SSHRunRequest(BaseModel):
+    host: str
+    port: int = 22
+    user: str
+    command: str
+    timeout_seconds: float = 30.0
+
+
 def _auth_dep(token: str | None) -> Any:
     async def _check(authorization: Annotated[str | None, Header()] = None) -> None:
         if token is None:
@@ -880,11 +895,13 @@ def create_app(
     def _ssh_pool() -> Any:
         if "pool" not in _ssh_pool_ref:
             try:
+                import asyncssh as _asyncssh  # noqa: F401 — presence check only
+
                 from maxwell_daemon.ssh.session import SSHSessionPool
 
                 _ssh_pool_ref["pool"] = SSHSessionPool()
             except ImportError:
-                return None
+                _ssh_pool_ref["pool"] = None
         return _ssh_pool_ref.get("pool")
 
     def _ssh_unavailable() -> Any:
@@ -934,12 +951,6 @@ def create_app(
         SSHKeyStore().remove(machine)
         return {"machine": machine, "deleted": True}
 
-    class SSHConnectRequest(BaseModel):
-        host: str
-        port: int = 22
-        user: str
-        password: str | None = None
-
     @app.post("/api/v1/ssh/connect", dependencies=[Depends(auth), Depends(_require_admin())])
     async def ssh_connect(payload: SSHConnectRequest) -> Any:
         """Open (or reuse) an SSH session and return its summary."""
@@ -958,13 +969,6 @@ def create_app(
             "user": payload.user,
             "age_seconds": round(session.age_seconds, 1),
         }
-
-    class SSHRunRequest(BaseModel):
-        host: str
-        port: int = 22
-        user: str
-        command: str
-        timeout_seconds: float = 30.0
 
     @app.post("/api/v1/ssh/run", dependencies=[Depends(auth), Depends(_require_admin())])
     async def ssh_run(payload: SSHRunRequest) -> Any:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -405,3 +405,34 @@ class TestAuth:
             headers={"Authorization": "Bearer secret-abc"},  # nosec B106 — test fixture token matching auth_client fixture
         )
         assert r.status_code == 200
+
+
+class TestSSHEndpointsWithoutAsyncSSH:
+    """Issue #231 — SSH endpoints must return 503 when asyncssh is absent.
+
+    The old guard only caught ImportError from importing SSHSessionPool, but
+    maxwell_daemon.ssh.session imports successfully regardless of asyncssh.
+    The fix adds an explicit ``import asyncssh`` check inside _ssh_pool() so
+    the None sentinel is set correctly and the 503 guard fires.
+    """
+
+    def test_ssh_sessions_returns_503_when_asyncssh_absent(self, daemon: Daemon) -> None:
+        import sys
+        from unittest.mock import patch
+
+        # Simulate asyncssh being absent by making it unimportable.
+        with patch.dict(sys.modules, {"asyncssh": None}), TestClient(create_app(daemon)) as c:
+            r = c.get("/api/v1/ssh/sessions")
+        assert r.status_code == 503
+        assert "SSH support not installed" in r.json()["detail"]
+
+    def test_ssh_connect_returns_503_when_asyncssh_absent(self, daemon: Daemon) -> None:
+        import sys
+        from unittest.mock import patch
+
+        with patch.dict(sys.modules, {"asyncssh": None}), TestClient(create_app(daemon)) as c:
+            r = c.post(
+                "/api/v1/ssh/connect",
+                json={"host": "srv", "user": "ubuntu"},
+            )
+        assert r.status_code == 503


### PR DESCRIPTION
## Summary

- Moves `SSHConnectRequest` and `SSHRunRequest` Pydantic models to module level so FastAPI can resolve type hints under PEP 563 (`from __future__ import annotations`). Previously these were defined inside `create_app()`, causing `NameError` during type resolution and returning 422 instead of 503 when asyncssh was absent.
- Adds an explicit `import asyncssh` probe in `_ssh_pool()` so the `None` sentinel is set when asyncssh is absent (the lazy `SSHSessionPool` import was silently succeeding).
- Stores `None` in `_ssh_pool_ref` after the ImportError so the absence check runs only once per process.
- Tests cover both `/ssh/sessions` and `/ssh/connect` returning 503 when asyncssh is patched out.

Closes #228, #230, #231.

## Test plan
- [ ] `pytest tests/unit/test_api.py::TestSSHEndpointsWithoutAsyncSSH` — both tests pass
- [ ] All other `test_api.py` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)