### PR TITLE
fix: address P1/P2 follow-up issues from PR reviews

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -159,6 +159,21 @@ class CostSummary(BaseModel):
     by_backend: dict[str, float]
 
 
+class SSHConnectRequest(BaseModel):
+    host: str
+    port: int = 22
+    user: str
+    password: str | None = None
+
+
+class SSHRunRequest(BaseModel):
+    host: str
+    port: int = 22
+    user: str
+    command: str
+    timeout_seconds: float = 30.0
+
+
 def _auth_dep(token: str | None) -> Any:
     async def _check(authorization: Annotated[str | None, Header()] = None) -> None:
         if token is None:
@@ -880,11 +895,13 @@ def create_app(
     def _ssh_pool() -> Any:
         if "pool" not in _ssh_pool_ref:
             try:
+                import asyncssh as _asyncssh  # noqa: F401 — presence check only
+
                 from maxwell_daemon.ssh.session import SSHSessionPool
 
                 _ssh_pool_ref["pool"] = SSHSessionPool()
             except ImportError:
-                return None
+                _ssh_pool_ref["pool"] = None
         return _ssh_pool_ref.get("pool")
 
     def _ssh_unavailable() -> Any:
@@ -934,12 +951,6 @@ def create_app(
         SSHKeyStore().remove(machine)
         return {"machine": machine, "deleted": True}
 
-    class SSHConnectRequest(BaseModel):
-        host: str
-        port: int = 22
-        user: str
-        password: str | None = None
-
     @app.post("/api/v1/ssh/connect", dependencies=[Depends(auth), Depends(_require_admin())])
     async def ssh_connect(payload: SSHConnectRequest) -> Any:
         """Open (or reuse) an SSH session and return its summary."""
@@ -958,13 +969,6 @@ def create_app(
             "user": payload.user,
             "age_seconds": round(session.age_seconds, 1),
         }
-
-    class SSHRunRequest(BaseModel):
-        host: str
-        port: int = 22
-        user: str
-        command: str
-        timeout_seconds: float = 30.0
 
     @app.post("/api/v1/ssh/run", dependencies=[Depends(auth), Depends(_require_admin())])
     async def ssh_run(payload: SSHRunRequest) -> Any:

--- a/maxwell_daemon/backends/agent_loop.py
+++ b/maxwell_daemon/backends/agent_loop.py
@@ -300,9 +300,7 @@ class AgentLoopBackend(ILLMBackend):
         ``budget_per_story_usd`` / ``wall_clock_timeout_seconds``.
         """
         effective_model = model or self._default_model
-        workspace_raw = workspace_dir or self._default_workspace
-        if not workspace_raw:
-            raise ValueError("No workspace specified")
+        workspace_raw = workspace_dir or self._default_workspace or os.getcwd()
         effective_workspace = Path(workspace_raw).resolve()
         effective_max_turns = max_turns if max_turns is not None else self._max_turns
 
@@ -474,9 +472,7 @@ class AgentLoopBackend(ILLMBackend):
         user-visible text so the latency difference is unnoticeable.
         """
         effective_model = model or self._default_model
-        workspace_raw = workspace_dir or self._default_workspace
-        if not workspace_raw:
-            raise ValueError("No workspace specified")
+        workspace_raw = workspace_dir or self._default_workspace or os.getcwd()
         effective_workspace = Path(workspace_raw).resolve()
         effective_max_turns = kwargs.pop("max_turns", None)
         if effective_max_turns is None:

--- a/maxwell_daemon/backends/ollama_agent_loop.py
+++ b/maxwell_daemon/backends/ollama_agent_loop.py
@@ -115,9 +115,7 @@ class OllamaAgentLoopBackend(ILLMBackend):
         max_turns: int | None = None,
         **_: Any,
     ) -> BackendResponse:
-        workspace_raw = workspace_dir or self._workspace
-        if not workspace_raw:
-            raise ValueError("No workspace specified")
+        workspace_raw = workspace_dir or self._workspace or os.getcwd()
         effective_workspace = Path(workspace_raw).resolve()
         effective_model = model or self.default_model
         effective_max_turns = max_turns if max_turns is not None else self._max_turns

--- a/maxwell_daemon/cli/spec.py
+++ b/maxwell_daemon/cli/spec.py
@@ -54,7 +54,7 @@ def show_spec(
     """Parse one spec and print its scenarios + steps."""
     try:
         spec = load_feature(feature)
-    except GherkinParseError as e:
+    except (GherkinParseError, FileNotFoundError, IsADirectoryError, PermissionError) as e:
         console.print(f"[red]✗[/red] {e}")
         raise typer.Exit(1) from None
     console.print(f"[bold]Feature:[/bold] {spec.feature}")
@@ -90,7 +90,7 @@ def generate_scaffold(
     """Render a pytest-bdd scaffold for ``feature`` and write it to disk."""
     try:
         spec = load_feature(feature)
-    except GherkinParseError as e:
+    except (GherkinParseError, FileNotFoundError, IsADirectoryError, PermissionError) as e:
         console.print(f"[red]✗[/red] {e}")
         raise typer.Exit(1) from None
 

--- a/maxwell_daemon/director/types.py
+++ b/maxwell_daemon/director/types.py
@@ -79,6 +79,12 @@ class Decomposition:
         _check_unique_ids("epic", tuple(e.id for e in self.epics))
         _check_unique_ids("story", tuple(s.id for s in self.stories))
         _check_unique_ids("task", tuple(t.id for t in self.tasks))
+        all_ids = (
+            tuple(e.id for e in self.epics)
+            + tuple(s.id for s in self.stories)
+            + tuple(t.id for t in self.tasks)
+        )
+        _check_unique_ids("global", all_ids)
 
         epic_ids = {e.id for e in self.epics}
         for s in self.stories:

--- a/maxwell_daemon/memory/embeddings.py
+++ b/maxwell_daemon/memory/embeddings.py
@@ -181,9 +181,17 @@ class OpenAIEmbeddingProvider:
         self._client = http_client
         self._model = model
         self._dimensions_override = dimensions_override
-        # Default dimension for text-embedding-3-small; overridable via
-        # `dimensions_override` (OpenAI supports truncation on this model).
-        self._dim = dimensions_override if dimensions_override is not None else 1536
+        # Derive default dimensions from the selected model so callers that
+        # rely on provider.dimensions get the right value without needing to
+        # set dimensions_override. Falls back to 1536 for unknown models.
+        _model_dims: dict[str, int] = {
+            "text-embedding-3-small": 1536,
+            "text-embedding-3-large": 3072,
+            "text-embedding-ada-002": 1536,
+        }
+        self._dim = (
+            dimensions_override if dimensions_override is not None else _model_dims.get(model, 1536)
+        )
 
     @property
     def dimensions(self) -> int:

--- a/maxwell_daemon/memory/embeddings.py
+++ b/maxwell_daemon/memory/embeddings.py
@@ -142,7 +142,7 @@ class StubEmbeddingProvider:
             text_hash=hash_text(text),
             vector=tuple(components),
             dimensions=self._dim,
-            provider_name=self.name,
+            provider_name=f"{self.name}:{self._dim}",
         )
 
 
@@ -211,7 +211,7 @@ class OpenAIEmbeddingProvider:
                     text_hash=hash_text(text),
                     vector=vector,
                     dimensions=len(vector),
-                    provider_name=self.name,
+                    provider_name=f"{self.name}:{self._model}:{len(vector)}",
                 )
             )
         return tuple(results)

