### PR TITLE
docs: add market assessment for agentic orchestrators

### DIFF
--- a/docs/development/planning/orchestrator_market_comparison.md
+++ b/docs/development/planning/orchestrator_market_comparison.md
@@ -1,0 +1,41 @@
+# Agentic Orchestrators: Market Assessment vs. Maxwell Daemon
+
+Based on the Gemini report analyzing the architecture of autonomous software engineering fleets, here is an evaluation of the enterprise market landscape compared to our **Maxwell Daemon**, specifically tailored for our target audience: the power home user and solo developer.
+
+## 1. Architectural Philosophy: Enterprise vs. "The Little Guy"
+
+The market report outlines an enterprise-grade future built on heavy, distributed infrastructure: **Kubernetes (KubeRay)** for orchestration, **Redis Streams** for messaging, and **Agent OS** for governance. 
+
+While powerful, this is the exact opposite of what the "power home user" wants. Our target user wants power without the DevOps overhead.
+
+**The Maxwell Daemon Advantage:**
+Maxwell Daemon provides the same orchestration capabilities but is designed as a **local-first, lightweight engine**. 
+* Instead of Redis and Kubernetes, we use **SQLite** (for durable ledgers, task queues, and artifacts) and **Python AsyncIO**.
+* Instead of complex cloud governance, we use local **AuditLoggers** with cryptographic hashing to ensure the user can trace every action their agent takes.
+* It runs natively on desktop hardware, allowing the user to utilize their own compute resources (like a local GPU) rather than paying for cloud hosting.
+
+## 2. Top Value-Added Features for the Power Home User
+
+If we want to empower the solo developer who juggles multiple AI vendor subscriptions, the following features from the report represent the highest ROI for Maxwell Daemon:
+
+### A. Universal Tooling via Model Context Protocol (MCP)
+**Why it matters:** A user with subscriptions to Claude, OpenAI, and a local Ollama instance does not want to write three different integration scripts to allow their agents to read their local files or query a database. 
+**The Feature:** Full adoption of **MCP** as the standard for tooling. MCP is the "USB-C of AI." By running a local MCP server, the user can expose their local development environment, smart home, or databases to *any* model Maxwell Daemon spins up. *(Note: Our recent test coverage shows we already have `maxwell_daemon/tools/mcp.py` in development, putting us ahead of the curve).*
+
+### B. Cost-Aware Routing and Local Execution (Hybrid Inference)
+**Why it matters:** Power users are cost-conscious. They want to use premium models (like Claude 3.5 Sonnet) for complex architectural planning, but want to use free, locally hosted models (like Llama 3 via Ollama) for routine refactoring or writing unit tests.
+**The Feature:** An intelligent routing layer. Maxwell Daemon's `dual_config` backend system already supports this. The most valuable addition is a **Cost-Control Dashboard** that automatically tracks `month_to_date_usd` (which we have endpoints for) and enforces budget limits per repository, automatically falling back to local models when the budget is reached.
+
+### C. Local CI/CD and Autonomous TDD Loops
+**Why it matters:** The report mentions "Spec-Driven Development" and agents writing failing tests before implementation. The solo developer doesn't have a QA team; they need the agent to verify its own work.
+**The Feature:** **Hermetic Validation Loops.** Maxwell Daemon should execute the user's local test suite (e.g., `pytest`, `cargo test`) in an isolated environment every time the agent modifies code. If the tests fail, the stdout/stderr is fed back to the agent to fix the code *before* it ever presents a Pull Request to the user. This ensures the user only reviews code that actually runs.
+
+### D. Token-Optimized Repository Context
+**Why it matters:** Dumping a whole codebase into an LLM context window burns through subscription limits instantly.
+**The Feature:** Implementing a **Tree-sitter based code mapper**. Instead of raw RAG (Retrieval-Augmented Generation), the daemon maps the repository into a skeletal structure (classes, method signatures, docstrings) and provides this index to the LLM. The LLM can then request specific function bodies via MCP tools. This dramatically reduces token consumption and API costs.
+
+## Summary: The Maxwell Daemon Positioning
+
+The market is building "Control Towers" for enterprise engineering teams. **Maxwell Daemon is building the "Iron Man Suit" for the solo developer.**
+
+By focusing on **local SQLite persistence, MCP tool interoperability, multi-backend cost routing, and local TDD validation loops**, Maxwell Daemon gives the little guy the capabilities of a distributed enterprise agent fleet, but optimized for cost control, privacy, and frictionless local hosting.


### PR DESCRIPTION
This PR introduces a new directory docs/development/planning/ for project planning and evaluation documents. It includes the initial market assessment comparing enterprise orchestrators to the Maxwell Daemon project, highlighting key features for the target solo developer audience (MCP, Cost Routing, TDD loops, Token Context).