### PR TITLE
chore: preserve ratcheting coverage threshold

### DIFF
--- a/scripts/config/coverage_floor.json
+++ b/scripts/config/coverage_floor.json
@@ -1,3 +1,3 @@
 {
-  "floor_percent": 90.50
+  "floor_percent": 91.26
 }


### PR DESCRIPTION
Resolves Issue #343. Restored the coverage floor to 91.26 to prevent CI quality gate weakening.