--- a/maxwell_daemon/metrics.py
+++ b/maxwell_daemon/metrics.py
@@ -77,25 +77,28 @@ def record_request(
     model: str,
     status: RequestStatus,
     tokens: int = 0,
-    cost_usd: float = 0.0,
+    cost_usd: float | None = None,
     duration_seconds: float = 0.0,
 ) -> None:
     """Emit all per-request metrics in one call.
 
     Token and cost metrics are only incremented when status == "success" so that
-    failed/rejected requests don't pollute spend dashboards. Zero-cost
-    successes (free-tier Ollama, cached hits) are counted separately via
-    ``MAXWELL_FREE_REQUESTS_TOTAL`` so dashboards can distinguish "never ran"
-    from "ran many free requests".
+    failed/rejected requests don't pollute spend dashboards. ``cost_usd=None``
+    (the default) means cost is unknown — callers that don't have cost data
+    (e.g. issue-executor paths) should omit the argument.  Explicitly passing
+    ``cost_usd=0.0`` signals a genuinely free call (free-tier Ollama, cached
+    hit) and is counted separately via ``MAXWELL_FREE_REQUESTS_TOTAL`` so
+    dashboards can distinguish "unknown cost" from "verified free".
     """
     MAXWELL_REQUESTS_TOTAL.labels(backend=backend, model=model, status=status).inc()
     if status == "success":
         if tokens > 0:
             MAXWELL_TOKENS_TOTAL.labels(backend=backend, model=model).inc(tokens)
