### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix environment variable leakage to hook subprocesses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** A command injection vulnerability bypassing `shlex.quote` in `maxwell_daemon/hooks.py`. The `_substitute` method replaced dictionary key-values iteratively, so if an attacker's input value was evaluated after an input that referenced its template key, the attacker's payload would expand *outside* of the `shlex.quote` protection boundary.
 **Learning:** Sequential `.replace()` template engines introduce a secondary evaluation order risk. A payload may use recursion or sequential interpolation to bypass quoting mechanisms designed to sanitize the first pass.
 **Prevention:** Always parse and replace all template fields in a single execution pass (such as via `re.sub`), prohibiting interpolated template outputs from being re-evaluated.
+## 2024-05-20 - Prevent environment variable leakage to hook subprocesses
+**Vulnerability:** The `_env` function in `maxwell_daemon/hooks.py` was passing the entire `os.environ` to hook subprocesses, exposing host secrets (like `ANTHROPIC_API_KEY`) to LLM-controlled hooks.
+**Learning:** Subprocesses should run with a strictly filtered allowlist of environment variables to maintain the LLM execution sandbox.
+**Prevention:** Use an allowlist approach (like `_build_run_bash_env`) to only pass safe environment variables (PATH, HOME, etc.) to subprocesses.

--- a/maxwell_daemon/hooks.py
+++ b/maxwell_daemon/hooks.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import asyncio
 import fnmatch
 import json
-import os
 import shlex
 import subprocess
 from collections.abc import Awaitable, Callable
@@ -38,6 +37,7 @@ from typing import Any
 import yaml
 
 from maxwell_daemon.contracts import require
+from maxwell_daemon.tools.builtins import _build_run_bash_env
 
 __all__ = [
     "HookConfig",
@@ -331,7 +331,7 @@ def _env(
     tool_output: str | None,
 ) -> dict[str, str]:
     """Build the environment visible to a hook subprocess."""
-    env: dict[str, str] = dict(os.environ)
+    env: dict[str, str] = _build_run_bash_env()
     env["MAXWELL_TOOL_NAME"] = tool_name or ""
     env["MAXWELL_TOOL_INPUT"] = json.dumps(tool_input or {}, default=str)
     env["MAXWELL_TOOL_OUTPUT"] = tool_output or ""


### PR DESCRIPTION
* 🚨 Severity: CRITICAL
* 💡 Vulnerability: The `_env` function in `maxwell_daemon/hooks.py` was passing the entire `os.environ` to hook subprocesses, exposing host secrets (like `ANTHROPIC_API_KEY`) to LLM-controlled hooks.
* 🎯 Impact: An attacker who compromises a hook or manipulates an LLM to inject commands into a hook could access sensitive host environment variables, including API keys and credentials.
* 🔧 Fix: Replaced `dict(os.environ)` with `_build_run_bash_env()` to restrict the environment variables passed to subprocesses to a safe allowlist (e.g., PATH, HOME, LANG).
* ✅ Verification: Ran `pytest tests/unit/test_hooks.py` and `ruff check maxwell_daemon/hooks.py` to ensure the fix works correctly and follows linting rules. Added a journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1142489135549767586](https://jules.google.com/task/1142489135549767586) started by @dieterolson*