### PR TITLE
fix: Keep fallback text when deferred output runs

### DIFF
--- a/maxwell_daemon/api/ui/app.js
+++ b/maxwell_daemon/api/ui/app.js
@@ -621,11 +621,13 @@ function handleEvent(evt) {
     state.testOutput.set(p.task_id, (prev + (p.chunk || "")).slice(-64_000));
     if (p.task_id === state.selected) {
       if (!_testOutputRaf) {
+        const selectedAtSchedule = p.task_id;
         _testOutputRaf = requestAnimationFrame(() => {
           _testOutputRaf = null;
           const outEl = document.getElementById("detail-output");
-          if (outEl) {
-            outEl.textContent = state.testOutput.get(state.selected);
+          if (outEl && state.selected === selectedAtSchedule) {
+            outEl.textContent =
+              state.testOutput.get(selectedAtSchedule) || "(no streamed output)";
           }
         });
       }

--- a/tests/unit/test_web_ui.py
+++ b/tests/unit/test_web_ui.py
@@ -92,6 +92,16 @@ class TestHTMLContent:
         assert "openCommandPalette" in js
         assert "terminal-log" in js
 
+    def test_deferred_test_output_keeps_selected_task_context(
+        self, client: TestClient
+    ) -> None:
+        js = client.get("/ui/app.js").text
+
+        assert "const selectedAtSchedule = p.task_id;" in js
+        assert "state.selected === selectedAtSchedule" in js
+        assert 'state.testOutput.get(selectedAtSchedule) || "(no streamed output)"' in js
+        assert "state.testOutput.get(state.selected)" not in js
+
 
 class TestNewTaskDialog:
     def test_dialog_present(self, client: TestClient) -> None:


### PR DESCRIPTION
Closes #334