### PR TITLE
fix: preserve remote issue task semantics in fleet dispatch

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -66,9 +66,14 @@ def _mount_web_ui(app: FastAPI) -> None:
 
 class TaskSubmit(BaseModel):
     prompt: str = Field(..., min_length=1)
+    task_id: str | None = None
+    kind: str = "prompt"
     repo: str | None = None
     backend: str | None = None
     model: str | None = None
+    issue_repo: str | None = None
+    issue_number: int | None = None
+    issue_mode: str | None = None
     priority: int = Field(default=100, ge=0, le=200)
 
 
@@ -415,12 +420,25 @@ def create_app(
         status_code=status.HTTP_202_ACCEPTED,
     )
     async def submit_task(payload: TaskSubmit) -> TaskView:
-        task = daemon.submit(
-            payload.prompt,
-            repo=payload.repo,
-            backend=payload.backend,
-            model=payload.model,
-        )
+        if payload.kind == "issue" and payload.issue_repo and payload.issue_number is not None:
+            task = daemon.submit_issue(
+                repo=payload.issue_repo,
+                issue_number=payload.issue_number,
+                mode=payload.issue_mode or "plan",
+                backend=payload.backend,
+                model=payload.model,
+                priority=payload.priority,
+                task_id=payload.task_id,
+            )
+        else:
+            task = daemon.submit(
+                payload.prompt,
+                repo=payload.repo,
+                backend=payload.backend,
+                model=payload.model,
+                priority=payload.priority,
+                task_id=payload.task_id,
+            )
         return TaskView.from_task(task)
 
     @app.get("/api/v1/tasks", dependencies=[Depends(_require_viewer())])

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -386,9 +386,10 @@ class Daemon:
         backend: str | None = None,
         model: str | None = None,
         priority: int = 100,
+        task_id: str | None = None,
     ) -> Task:
         task = Task(
-            id=uuid.uuid4().hex[:12],
+            id=task_id or uuid.uuid4().hex[:12],
             prompt=prompt,
             kind=TaskKind.PROMPT,
             repo=repo,
@@ -464,12 +465,13 @@ class Daemon:
         backend: str | None = None,
         model: str | None = None,
         priority: int = 100,
+        task_id: str | None = None,
     ) -> Task:
         """Queue a task that reads a GitHub issue and opens a draft PR for it."""
         if mode not in {"plan", "implement"}:
             raise ValueError(f"mode must be 'plan' or 'implement', got {mode!r}")
         task = Task(
-            id=uuid.uuid4().hex[:12],
+            id=task_id or uuid.uuid4().hex[:12],
             prompt=f"{repo}#{issue_number}",
             kind=TaskKind.ISSUE,
             repo=repo,


### PR DESCRIPTION
Closes #297

Updates `TaskSubmit` schema to accept task_id and issue metadata, preserving issue semantics when tasks are dispatched to remote workers.