### PR TITLE
feat: add coordinator-owned shared codebase memory for fleet workers

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -22,7 +22,7 @@ keys to `maxwell-daemon.yaml`.
 
 ## Ansible Fleet
 
-Use Ansible when you already know the hosts that should run workers.
+Use Ansible when you already know the hosts that should run workers. For securely connecting your fleet over a private network, see the [Tailscale Fleet Deployment Guide](tailscale.md).
 
 ```bash
 cp ansible/inventory.example.yml ansible/inventory.yml

--- a/docs/operations/tailscale.md
+++ b/docs/operations/tailscale.md
@@ -1,0 +1,42 @@
+# Tailscale Fleet Deployment
+
+Maxwell-Daemon's fleet transport uses generic HTTP(S) to communicate between the coordinator and workers. While you can run the fleet over any network, **Tailscale** is the recommended topology for securely connecting a distributed fleet of worker nodes.
+
+## Recommended Topology
+
+When using Tailscale, deploy your coordinator and all worker nodes onto the same tailnet. This ensures that all fleet coordination traffic is encrypted end-to-end and bypasses the public internet entirely.
+
+- **Coordinator**: Binds its API (e.g., `0.0.0.0:8000`) but is only accessed via its Tailscale IP (e.g., `100.x.y.z`) or MagicDNS name (e.g., `maxwell-coordinator.tailnet-name.ts.net`).
+- **Workers**: Connect to the coordinator using the coordinator's MagicDNS name. They do not expose their own APIs to the internet.
+
+> [!NOTE]
+> Maxwell-Daemon does **not** install, provision, or manage Tailscale. You must install Tailscale and join the nodes to your tailnet using your preferred infrastructure-as-code tool (e.g., Ansible or Terraform) before configuring the Maxwell fleet.
+
+## Configuration
+
+In your coordinator's `fleet.yaml` (or via `MAXWELL_FLEET_CONFIG`), define the machines using their MagicDNS names:
+
+```yaml
+fleet:
+  name: "production-fleet"
+
+machines:
+  - name: "worker-01"
+    host: "worker-01.tailnet-name.ts.net"
+    port: 8000
+    capacity: 4
+  - name: "worker-02"
+    host: "worker-02.tailnet-name.ts.net"
+    port: 8000
+    capacity: 4
+```
+
+## Security Posture
+
+- **No Public Exposure**: No memory or task APIs should be exposed to the public internet. Ensure your cloud firewalls (Security Groups, VPC rules) block inbound port 8000 from `0.0.0.0/0`.
+- **Authentication**: Tailscale provides network-level encryption and identity, but you must still configure a strong `api.auth_token` or JWT configuration in Maxwell-Daemon's configuration. The coordinator and workers will use this token for application-level authentication.
+- **ACLs**: Use Tailscale ACLs to restrict which nodes can communicate with the coordinator on port 8000, enforcing least-privilege network access.
+
+## Validating the Setup
+
+Use the `maxwell-daemon health` command on the coordinator, or check the `/api/v1/fleet` endpoint. If the coordinator can reach the workers, their `healthy` status will be `true`. If MagicDNS resolution fails or Tailscale is disconnected, the status will correctly report as unhealthy.

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -66,9 +66,14 @@ def _mount_web_ui(app: FastAPI) -> None:
 
 class TaskSubmit(BaseModel):
     prompt: str = Field(..., min_length=1)
+    task_id: str | None = None
+    kind: str = "prompt"
     repo: str | None = None
     backend: str | None = None
     model: str | None = None
+    issue_repo: str | None = None
+    issue_number: int | None = None
+    issue_mode: str | None = None
     priority: int = Field(default=100, ge=0, le=200)
 
 
@@ -415,12 +420,25 @@ def create_app(
         status_code=status.HTTP_202_ACCEPTED,
     )
     async def submit_task(payload: TaskSubmit) -> TaskView:
-        task = daemon.submit(
-            payload.prompt,
-            repo=payload.repo,
-            backend=payload.backend,
-            model=payload.model,
-        )
+        if payload.kind == "issue" and payload.issue_repo and payload.issue_number is not None:
+            task = daemon.submit_issue(
+                repo=payload.issue_repo,
+                issue_number=payload.issue_number,
+                mode=payload.issue_mode or "plan",
+                backend=payload.backend,
+                model=payload.model,
+                priority=payload.priority,
+                task_id=payload.task_id,
+            )
+        else:
+            task = daemon.submit(
+                payload.prompt,
+                repo=payload.repo,
+                backend=payload.backend,
+                model=payload.model,
+                priority=payload.priority,
+                task_id=payload.task_id,
+            )
         return TaskView.from_task(task)
 
     @app.get("/api/v1/tasks", dependencies=[Depends(_require_viewer())])

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -164,6 +164,26 @@ class CostSummary(BaseModel):
     by_backend: dict[str, float]
 
 
+class AssembleMemoryRequest(BaseModel):
+    repo: str = Field(..., min_length=1)
+    issue_title: str = ""
+    issue_body: str = ""
+    task_id: str = Field(..., min_length=1)
+    max_chars: int = 8000
+
+
+class RecordMemoryOutcome(BaseModel):
+    task_id: str = Field(..., min_length=1)
+    repo: str = Field(..., min_length=1)
+    issue_number: int
+    issue_title: str = ""
+    issue_body: str = ""
+    plan: str = ""
+    applied_diff: bool = False
+    pr_url: str = ""
+    outcome: str = ""
+
+
 class SSHConnectRequest(BaseModel):
     host: str
     port: int = 22
@@ -482,6 +502,41 @@ def create_app(
         except ValueError as e:
             raise HTTPException(status.HTTP_409_CONFLICT, str(e)) from None
         return TaskView.from_task(cancelled)
+
+    @app.post(
+        "/api/v1/memory/assemble",
+        dependencies=[Depends(auth), Depends(_require_operator())],
+    )
+    async def assemble_memory(payload: AssembleMemoryRequest) -> dict[str, Any]:
+        """Assemble repo/task context from the coordinator's shared memory store."""
+        context = daemon._memory.assemble_context(
+            repo=payload.repo,
+            issue_title=payload.issue_title,
+            issue_body=payload.issue_body,
+            task_id=payload.task_id,
+            max_chars=payload.max_chars,
+        )
+        return {"context": context}
+
+    @app.post(
+        "/api/v1/memory/record",
+        dependencies=[Depends(auth), Depends(_require_operator())],
+        status_code=status.HTTP_201_CREATED,
+    )
+    async def record_memory(payload: RecordMemoryOutcome) -> dict[str, Any]:
+        """Record a completed task's outcome to the coordinator's shared memory store."""
+        daemon._memory.record_outcome(
+            task_id=payload.task_id,
+            repo=payload.repo,
+            issue_number=payload.issue_number,
+            issue_title=payload.issue_title,
+            issue_body=payload.issue_body,
+            plan=payload.plan,
+            applied_diff=payload.applied_diff,
+            pr_url=payload.pr_url,
+            outcome=payload.outcome,
+        )
+        return {"status": "recorded"}
 
     @app.post(
         "/api/v1/issues",

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -183,6 +183,7 @@ class FleetConfig(BaseModel):
     discovery_method: Literal["manual", "mdns"] = "manual"
     heartbeat_seconds: int = Field(30, ge=5)
     coordinator_poll_seconds: int = Field(30, ge=5)
+    coordinator_url: str | None = Field(None, description="URL of the coordinator daemon (e.g. https://coordinator:8080)")
 
 
 class WebhookRouteConfig(BaseModel):
@@ -319,6 +320,11 @@ class MaxwellDaemonConfig(BaseModel):
     def fleet_machines(self) -> list[MachineConfig]:
         """Shortcut for ``fleet.machines``."""
         return self.fleet.machines
+
+    @property
+    def fleet_coordinator_url(self) -> str | None:
+        """Shortcut for ``fleet.coordinator_url``."""
+        return self.fleet.coordinator_url
 
     @property
     def memory_workspace_path(self) -> Path:

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -183,7 +183,9 @@ class FleetConfig(BaseModel):
     discovery_method: Literal["manual", "mdns"] = "manual"
     heartbeat_seconds: int = Field(30, ge=5)
     coordinator_poll_seconds: int = Field(30, ge=5)
-    coordinator_url: str | None = Field(None, description="URL of the coordinator daemon (e.g. https://coordinator:8080)")
+    coordinator_url: str | None = Field(
+        None, description="URL of the coordinator daemon (e.g. https://coordinator:8080)"
+    )
 
 
 class WebhookRouteConfig(BaseModel):

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -386,9 +386,10 @@ class Daemon:
         backend: str | None = None,
         model: str | None = None,
         priority: int = 100,
+        task_id: str | None = None,
     ) -> Task:
         task = Task(
-            id=uuid.uuid4().hex[:12],
+            id=task_id or uuid.uuid4().hex[:12],
             prompt=prompt,
             kind=TaskKind.PROMPT,
             repo=repo,
@@ -464,12 +465,13 @@ class Daemon:
         backend: str | None = None,
         model: str | None = None,
         priority: int = 100,
+        task_id: str | None = None,
     ) -> Task:
         """Queue a task that reads a GitHub issue and opens a draft PR for it."""
         if mode not in {"plan", "implement"}:
             raise ValueError(f"mode must be 'plan' or 'implement', got {mode!r}")
         task = Task(
-            id=uuid.uuid4().hex[:12],
+            id=task_id or uuid.uuid4().hex[:12],
             prompt=f"{repo}#{issue_number}",
             kind=TaskKind.ISSUE,
             repo=repo,

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -132,11 +132,18 @@ class Daemon:
         )
 
         default_memory = self._config.memory_workspace_path / "memory.db"
-        self._memory = MemoryManager(
-            scratchpad=ScratchPad(),
-            profile=RepoProfile(default_memory),
-            episodes=EpisodicStore(default_memory),
-        )
+        if self._config.role == "worker" and self._config.fleet_coordinator_url:
+            from maxwell_daemon.fleet.memory import RemoteMemoryManager
+            self._memory = RemoteMemoryManager(
+                coordinator_url=self._config.fleet_coordinator_url,
+                auth_token=self._config.api_auth_token,
+            )
+        else:
+            self._memory = MemoryManager(
+                scratchpad=ScratchPad(),
+                profile=RepoProfile(default_memory),
+                episodes=EpisodicStore(default_memory),
+            )
         self._tasks: dict[str, Task] = {}
         # ``_tasks`` is touched from async workers *and* from synchronous
         # callers like :meth:`submit` (typically a FastAPI request thread).

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -132,8 +132,10 @@ class Daemon:
         )
 
         default_memory = self._config.memory_workspace_path / "memory.db"
+        self._memory: MemoryManager
         if self._config.role == "worker" and self._config.fleet_coordinator_url:
             from maxwell_daemon.fleet.memory import RemoteMemoryManager
+
             self._memory = RemoteMemoryManager(
                 coordinator_url=self._config.fleet_coordinator_url,
                 auth_token=self._config.api_auth_token,

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -126,13 +126,14 @@ class Daemon:
         # Memory store — co-located with the ledger for easy backup.
         from maxwell_daemon.memory import (
             EpisodicStore,
+            MemoryBackend,
             MemoryManager,
             RepoProfile,
             ScratchPad,
         )
 
         default_memory = self._config.memory_workspace_path / "memory.db"
-        self._memory: MemoryManager
+        self._memory: MemoryBackend
         if self._config.role == "worker" and self._config.fleet_coordinator_url:
             from maxwell_daemon.fleet.memory import RemoteMemoryManager
 

--- a/maxwell_daemon/fleet/memory.py
+++ b/maxwell_daemon/fleet/memory.py
@@ -1,0 +1,86 @@
+"""Remote memory manager for worker nodes.
+
+Routes memory operations to the coordinator's HTTP API.
+"""
+
+from __future__ import annotations
+
+import httpx
+from maxwell_daemon.memory.scratchpad import ScratchPad
+
+class RemoteMemoryManager:
+    def __init__(self, coordinator_url: str, auth_token: str | None = None) -> None:
+        self._url = coordinator_url.rstrip("/")
+        self._headers = {"Content-Type": "application/json"}
+        if auth_token:
+            self._headers["Authorization"] = f"Bearer {auth_token}"
+        self.scratchpad = ScratchPad()
+
+    def assemble_context(
+        self,
+        *,
+        repo: str,
+        issue_title: str,
+        issue_body: str,
+        task_id: str,
+        max_chars: int = 8000,
+    ) -> str:
+        with httpx.Client() as client:
+            try:
+                resp = client.post(
+                    f"{self._url}/api/v1/memory/assemble",
+                    json={
+                        "repo": repo,
+                        "issue_title": issue_title,
+                        "issue_body": issue_body,
+                        "task_id": task_id,
+                        "max_chars": max_chars,
+                    },
+                    headers=self._headers,
+                    timeout=10.0,
+                )
+                resp.raise_for_status()
+                base_context = resp.json().get("context", "")
+            except Exception:
+                base_context = ""
+        
+        # Merge local scratchpad
+        scratch_text = self.scratchpad.render(task_id, max_chars=max_chars // 4)
+        if scratch_text:
+            return f"{base_context}\n\n## Scratchpad (this task's history)\n\n{scratch_text}"
+        return base_context
+
+    def record_outcome(
+        self,
+        *,
+        task_id: str,
+        repo: str,
+        issue_number: int,
+        issue_title: str,
+        issue_body: str,
+        plan: str,
+        applied_diff: bool,
+        pr_url: str,
+        outcome: str,
+    ) -> None:
+        with httpx.Client() as client:
+            try:
+                client.post(
+                    f"{self._url}/api/v1/memory/record",
+                    json={
+                        "task_id": task_id,
+                        "repo": repo,
+                        "issue_number": issue_number,
+                        "issue_title": issue_title,
+                        "issue_body": issue_body,
+                        "plan": plan,
+                        "applied_diff": applied_diff,
+                        "pr_url": pr_url,
+                        "outcome": outcome,
+                    },
+                    headers=self._headers,
+                    timeout=10.0,
+                )
+            except Exception:
+                pass
+        self.scratchpad.clear(task_id)

--- a/maxwell_daemon/fleet/memory.py
+++ b/maxwell_daemon/fleet/memory.py
@@ -5,10 +5,14 @@ Routes memory operations to the coordinator's HTTP API.
 
 from __future__ import annotations
 
-import httpx
-from maxwell_daemon.memory.scratchpad import ScratchPad
+import contextlib
 
-class RemoteMemoryManager:
+import httpx
+
+from maxwell_daemon.memory import MemoryManager, ScratchPad
+
+
+class RemoteMemoryManager(MemoryManager):
     def __init__(self, coordinator_url: str, auth_token: str | None = None) -> None:
         self._url = coordinator_url.rstrip("/")
         self._headers = {"Content-Type": "application/json"}
@@ -40,10 +44,12 @@ class RemoteMemoryManager:
                     timeout=10.0,
                 )
                 resp.raise_for_status()
-                base_context = resp.json().get("context", "")
+                data = resp.json()
+                context = data.get("context", "") if isinstance(data, dict) else ""
+                base_context = context if isinstance(context, str) else str(context)
             except Exception:
                 base_context = ""
-        
+
         # Merge local scratchpad
         scratch_text = self.scratchpad.render(task_id, max_chars=max_chars // 4)
         if scratch_text:
@@ -63,24 +69,21 @@ class RemoteMemoryManager:
         pr_url: str,
         outcome: str,
     ) -> None:
-        with httpx.Client() as client:
-            try:
-                client.post(
-                    f"{self._url}/api/v1/memory/record",
-                    json={
-                        "task_id": task_id,
-                        "repo": repo,
-                        "issue_number": issue_number,
-                        "issue_title": issue_title,
-                        "issue_body": issue_body,
-                        "plan": plan,
-                        "applied_diff": applied_diff,
-                        "pr_url": pr_url,
-                        "outcome": outcome,
-                    },
-                    headers=self._headers,
-                    timeout=10.0,
-                )
-            except Exception:
-                pass
+        with httpx.Client() as client, contextlib.suppress(Exception):
+            client.post(
+                f"{self._url}/api/v1/memory/record",
+                json={
+                    "task_id": task_id,
+                    "repo": repo,
+                    "issue_number": issue_number,
+                    "issue_title": issue_title,
+                    "issue_body": issue_body,
+                    "plan": plan,
+                    "applied_diff": applied_diff,
+                    "pr_url": pr_url,
+                    "outcome": outcome,
+                },
+                headers=self._headers,
+                timeout=10.0,
+            )
         self.scratchpad.clear(task_id)

--- a/maxwell_daemon/fleet/memory.py
+++ b/maxwell_daemon/fleet/memory.py
@@ -29,6 +29,7 @@ class RemoteMemoryManager(MemoryManager):
         task_id: str,
         max_chars: int = 8000,
     ) -> str:
+        base_context = ""
         with httpx.Client() as client:
             try:
                 resp = client.post(
@@ -44,10 +45,12 @@ class RemoteMemoryManager(MemoryManager):
                     timeout=10.0,
                 )
                 resp.raise_for_status()
-                data = resp.json()
-                context = data.get("context", "") if isinstance(data, dict) else ""
-                base_context = context if isinstance(context, str) else str(context)
-            except Exception:
+                payload = resp.json()
+                if isinstance(payload, dict):
+                    context = payload.get("context")
+                    if isinstance(context, str):
+                        base_context = context
+            except (httpx.HTTPError, ValueError, TypeError):
                 base_context = ""
 
         # Merge local scratchpad
@@ -69,8 +72,8 @@ class RemoteMemoryManager(MemoryManager):
         pr_url: str,
         outcome: str,
     ) -> None:
-        with httpx.Client() as client, contextlib.suppress(Exception):
-            client.post(
+        with httpx.Client() as client, contextlib.suppress(httpx.HTTPError):
+            resp = client.post(
                 f"{self._url}/api/v1/memory/record",
                 json={
                     "task_id": task_id,
@@ -86,4 +89,5 @@ class RemoteMemoryManager(MemoryManager):
                 headers=self._headers,
                 timeout=10.0,
             )
+            resp.raise_for_status()
         self.scratchpad.clear(task_id)

--- a/maxwell_daemon/gh/executor.py
+++ b/maxwell_daemon/gh/executor.py
@@ -27,7 +27,7 @@ from maxwell_daemon.core.repo_overrides import RepoOverrides
 from maxwell_daemon.gh.context import ContextBuilder
 from maxwell_daemon.gh.test_runner import TestResult, TestRunner
 from maxwell_daemon.gh.workspace import WorkspaceError
-from maxwell_daemon.memory import MemoryManager
+from maxwell_daemon.memory import MemoryBackend
 from maxwell_daemon.templates import classify_issue, render_system_prompt
 from maxwell_daemon.tracing import span as _trace_span
 
@@ -112,7 +112,7 @@ class IssueExecutor:
         test_runner: TestRunner | Any | None = None,
         max_test_retries: int = 1,
         test_timeout_seconds: float = 300.0,
-        memory: MemoryManager | None = None,
+        memory: MemoryBackend | None = None,
         memory_max_chars: int = 8000,
     ) -> None:
         self._gh = github

--- a/maxwell_daemon/memory/__init__.py
+++ b/maxwell_daemon/memory/__init__.py
@@ -11,13 +11,14 @@ us searchable episodic memory at a tenth of the complexity.
 """
 
 from maxwell_daemon.memory.episodic import Episode, EpisodicStore
-from maxwell_daemon.memory.manager import MemoryManager
+from maxwell_daemon.memory.manager import MemoryBackend, MemoryManager
 from maxwell_daemon.memory.profile import RepoProfile
 from maxwell_daemon.memory.scratchpad import ScratchEntry, ScratchPad
 
 __all__ = [
     "Episode",
     "EpisodicStore",
+    "MemoryBackend",
     "MemoryManager",
     "RepoProfile",
     "ScratchEntry",

--- a/maxwell_daemon/memory/manager.py
+++ b/maxwell_daemon/memory/manager.py
@@ -7,11 +7,43 @@ task ends successfully.
 
 from __future__ import annotations
 
+from typing import Protocol
+
 from maxwell_daemon.memory.episodic import Episode, EpisodicStore
 from maxwell_daemon.memory.profile import RepoProfile
 from maxwell_daemon.memory.scratchpad import ScratchPad
 
-__all__ = ["MemoryManager"]
+__all__ = ["MemoryBackend", "MemoryManager"]
+
+
+class MemoryBackend(Protocol):
+    """Shared interface used by issue execution for local or coordinator memory."""
+
+    scratchpad: ScratchPad
+
+    def assemble_context(
+        self,
+        *,
+        repo: str,
+        issue_title: str,
+        issue_body: str,
+        task_id: str,
+        max_chars: int = 8000,
+    ) -> str: ...
+
+    def record_outcome(
+        self,
+        *,
+        task_id: str,
+        repo: str,
+        issue_number: int,
+        issue_title: str,
+        issue_body: str,
+        plan: str,
+        applied_diff: bool,
+        pr_url: str,
+        outcome: str,
+    ) -> None: ...
 
 
 class MemoryManager:

--- a/tests/unit/test_fleet_memory.py
+++ b/tests/unit/test_fleet_memory.py
@@ -1,0 +1,114 @@
+"""Remote fleet memory behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, ClassVar
+
+import httpx
+import pytest
+
+from maxwell_daemon.fleet.memory import RemoteMemoryManager
+
+
+class _Response:
+    def __init__(self, payload: object, *, status_code: int = 200) -> None:
+        self._payload = payload
+        self._status_code = status_code
+
+    def json(self) -> object:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self._status_code >= 400:
+            raise httpx.HTTPStatusError(
+                "bad status",
+                request=httpx.Request("POST", "https://coordinator.test"),
+                response=httpx.Response(self._status_code),
+            )
+
+
+class _Client:
+    requests: ClassVar[list[dict[str, Any]]] = []
+    response: ClassVar[_Response | Exception] = _Response({"context": "shared context"})
+
+    def __enter__(self) -> _Client:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def post(
+        self,
+        url: str,
+        *,
+        json: Mapping[str, object],
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> _Response:
+        self.requests.append(
+            {"url": url, "json": dict(json), "headers": dict(headers), "timeout": timeout}
+        )
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+@pytest.fixture(autouse=True)
+def _reset_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    _Client.requests = []
+    _Client.response = _Response({"context": "shared context"})
+    monkeypatch.setattr(httpx, "Client", _Client)
+
+
+def test_assemble_context_merges_remote_context_and_local_scratchpad() -> None:
+    manager = RemoteMemoryManager("https://coordinator.test/", auth_token="token")
+    manager.scratchpad.append("task-1", role="plan", content="local note")
+
+    assembled = manager.assemble_context(
+        repo="D-sorganization/Maxwell-Daemon",
+        issue_title="title",
+        issue_body="body",
+        task_id="task-1",
+    )
+
+    assert "shared context" in assembled
+    assert "local note" in assembled
+    assert _Client.requests[0]["url"] == "https://coordinator.test/api/v1/memory/assemble"
+    assert _Client.requests[0]["headers"]["Authorization"] == "Bearer token"
+
+
+def test_assemble_context_falls_back_to_scratchpad_when_remote_fails() -> None:
+    _Client.response = httpx.ConnectError("offline")
+    manager = RemoteMemoryManager("https://coordinator.test")
+    manager.scratchpad.append("task-1", role="plan", content="offline note")
+
+    assembled = manager.assemble_context(
+        repo="D-sorganization/Maxwell-Daemon",
+        issue_title="title",
+        issue_body="body",
+        task_id="task-1",
+    )
+
+    assert "offline note" in assembled
+
+
+def test_record_outcome_posts_to_coordinator_and_clears_scratchpad() -> None:
+    manager = RemoteMemoryManager("https://coordinator.test")
+    manager.scratchpad.append("task-1", role="plan", content="done")
+
+    manager.record_outcome(
+        task_id="task-1",
+        repo="D-sorganization/Maxwell-Daemon",
+        issue_number=296,
+        issue_title="title",
+        issue_body="body",
+        plan="plan",
+        applied_diff=True,
+        pr_url="https://github.com/D-sorganization/Maxwell-Daemon/pull/303",
+        outcome="completed",
+    )
+
+    assert _Client.requests[0]["url"] == "https://coordinator.test/api/v1/memory/record"
+    assert _Client.requests[0]["json"]["issue_number"] == 296
+    assert manager.scratchpad.entries("task-1") == []

--- a/tests/unit/test_remote_memory_manager.py
+++ b/tests/unit/test_remote_memory_manager.py
@@ -1,0 +1,12 @@
+"""Remote memory manager contract tests."""
+
+from __future__ import annotations
+
+from maxwell_daemon.fleet.memory import RemoteMemoryManager
+from maxwell_daemon.memory import MemoryManager
+
+
+def test_remote_memory_manager_implements_memory_manager_contract() -> None:
+    manager = RemoteMemoryManager("https://coordinator.example")
+
+    assert isinstance(manager, MemoryManager)


### PR DESCRIPTION
Closes #296

Adds coordinator APIs for assembling memory context and recording task outcomes. Fleet workers now default to using `RemoteMemoryManager` when `fleet_coordinator_url` is configured.