### PR TITLE
 fix: guard free-request counter and fix cost typing across backends

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -368,13 +368,19 @@ def create_app(
         return TokenResponse(access_token=token, expires_in=ttl, role=role.value)
 
     @app.get("/api/v1/auth/me")
-    async def whoami(authorization: Annotated[str | None, Header()] = None) -> dict[str, Any]:
+    async def whoami(
+        authorization: Annotated[str | None, Header()] = None,
+    ) -> dict[str, Any]:
         """Decode and return the caller's JWT claims (or static-token identity)."""
         if jwt_config is not None and authorization and authorization.startswith("Bearer "):
             raw = authorization.removeprefix("Bearer ").strip()
             try:
                 claims = jwt_config.decode_token(raw)
-                return {"sub": claims.sub, "role": claims.role.value, "exp": claims.exp.isoformat()}
+                return {
+                    "sub": claims.sub,
+                    "role": claims.role.value,
+                    "exp": claims.exp.isoformat(),
+                }
             except Exception:  # nosec B110 — invalid/expired JWT, fall through to token check
                 pass
         if auth_token is not None and authorization:
@@ -447,7 +453,8 @@ def create_app(
         return TaskView.from_task(t)
 
     @app.post(
-        "/api/v1/tasks/{task_id}/cancel", dependencies=[Depends(auth), Depends(_require_operator())]
+        "/api/v1/tasks/{task_id}/cancel",
+        dependencies=[Depends(auth), Depends(_require_operator())],
     )
     async def cancel_task(task_id: str) -> TaskView:
         try:
@@ -597,7 +604,10 @@ def create_app(
         if not machine_name:
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "machine_name required")
         daemon.record_worker_heartbeat(machine_name)
-        return {"machine_name": machine_name, "recorded_at": datetime.now(timezone.utc).isoformat()}
+        return {
+            "machine_name": machine_name,
+            "recorded_at": datetime.now(timezone.utc).isoformat(),
+        }
 
     @app.get("/api/v1/fleet", dependencies=[Depends(_require_viewer())])
     async def fleet_overview() -> dict[str, Any]:
@@ -698,7 +708,7 @@ def create_app(
                 {
                     "name": name,
                     "org": org,
-                    "github_url": f"https://github.com/{org}/{name}" if org and name else None,
+                    "github_url": (f"https://github.com/{org}/{name}" if org and name else None),
                     "slots": r.get("slots", default_slots),
                     "budget_per_story": r.get("budget_per_story", default_budget),
                     "pr_target_branch": r.get("pr_target_branch", default_branch),

--- a/maxwell_daemon/audit.py
+++ b/maxwell_daemon/audit.py
@@ -167,7 +167,12 @@ class AuditLogger:
             status=None,
             user=None,
             request_id=None,
-            details={"operation": operation, "task_id": task_id, "repo": repo, **(details or {})},
+            details={
+                "operation": operation,
+                "task_id": task_id,
+                "repo": repo,
+                **(details or {}),
+            },
         )
 
     def log_config_change(

--- a/maxwell_daemon/auth.py
+++ b/maxwell_daemon/auth.py
@@ -150,7 +150,9 @@ def require_role(minimum: Role, jwt_config: JWTConfig) -> Any:
     """
     from fastapi import Header, HTTPException, status
 
-    async def _dep(authorization: Annotated[str | None, Header()] = None) -> TokenClaims:
+    async def _dep(
+        authorization: Annotated[str | None, Header()] = None,
+    ) -> TokenClaims:
         if authorization is None or not authorization.startswith("Bearer "):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, "JWT bearer token required")
         raw = authorization.removeprefix("Bearer ").strip()

--- a/maxwell_daemon/backends/base.py
+++ b/maxwell_daemon/backends/base.py
@@ -56,8 +56,8 @@ class BackendCapabilities:
     supports_system_prompt: bool = True
     max_context_tokens: int = 8_192
     is_local: bool = False
-    cost_per_1k_input_tokens: float = 0.0
-    cost_per_1k_output_tokens: float = 0.0
+    cost_per_1k_input_tokens: float | None = None
+    cost_per_1k_output_tokens: float | None = None
 
 
 @dataclass(slots=True)
@@ -127,8 +127,10 @@ class ILLMBackend(ABC):
     def capabilities(self, model: str) -> BackendCapabilities:
         """Describe what `model` can do. Used for routing decisions."""
 
-    def estimate_cost(self, usage: TokenUsage, model: str) -> float:
+    def estimate_cost(self, usage: TokenUsage, model: str) -> float | None:
         caps = self.capabilities(model)
+        if caps.cost_per_1k_input_tokens is None or caps.cost_per_1k_output_tokens is None:
+            return 0.0 if caps.is_local else None
         return (
             usage.prompt_tokens * caps.cost_per_1k_input_tokens / 1000
             + usage.completion_tokens * caps.cost_per_1k_output_tokens / 1000

--- a/maxwell_daemon/backends/claude_code.py
+++ b/maxwell_daemon/backends/claude_code.py
@@ -156,8 +156,8 @@ class ClaudeCodeCLIBackend(ILLMBackend):
             is_local=False,
             # No authoritative pricing for the CLI — rely on the user's
             # subscription / API key cost accounting.
-            cost_per_1k_input_tokens=0.0,
-            cost_per_1k_output_tokens=0.0,
+            cost_per_1k_input_tokens=None,
+            cost_per_1k_output_tokens=None,
         )
 
 

--- a/maxwell_daemon/backends/codex_cli.py
+++ b/maxwell_daemon/backends/codex_cli.py
@@ -150,8 +150,8 @@ class CodexCLIBackend(ILLMBackend):
             is_local=False,
             # Codex rides the user's own OpenAI subscription/API key — no
             # pricing owned by this adapter.
-            cost_per_1k_input_tokens=0.0,
-            cost_per_1k_output_tokens=0.0,
+            cost_per_1k_input_tokens=None,
+            cost_per_1k_output_tokens=None,
         )
 
 

--- a/maxwell_daemon/backends/continue_cli.py
+++ b/maxwell_daemon/backends/continue_cli.py
@@ -141,8 +141,8 @@ class ContinueCLIBackend(ILLMBackend):
             supports_system_prompt=True,
             max_context_tokens=128_000,
             is_local=False,
-            cost_per_1k_input_tokens=0.0,
-            cost_per_1k_output_tokens=0.0,
+            cost_per_1k_input_tokens=None,
+            cost_per_1k_output_tokens=None,
         )
 
 

--- a/maxwell_daemon/cli/spec.py
+++ b/maxwell_daemon/cli/spec.py
@@ -54,7 +54,12 @@ def show_spec(
     """Parse one spec and print its scenarios + steps."""
     try:
         spec = load_feature(feature)
-    except (GherkinParseError, FileNotFoundError, IsADirectoryError, PermissionError) as e:
+    except (
+        GherkinParseError,
+        FileNotFoundError,
+        IsADirectoryError,
+        PermissionError,
+    ) as e:
         console.print(f"[red]✗[/red] {e}")
         raise typer.Exit(1) from None
     console.print(f"[bold]Feature:[/bold] {spec.feature}")
@@ -90,7 +95,12 @@ def generate_scaffold(
     """Render a pytest-bdd scaffold for ``feature`` and write it to disk."""
     try:
         spec = load_feature(feature)
-    except (GherkinParseError, FileNotFoundError, IsADirectoryError, PermissionError) as e:
+    except (
+        GherkinParseError,
+        FileNotFoundError,
+        IsADirectoryError,
+        PermissionError,
+    ) as e:
         console.print(f"[red]✗[/red] {e}")
         raise typer.Exit(1) from None
 

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -9,7 +9,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 
 
 class BackendConfig(BaseModel):

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -559,7 +559,11 @@ class Daemon:
                 worker_id = current + i
                 task = asyncio.create_task(self._worker_loop(worker_id), name=f"worker-{worker_id}")
                 self._workers.append(task)
-                log.info("scaled up: added worker %d (total=%d)", worker_id, len(self._workers))
+                log.info(
+                    "scaled up: added worker %d (total=%d)",
+                    worker_id,
+                    len(self._workers),
+                )
         elif n < current:
             # Send sentinel (priority=-1, task=None) to excess workers so they
             # exit cleanly after finishing their current task.
@@ -616,7 +620,11 @@ class Daemon:
     async def _dispatch_to_fleet(self) -> None:
         """One coordinator dispatch tick: probe machines, plan, submit, requeue stale tasks."""
         from maxwell_daemon.fleet.client import RemoteDaemonClient, RemoteDaemonError
-        from maxwell_daemon.fleet.dispatcher import FleetDispatcher, MachineState, TaskRequirement
+        from maxwell_daemon.fleet.dispatcher import (
+            FleetDispatcher,
+            MachineState,
+            TaskRequirement,
+        )
 
         fleet_machines = self._config.fleet_machines
         if not fleet_machines:
@@ -727,7 +735,9 @@ class Daemon:
                 result = await client.submit_task(machine, task_payload=task_payload)
             except RemoteDaemonError:
                 log.exception(
-                    "failed to dispatch task %s to machine %s", assigned_task.id, machine.name
+                    "failed to dispatch task %s to machine %s",
+                    assigned_task.id,
+                    machine.name,
                 )
                 continue
 
@@ -840,7 +850,8 @@ class Daemon:
                 model=decision.model,
             )
             task.result = resp.content
-            task.cost_usd = decision.backend.estimate_cost(resp.usage, decision.model)
+            estimated_cost = decision.backend.estimate_cost(resp.usage, decision.model)
+            task.cost_usd = estimated_cost if estimated_cost is not None else 0.0
             task.status = TaskStatus.COMPLETED
             self._ledger.record(
                 CostRecord(
@@ -858,7 +869,7 @@ class Daemon:
                 model=decision.model,
                 status="success",
                 tokens=resp.usage.total_tokens,
-                cost_usd=task.cost_usd,
+                cost_usd=estimated_cost,
                 duration_seconds=(
                     (datetime.now(timezone.utc) - task.started_at).total_seconds()
                     if task.started_at is not None

--- a/maxwell_daemon/gh/__init__.py
+++ b/maxwell_daemon/gh/__init__.py
@@ -1,5 +1,11 @@
 """GitHub integration — issue/PR lifecycle via the `gh` CLI."""
 
-from maxwell_daemon.gh.client import GhCliError, GitHubClient, Issue, PullRequest, RateLimitError
+from maxwell_daemon.gh.client import (
+    GhCliError,
+    GitHubClient,
+    Issue,
+    PullRequest,
+    RateLimitError,
+)
 
 __all__ = ["GhCliError", "GitHubClient", "Issue", "PullRequest", "RateLimitError"]

--- a/maxwell_daemon/gh/repo_map.py
+++ b/maxwell_daemon/gh/repo_map.py
@@ -395,7 +395,9 @@ _RUST_TRAIT_RE = re.compile(
 )
 # `impl [<...>] [Trait for] Type` — capture the inherent/target type name.
 _RUST_IMPL_RE = re.compile(
-    r"impl\b(?:\s*<[^>]*>)?\s+" r"(?:[A-Za-z_][\w:]*(?:<[^>]*>)?\s+for\s+)?" r"([A-Za-z_][\w]*)",
+    r"impl\b(?:\s*<[^>]*>)?\s+"
+    r"(?:[A-Za-z_][\w:]*(?:<[^>]*>)?\s+for\s+)?"
+    r"([A-Za-z_][\w]*)",
 )
 _RUST_METHOD_RE = re.compile(
     r"^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?(?:const\s+)?(?:unsafe\s+)?"

--- a/maxwell_daemon/github_auth.py
+++ b/maxwell_daemon/github_auth.py
@@ -164,7 +164,10 @@ class GitHubAuth:
         except ImportError as exc:
             raise ImportError("httpx is required for GitHub App auth.") from exc
 
-        require(self._private_key_pem is not None, "private_key_pem must be set for App auth")
+        require(
+            self._private_key_pem is not None,
+            "private_key_pem must be set for App auth",
+        )
         now = int(time.time())
         payload = {"iat": now - 60, "exp": now + 600, "iss": str(self._app_id)}
         if self._private_key_pem is None:
@@ -208,7 +211,10 @@ class GitHubAuth:
 
         now = int(time.time())
         payload = {"iat": now - 60, "exp": now + 600, "iss": str(self._app_id)}
-        require(self._private_key_pem is not None, "private_key_pem must be set for App auth")
+        require(
+            self._private_key_pem is not None,
+            "private_key_pem must be set for App auth",
+        )
         jwt_token = _jwt.encode(payload, self._private_key_pem, algorithm="RS256")
 
         async with _httpx.AsyncClient(timeout=15) as client:

--- a/maxwell_daemon/metrics.py
+++ b/maxwell_daemon/metrics.py
@@ -10,10 +10,15 @@ from __future__ import annotations
 from typing import Literal
 
 from fastapi import FastAPI, Response
-from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, generate_latest
+from prometheus_client import (
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
 
 __all__ = [
-    "MAXWELL_COST_FORECAST_USD",
     "MAXWELL_COST_FORECAST_USD",
     "MAXWELL_FREE_REQUESTS_TOTAL",
     "MAXWELL_REQUESTS_TOTAL",
@@ -97,7 +102,7 @@ def record_request(
         if cost_usd is not None:
             if cost_usd > 0:
                 MAXWELL_REQUEST_COST.labels(backend=backend, model=model).inc(cost_usd)
-            else:
+            elif cost_usd == 0.0:
                 MAXWELL_FREE_REQUESTS_TOTAL.labels(backend=backend, model=model).inc()
         if duration_seconds > 0:
             MAXWELL_REQUEST_DURATION.labels(backend=backend, model=model).observe(duration_seconds)

--- a/maxwell_daemon/ssh/session.py
+++ b/maxwell_daemon/ssh/session.py
@@ -130,7 +130,10 @@ class SSHSession:
 
     async def download(self, remote_path: str) -> bytes:
         """Download a remote file and return its contents."""
-        async with self._conn.start_sftp_client() as sftp, sftp.open(remote_path, "rb") as fh:
+        async with (
+            self._conn.start_sftp_client() as sftp,
+            sftp.open(remote_path, "rb") as fh,
+        ):
             data: bytes = await fh.read()
             return data
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -421,7 +421,10 @@ class TestSSHEndpointsWithoutAsyncSSH:
         from unittest.mock import patch
 
         # Simulate asyncssh being absent by making it unimportable.
-        with patch.dict(sys.modules, {"asyncssh": None}), TestClient(create_app(daemon)) as c:
+        with (
+            patch.dict(sys.modules, {"asyncssh": None}),
+            TestClient(create_app(daemon)) as c,
+        ):
             r = c.get("/api/v1/ssh/sessions")
         assert r.status_code == 503
         assert "SSH support not installed" in r.json()["detail"]
@@ -430,7 +433,10 @@ class TestSSHEndpointsWithoutAsyncSSH:
         import sys
         from unittest.mock import patch
 
-        with patch.dict(sys.modules, {"asyncssh": None}), TestClient(create_app(daemon)) as c:
+        with (
+            patch.dict(sys.modules, {"asyncssh": None}),
+            TestClient(create_app(daemon)) as c,
+        ):
             r = c.post(
                 "/api/v1/ssh/connect",
                 json={"host": "srv", "user": "ubuntu"},

--- a/tests/unit/test_backend_agent_loop.py
+++ b/tests/unit/test_backend_agent_loop.py
@@ -448,7 +448,9 @@ class TestMonthlyBudgetEnforcerPerTurn:
     async def test_budget_enforcer_raises_aborts_loop(self, tmp_path: Path) -> None:
         """If require_under_budget() raises, the loop must abort immediately."""
         from maxwell_daemon.config import BudgetConfig
-        from maxwell_daemon.core.budget import BudgetExceededError as CoreBudgetExceededError
+        from maxwell_daemon.core.budget import (
+            BudgetExceededError as CoreBudgetExceededError,
+        )
 
         enforcer = MagicMock()
         enforcer.require_under_budget = MagicMock(

--- a/tests/unit/test_backend_claude_code.py
+++ b/tests/unit/test_backend_claude_code.py
@@ -49,7 +49,8 @@ class TestDefaultRunner:
             return _FakeProcess()
 
         monkeypatch.setattr(
-            "maxwell_daemon.backends.claude_code.asyncio.create_subprocess_exec", fake_exec
+            "maxwell_daemon.backends.claude_code.asyncio.create_subprocess_exec",
+            fake_exec,
         )
 
         rc, stdout, stderr = asyncio.run(_default_runner("claude", "-p", "hi", cwd="repo"))

--- a/tests/unit/test_backend_codex_cli.py
+++ b/tests/unit/test_backend_codex_cli.py
@@ -75,7 +75,8 @@ class TestDefaultRunner:
             return process
 
         monkeypatch.setattr(
-            "maxwell_daemon.backends.codex_cli.asyncio.create_subprocess_exec", fake_exec
+            "maxwell_daemon.backends.codex_cli.asyncio.create_subprocess_exec",
+            fake_exec,
         )
 
         rc, stdout, stderr = asyncio.run(
@@ -273,7 +274,7 @@ class TestHealthCheck:
 
 
 class TestCapabilities:
-    def test_non_local_with_tool_use_and_zero_cost(self) -> None:
+    def test_non_local_with_tool_use_and_unknown_cost(self) -> None:
         backend = CodexCLIBackend(runner=_Runner())
         caps = backend.capabilities("gpt-5-codex")
         assert caps.is_local is False
@@ -282,8 +283,10 @@ class TestCapabilities:
         assert caps.supports_vision is False
         assert caps.supports_system_prompt is True
         assert caps.max_context_tokens == 128_000
-        assert caps.cost_per_1k_input_tokens == 0.0
-        assert caps.cost_per_1k_output_tokens == 0.0
+        # Codex CLI rides the user's own OpenAI subscription — cost is unknown
+        # to the daemon, so the adapter returns None rather than a misleading 0.0.
+        assert caps.cost_per_1k_input_tokens is None
+        assert caps.cost_per_1k_output_tokens is None
 
 
 # ---------------------------------------------------------------- registry

--- a/tests/unit/test_backend_continue_cli.py
+++ b/tests/unit/test_backend_continue_cli.py
@@ -48,7 +48,8 @@ class TestDefaultRunner:
             return _FakeProcess()
 
         monkeypatch.setattr(
-            "maxwell_daemon.backends.continue_cli.asyncio.create_subprocess_exec", fake_exec
+            "maxwell_daemon.backends.continue_cli.asyncio.create_subprocess_exec",
+            fake_exec,
         )
 
         rc, stdout, stderr = asyncio.run(_default_runner("cn", "ask", "hi", cwd="repo"))
@@ -214,14 +215,16 @@ class TestHealthCheck:
 
 
 class TestCapabilities:
-    def test_no_tool_use_and_zero_cost(self) -> None:
+    def test_no_tool_use_and_unknown_cost(self) -> None:
         backend = ContinueCLIBackend(runner=_Runner())
         caps = backend.capabilities("auto")
         assert caps.supports_tool_use is False
         assert caps.supports_streaming is False
         assert caps.supports_system_prompt is True
-        assert caps.cost_per_1k_input_tokens == 0.0
-        assert caps.cost_per_1k_output_tokens == 0.0
+        # Continue.dev CLI uses the user's own subscription — cost is unknown
+        # to the daemon, represented as None rather than a misleading 0.0.
+        assert caps.cost_per_1k_input_tokens is None
+        assert caps.cost_per_1k_output_tokens is None
         assert caps.max_context_tokens == 128_000
         assert caps.is_local is False
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -48,7 +48,9 @@ async def _with_daemon(
     body: Callable[[Daemon], Awaitable[T]],
 ) -> T:
     d = Daemon(
-        config, ledger_path=ledger_path, task_store_path=ledger_path.with_suffix(".tasks.db")
+        config,
+        ledger_path=ledger_path,
+        task_store_path=ledger_path.with_suffix(".tasks.db"),
     )
     await d.start(worker_count=worker_count)
     try:
@@ -424,7 +426,11 @@ class TestSubmitThreadsafe:
             task = await asyncio.to_thread(background)
             assert isinstance(task, Task)
             assert task.prompt == "my prompt"
-            assert task.status in (TaskStatus.QUEUED, TaskStatus.RUNNING, TaskStatus.COMPLETED)
+            assert task.status in (
+                TaskStatus.QUEUED,
+                TaskStatus.RUNNING,
+                TaskStatus.COMPLETED,
+            )
             await _wait_for_status(d, task.id, TaskStatus.COMPLETED)
 
         _run(_with_daemon(minimal_config, isolated_ledger_path, worker_count=1, body=body))

--- a/tests/unit/test_fleet_coordinator.py
+++ b/tests/unit/test_fleet_coordinator.py
@@ -463,7 +463,9 @@ class TestSetWorkerCount:
         async def _run() -> None:
             cfg = _make_config()
             daemon = Daemon(
-                cfg, ledger_path=tmp_path / "ledger.db", task_store_path=tmp_path / "tasks.db"
+                cfg,
+                ledger_path=tmp_path / "ledger.db",
+                task_store_path=tmp_path / "tasks.db",
             )
             await daemon.start(worker_count=1)
             try:
@@ -479,7 +481,9 @@ class TestSetWorkerCount:
         async def _run() -> None:
             cfg = _make_config()
             daemon = Daemon(
-                cfg, ledger_path=tmp_path / "ledger.db", task_store_path=tmp_path / "tasks.db"
+                cfg,
+                ledger_path=tmp_path / "ledger.db",
+                task_store_path=tmp_path / "tasks.db",
             )
             await daemon.start(worker_count=3)
             try:
@@ -495,7 +499,9 @@ class TestSetWorkerCount:
         async def _run() -> None:
             cfg = _make_config()
             daemon = Daemon(
-                cfg, ledger_path=tmp_path / "ledger.db", task_store_path=tmp_path / "tasks.db"
+                cfg,
+                ledger_path=tmp_path / "ledger.db",
+                task_store_path=tmp_path / "tasks.db",
             )
             await daemon.start(worker_count=1)
             try:
@@ -514,7 +520,9 @@ class TestReprioritizeTask:
         async def _run() -> None:
             cfg = _make_config()
             daemon = Daemon(
-                cfg, ledger_path=tmp_path / "ledger.db", task_store_path=tmp_path / "tasks.db"
+                cfg,
+                ledger_path=tmp_path / "ledger.db",
+                task_store_path=tmp_path / "tasks.db",
             )
             await daemon.start(worker_count=1)
             try:
@@ -532,7 +540,9 @@ class TestReprioritizeTask:
         async def _run() -> None:
             cfg = _make_config()
             daemon = Daemon(
-                cfg, ledger_path=tmp_path / "ledger.db", task_store_path=tmp_path / "tasks.db"
+                cfg,
+                ledger_path=tmp_path / "ledger.db",
+                task_store_path=tmp_path / "tasks.db",
             )
             await daemon.start(worker_count=1)
             try:
@@ -555,7 +565,9 @@ class TestReloadConfig:
             cfg_path = tmp_path / "config.yaml"
             save_config(cfg, cfg_path)
             daemon = Daemon(
-                cfg, ledger_path=tmp_path / "ledger.db", task_store_path=tmp_path / "tasks.db"
+                cfg,
+                ledger_path=tmp_path / "ledger.db",
+                task_store_path=tmp_path / "tasks.db",
             )
             daemon._config_path = cfg_path
             await daemon.start(worker_count=1)

--- a/tests/unit/test_gh_client.py
+++ b/tests/unit/test_gh_client.py
@@ -11,7 +11,13 @@ import json
 
 import pytest
 
-from maxwell_daemon.gh import GhCliError, GitHubClient, Issue, PullRequest, RateLimitError
+from maxwell_daemon.gh import (
+    GhCliError,
+    GitHubClient,
+    Issue,
+    PullRequest,
+    RateLimitError,
+)
 from maxwell_daemon.gh.client import GitHubRateLimitError
 
 
@@ -312,7 +318,16 @@ class TestRateLimitHandling:
         import json as _json
 
         issues_payload = _json.dumps(
-            [{"number": 1, "title": "t", "body": "", "state": "OPEN", "labels": [], "url": "u"}]
+            [
+                {
+                    "number": 1,
+                    "title": "t",
+                    "body": "",
+                    "state": "OPEN",
+                    "labels": [],
+                    "url": "u",
+                }
+            ]
         ).encode()
 
         runner = self._make_runner(
@@ -360,7 +375,16 @@ class TestRateLimitHandling:
         import json as _json
 
         issues_payload = _json.dumps(
-            [{"number": 2, "title": "x", "body": "", "state": "OPEN", "labels": [], "url": "u"}]
+            [
+                {
+                    "number": 2,
+                    "title": "x",
+                    "body": "",
+                    "state": "OPEN",
+                    "labels": [],
+                    "url": "u",
+                }
+            ]
         ).encode()
 
         runner = self._make_runner(
@@ -614,7 +638,16 @@ class TestRateLimitRetry:
         monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
         issues_json = json.dumps(
-            [{"number": 1, "title": "t", "body": "b", "state": "OPEN", "labels": [], "url": "u"}]
+            [
+                {
+                    "number": 1,
+                    "title": "t",
+                    "body": "b",
+                    "state": "OPEN",
+                    "labels": [],
+                    "url": "u",
+                }
+            ]
         ).encode()
 
         runner = RetryRunner(
@@ -639,7 +672,14 @@ class TestRateLimitRetry:
         monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
         issue_json = json.dumps(
-            {"number": 7, "title": "t", "body": "b", "state": "OPEN", "labels": [], "url": "u"}
+            {
+                "number": 7,
+                "title": "t",
+                "body": "b",
+                "state": "OPEN",
+                "labels": [],
+                "url": "u",
+            }
         ).encode()
 
         runner = RetryRunner(

--- a/tests/unit/test_github_auth.py
+++ b/tests/unit/test_github_auth.py
@@ -103,7 +103,9 @@ class TestAppAuth:
         )
 
         with patch.object(
-            auth, "_fetch_installation_token", return_value=("refreshed", time.monotonic() + 3600)
+            auth,
+            "_fetch_installation_token",
+            return_value=("refreshed", time.monotonic() + 3600),
         ):
             result = auth.token
 
@@ -112,7 +114,10 @@ class TestAppAuth:
     def test_no_jwt_import_raises_helpful_error(self) -> None:
         auth = self._make_auth()
 
-        with patch.dict("sys.modules", {"jwt": None}), pytest.raises(ImportError, match="PyJWT"):
+        with (
+            patch.dict("sys.modules", {"jwt": None}),
+            pytest.raises(ImportError, match="PyJWT"),
+        ):
             auth._fetch_installation_token()
 
     def test_no_httpx_import_raises_helpful_error(self) -> None:
@@ -242,7 +247,10 @@ class TestAsyncGetToken:
 
     async def test_async_fetch_no_jwt_raises(self) -> None:
         auth = self._make_auth()
-        with patch.dict("sys.modules", {"jwt": None}), pytest.raises(ImportError, match="PyJWT"):
+        with (
+            patch.dict("sys.modules", {"jwt": None}),
+            pytest.raises(ImportError, match="PyJWT"),
+        ):
             await auth._async_fetch_installation_token()
 
     async def test_async_fetch_no_httpx_raises(self) -> None:

--- a/tests/unit/test_system_prompt_override.py
+++ b/tests/unit/test_system_prompt_override.py
@@ -210,7 +210,9 @@ class TestSystemPromptInExecuteIssue:
         backend = CapturingBackend()
         asyncio.run(
             IssueExecutor(
-                github=FakeGitHub(issue=_issue()), workspace=FakeWorkspace(), backend=backend
+                github=FakeGitHub(issue=_issue()),
+                workspace=FakeWorkspace(),
+                backend=backend,
             ).execute_issue(repo="o/r", issue_number=42, model="m", mode="plan", overrides=None)
         )
         assert any("JSON" in msg or "json" in msg.lower() for msg in backend.system_messages)
@@ -219,7 +221,9 @@ class TestSystemPromptInExecuteIssue:
         backend = CapturingBackend()
         asyncio.run(
             IssueExecutor(
-                github=FakeGitHub(issue=_issue()), workspace=FakeWorkspace(), backend=backend
+                github=FakeGitHub(issue=_issue()),
+                workspace=FakeWorkspace(),
+                backend=backend,
             ).execute_issue(
                 repo="o/r",
                 issue_number=42,
@@ -236,7 +240,9 @@ class TestSystemPromptInExecuteIssue:
         backend = CapturingBackend()
         asyncio.run(
             IssueExecutor(
-                github=FakeGitHub(issue=_issue()), workspace=FakeWorkspace(), backend=backend
+                github=FakeGitHub(issue=_issue()),
+                workspace=FakeWorkspace(),
+                backend=backend,
             ).execute_issue(
                 repo="o/r",
                 issue_number=42,
@@ -251,7 +257,9 @@ class TestSystemPromptInExecuteIssue:
         backend = CapturingBackend()
         asyncio.run(
             IssueExecutor(
-                github=FakeGitHub(issue=_issue()), workspace=FakeWorkspace(), backend=backend
+                github=FakeGitHub(issue=_issue()),
+                workspace=FakeWorkspace(),
+                backend=backend,
             ).execute_issue(
                 repo="owner/testrepo",
                 issue_number=42,
@@ -286,7 +294,11 @@ class TestRepoConfigSystemPromptFields:
 
     def test_accepts_system_prompt_file(self, tmp_path: Path) -> None:
         rc = RepoConfig.model_validate(
-            {"name": "x", "path": "/tmp/x", "system_prompt_file": str(tmp_path / "p.md")}
+            {
+                "name": "x",
+                "path": "/tmp/x",
+                "system_prompt_file": str(tmp_path / "p.md"),
+            }
         )
         assert rc.system_prompt_file == tmp_path / "p.md"
 

--- a/tests/unit/test_tools_builtins.py
+++ b/tests/unit/test_tools_builtins.py
@@ -208,7 +208,8 @@ def test_sandbox_cmd_mac_sandbox_exec(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("sys.platform", "darwin")
     monkeypatch.setattr(
-        "shutil.which", lambda cmd: "/usr/bin/sandbox-exec" if cmd == "sandbox-exec" else None
+        "shutil.which",
+        lambda cmd: "/usr/bin/sandbox-exec" if cmd == "sandbox-exec" else None,
     )
     res = get_sandboxed_bash_cmd(["bash", "-c", "echo hi"], "/tmp/workspace")
     assert res[:3] == ["sandbox-exec", "-f", "/usr/share/sandbox/pure_computation.sb"]


### PR DESCRIPTION
## Summary

Fixes #244

### Problem
The `record_request()` function was incrementing `MAXWELL_FREE_REQUESTS_TOTAL` for any successful call with `cost_usd == 0.0`, but several CLI-based backends (codex-cli, continue-cli, claude-code) were returning `0.0` simply because they had no cost data — not because they were actually free. This caused misleading dashboard metrics.

### Changes
- `BackendCapabilities.cost_per_1k_*` fields changed from `float = 0.0` to `float | None = None`
- Subscription backends return `None` (cost unknown); local backends keep explicit `0.0` (truly free)
- `estimate_cost()` now returns `float | None` with the same semantics
- `record_request()` free-counter guard: only increments when `cost_usd is not None and cost_usd == 0.0`
- `runner.py` stores float for task accounting but passes raw Optional to Prometheus
- Fleet-wide black + ruff formatting applied (152 files reformatted)
- Test assertions updated for codex-cli and continue-cli capabilities

### Test Results
1505 passed, 4 skipped, 3 pre-existing environment failures (Windows subprocess/Unicode) unrelated to this change.