-        if cost_usd > 0:
-            MAXWELL_REQUEST_COST.labels(backend=backend, model=model).inc(cost_usd)
-        else:
-            MAXWELL_FREE_REQUESTS_TOTAL.labels(backend=backend, model=model).inc()
+        if cost_usd is not None:
+            if cost_usd > 0:
+                MAXWELL_REQUEST_COST.labels(backend=backend, model=model).inc(cost_usd)
+            else:
+                MAXWELL_FREE_REQUESTS_TOTAL.labels(backend=backend, model=model).inc()
         if duration_seconds > 0:
             MAXWELL_REQUEST_DURATION.labels(backend=backend, model=model).observe(duration_seconds)
 

--- a/maxwell_daemon/rules.py
+++ b/maxwell_daemon/rules.py
@@ -102,8 +102,17 @@ def _parse_rule(path: Path) -> Rule:
     if not isinstance(raw_globs, list):
         raise RuleLoadError(f"{path}: globs must be a list")
     globs = tuple(str(g) for g in raw_globs)
-    always_apply = bool(parsed.get("always_apply", False))
-    priority = int(parsed.get("priority", 0))
+    raw_always_apply = parsed.get("always_apply", False)
+    if not isinstance(raw_always_apply, bool):
+        raise RuleLoadError(
+            f"{path}: always_apply must be a boolean, got {type(raw_always_apply).__name__!r}"
+        )
+    always_apply = raw_always_apply
+    raw_priority = parsed.get("priority", 0)
+    try:
+        priority = int(raw_priority)
+    except (TypeError, ValueError) as exc:
+        raise RuleLoadError(f"{path}: priority must be an integer, got {raw_priority!r}") from exc
 
     body = match.group("body").strip()
     return Rule(

--- a/maxwell_daemon/tools/mcp.py
+++ b/maxwell_daemon/tools/mcp.py
@@ -194,7 +194,13 @@ class ToolRegistry:
         spec = self.get(name)  # raises ToolRegistryError on unknown — caller bug, not model bug
 
         if self._hook_runner is not None:
-            pre = await self._hook_runner.run_pre_tool(name, arguments)
+            try:
+                pre = await self._hook_runner.run_pre_tool(name, arguments)
+            except Exception as exc:
+                return ToolResult(
+                    content=f"pre_tool hook runner error: {type(exc).__name__}: {exc}",
+                    is_error=True,
+                )
             if pre.blocked:
                 return ToolResult(
                     content=(
@@ -212,7 +218,15 @@ class ToolRegistry:
             return ToolResult(content=f"{type(exc).__name__}: {exc}", is_error=True)
 
         if self._hook_runner is not None:
-            post = await self._hook_runner.run_post_tool(name, arguments, tool_output=content)
+            try:
+                post = await self._hook_runner.run_post_tool(name, arguments, tool_output=content)
+            except Exception as exc:
+                return ToolResult(
+                    content=(
+                        f"{content}\n\npost_tool hook runner error: {type(exc).__name__}: {exc}"
+                    ),
+                    is_error=True,
+                )
             if post.errored:
                 return ToolResult(
                     content=(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -405,3 +405,34 @@ class TestAuth:
             headers={"Authorization": "Bearer secret-abc"},  # nosec B106 — test fixture token matching auth_client fixture
         )
         assert r.status_code == 200
+
+
+class TestSSHEndpointsWithoutAsyncSSH:
+    """Issue #231 — SSH endpoints must return 503 when asyncssh is absent.
+
+    The old guard only caught ImportError from importing SSHSessionPool, but
+    maxwell_daemon.ssh.session imports successfully regardless of asyncssh.
+    The fix adds an explicit ``import asyncssh`` check inside _ssh_pool() so
+    the None sentinel is set correctly and the 503 guard fires.
+    """
+
+    def test_ssh_sessions_returns_503_when_asyncssh_absent(self, daemon: Daemon) -> None:
+        import sys
+        from unittest.mock import patch
+
+        # Simulate asyncssh being absent by making it unimportable.
+        with patch.dict(sys.modules, {"asyncssh": None}), TestClient(create_app(daemon)) as c:
+            r = c.get("/api/v1/ssh/sessions")
+        assert r.status_code == 503
+        assert "SSH support not installed" in r.json()["detail"]
+
+    def test_ssh_connect_returns_503_when_asyncssh_absent(self, daemon: Daemon) -> None:
+        import sys
+        from unittest.mock import patch
+
+        with patch.dict(sys.modules, {"asyncssh": None}), TestClient(create_app(daemon)) as c:
+            r = c.post(
+                "/api/v1/ssh/connect",
+                json={"host": "srv", "user": "ubuntu"},
+            )
+        assert r.status_code == 503

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -79,7 +79,7 @@ class TestStubProvider:
     def test_provider_name_stamped(self) -> None:
         provider = StubEmbeddingProvider(dimensions=32)
         out = _run(provider.embed_batch(("x",)))
-        assert out[0].provider_name == "stub"
+        assert out[0].provider_name == "stub:32"
 
 
 # ---------------------------------------------------------------------------
@@ -138,7 +138,7 @@ class TestOpenAIProvider:
         assert isinstance(result, EmbeddingResult)
         assert result.vector == (0.5, 0.5, 0.5)
         assert result.dimensions == 3
-        assert result.provider_name == "openai"
+        assert result.provider_name == "openai:text-embedding-3-small:3"
         assert result.text_hash == hash_text("only")
 
     def test_dimensions_override_forwarded(self) -> None:


### PR DESCRIPTION
## Summary

Batch of 7 fixes from open follow-up issues created by the review automation.

- **#242/#243** — Restore `os.getcwd()` fallback in `agent_loop.py` and `ollama_agent_loop.py`. The strict `ValueError` broke callers in `runner.py`/`gh/executor.py` that don't supply `workspace_dir`.
- **#244** — `record_request()` now uses `cost_usd=None` as default (unknown cost). Only `cost_usd=0.0` increments `MAXWELL_FREE_REQUESTS_TOTAL`. Issue-executor paths no longer mis-count as free.
- **#246** — Embedding cache key now encodes model+dimensions in `provider_name` (e.g. `"stub:64"`, `"openai:text-embedding-3-small:1536"`). Changing config no longer silently reuses stale vectors.
- **#249** — `rules.py` raises `RuleLoadError` for non-bool `always_apply` and non-integer `priority` instead of silently coercing or leaking `ValueError`.
- **#250** — `spec.py` show/generate commands catch `FileNotFoundError`, `IsADirectoryError`, `PermissionError` for user-facing errors instead of bubbling exceptions.
- **#251** — `mcp.py` wraps pre/post hook runner calls in `try/except` so spawn failures return `ToolResult(is_error=True)` instead of crashing the agent loop.

Note: #239 was verified as already resolved (metrics.py still exports `MAXWELL_COST_FORECAST_USD`).

Closes #242, #243, #244, #246, #249, #250, #251.

## Test plan
- [ ] All existing unit tests pass (no regressions)
- [ ] `ruff check` and `ruff format --check` pass on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)