### PR TITLE
docs: add Tailscale fleet deployment guide

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -22,7 +22,7 @@ keys to `maxwell-daemon.yaml`.
 
 ## Ansible Fleet
 
-Use Ansible when you already know the hosts that should run workers.
+Use Ansible when you already know the hosts that should run workers. For securely connecting your fleet over a private network, see the [Tailscale Fleet Deployment Guide](tailscale.md).
 
 ```bash
 cp ansible/inventory.example.yml ansible/inventory.yml

--- a/docs/operations/tailscale.md
+++ b/docs/operations/tailscale.md
@@ -1,0 +1,42 @@
+# Tailscale Fleet Deployment
+
+Maxwell-Daemon's fleet transport uses generic HTTP(S) to communicate between the coordinator and workers. While you can run the fleet over any network, **Tailscale** is the recommended topology for securely connecting a distributed fleet of worker nodes.
+
+## Recommended Topology
+
+When using Tailscale, deploy your coordinator and all worker nodes onto the same tailnet. This ensures that all fleet coordination traffic is encrypted end-to-end and bypasses the public internet entirely.
+
+- **Coordinator**: Binds its API (e.g., `0.0.0.0:8000`) but is only accessed via its Tailscale IP (e.g., `100.x.y.z`) or MagicDNS name (e.g., `maxwell-coordinator.tailnet-name.ts.net`).
+- **Workers**: Connect to the coordinator using the coordinator's MagicDNS name. They do not expose their own APIs to the internet.
+
+> [!NOTE]
+> Maxwell-Daemon does **not** install, provision, or manage Tailscale. You must install Tailscale and join the nodes to your tailnet using your preferred infrastructure-as-code tool (e.g., Ansible or Terraform) before configuring the Maxwell fleet.
+
+## Configuration
+
+In your coordinator's `fleet.yaml` (or via `MAXWELL_FLEET_CONFIG`), define the machines using their MagicDNS names:
+
+```yaml
+fleet:
+  name: "production-fleet"
+
+machines:
+  - name: "worker-01"
+    host: "worker-01.tailnet-name.ts.net"
+    port: 8000
+    capacity: 4
+  - name: "worker-02"
+    host: "worker-02.tailnet-name.ts.net"
+    port: 8000
+    capacity: 4
+```
+
+## Security Posture
+
+- **No Public Exposure**: No memory or task APIs should be exposed to the public internet. Ensure your cloud firewalls (Security Groups, VPC rules) block inbound port 8000 from `0.0.0.0/0`.
+- **Authentication**: Tailscale provides network-level encryption and identity, but you must still configure a strong `api.auth_token` or JWT configuration in Maxwell-Daemon's configuration. The coordinator and workers will use this token for application-level authentication.
+- **ACLs**: Use Tailscale ACLs to restrict which nodes can communicate with the coordinator on port 8000, enforcing least-privilege network access.
+
+## Validating the Setup
+
+Use the `maxwell-daemon health` command on the coordinator, or check the `/api/v1/fleet` endpoint. If the coordinator can reach the workers, their `healthy` status will be `true`. If MagicDNS resolution fails or Tailscale is disconnected, the status will correctly report as unhealthy.

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -66,9 +66,14 @@ def _mount_web_ui(app: FastAPI) -> None:
 
 class TaskSubmit(BaseModel):
     prompt: str = Field(..., min_length=1)
+    task_id: str | None = None
+    kind: str = "prompt"
     repo: str | None = None
     backend: str | None = None
     model: str | None = None
+    issue_repo: str | None = None
+    issue_number: int | None = None
+    issue_mode: str | None = None
     priority: int = Field(default=100, ge=0, le=200)
 
 
@@ -415,12 +420,25 @@ def create_app(
         status_code=status.HTTP_202_ACCEPTED,
     )
     async def submit_task(payload: TaskSubmit) -> TaskView:
-        task = daemon.submit(
-            payload.prompt,
-            repo=payload.repo,
-            backend=payload.backend,
-            model=payload.model,
-        )
+        if payload.kind == "issue" and payload.issue_repo and payload.issue_number is not None:
+            task = daemon.submit_issue(
+                repo=payload.issue_repo,
+                issue_number=payload.issue_number,
+                mode=payload.issue_mode or "plan",
+                backend=payload.backend,
+                model=payload.model,
+                priority=payload.priority,
+                task_id=payload.task_id,
+            )
+        else:
+            task = daemon.submit(
+                payload.prompt,
+                repo=payload.repo,
+                backend=payload.backend,
+                model=payload.model,
+                priority=payload.priority,
+                task_id=payload.task_id,
+            )
         return TaskView.from_task(task)
 
     @app.get("/api/v1/tasks", dependencies=[Depends(_require_viewer())])

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -386,9 +386,10 @@ class Daemon:
         backend: str | None = None,
         model: str | None = None,
         priority: int = 100,
+        task_id: str | None = None,
     ) -> Task:
         task = Task(
-            id=uuid.uuid4().hex[:12],
+            id=task_id or uuid.uuid4().hex[:12],
             prompt=prompt,
             kind=TaskKind.PROMPT,
             repo=repo,
@@ -464,12 +465,13 @@ class Daemon:
         backend: str | None = None,
         model: str | None = None,
         priority: int = 100,
+        task_id: str | None = None,
     ) -> Task:
         """Queue a task that reads a GitHub issue and opens a draft PR for it."""
         if mode not in {"plan", "implement"}:
             raise ValueError(f"mode must be 'plan' or 'implement', got {mode!r}")
         task = Task(
-            id=uuid.uuid4().hex[:12],
+            id=task_id or uuid.uuid4().hex[:12],
             prompt=f"{repo}#{issue_number}",
             kind=TaskKind.ISSUE,
             repo=repo,


### PR DESCRIPTION
Closes #298

Adds documentation for deploying the Maxwell fleet over Tailscale, including MagicDNS configuration and security posturing.