### PR TITLE
🎨 Palette: Add keyboard navigation to command palette

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Keyboard Navigation for Command Palette
+**Learning:** Adding `keydown` listeners for `ArrowUp`/`ArrowDown` coupled with `element.focus()` and `:focus-visible` styles is an effective pattern for building accessible, keyboard-navigable list widgets like command palettes in vanilla JS.
+**Action:** Always check if custom drop-downs, search result lists, or palettes support arrow key navigation. If not, implement standard WAI-ARIA keyboard interaction patterns to allow power users and screen-reader users to interact smoothly.

--- a/maxwell_daemon/api/ui/app.js
+++ b/maxwell_daemon/api/ui/app.js
@@ -1163,10 +1163,40 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("command-palette-input").addEventListener("input", (ev) => {
     renderCommandPalette(ev.target.value);
   });
+
+  document.getElementById("command-palette-input").addEventListener("keydown", (ev) => {
+    if (ev.key === "ArrowDown") {
+      ev.preventDefault();
+      const first = document.querySelector("#command-palette-results button[data-command]");
+      if (first) first.focus();
+    }
+  });
+
+  document.getElementById("command-palette-results").addEventListener("keydown", (ev) => {
+    if (ev.key === "ArrowDown") {
+      ev.preventDefault();
+      const next = ev.target.parentElement.nextElementSibling?.querySelector("button");
+      if (next) next.focus();
+    } else if (ev.key === "ArrowUp") {
+      ev.preventDefault();
+      const prev = ev.target.parentElement.previousElementSibling?.querySelector("button");
+      if (prev) {
+        prev.focus();
+      } else {
+        document.getElementById("command-palette-input").focus();
+      }
+    }
+  });
+
   document.getElementById("command-palette-form").addEventListener("submit", (ev) => {
     ev.preventDefault();
-    const first = document.querySelector("#command-palette-results button[data-command]");
-    if (first) runCommand(first.dataset.command);
+    const active = document.activeElement;
+    if (active && active.dataset.command) {
+        runCommand(active.dataset.command);
+    } else {
+        const first = document.querySelector("#command-palette-results button[data-command]");
+        if (first) runCommand(first.dataset.command);
+    }
   });
 
   // Keyboard shortcut: digit keys switch primary tabs

--- a/maxwell_daemon/api/ui/style.css
+++ b/maxwell_daemon/api/ui/style.css
@@ -283,16 +283,25 @@ button {
   cursor: pointer;
 }
 button:hover { background: var(--border); }
+button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 button.cancel { color: var(--err); }
 
 input,
-select {
+select,
+textarea {
   background: var(--panel-alt);
   color: var(--text);
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 4px 8px;
   font: inherit;
+}
+
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
 }
 
 .status-bar {


### PR DESCRIPTION
💡 What: Added `keydown` event listeners to the command palette input and results to support `ArrowDown` and `ArrowUp` navigation, and updated `style.css` to add `:focus-visible` styles for `button`, `input`, `select`, and `textarea`.

🎯 Why: To make the command palette accessible and usable via keyboard shortcuts, improving the overall developer experience and usability for power users.

♿ Accessibility: Added proper focus rings (`:focus-visible`) for all interactive elements globally to make keyboard navigation explicit and visible, and allowed complete non-mouse interaction with the core command palette workflow.

---
*PR created automatically by Jules for task [5495023041004605902](https://jules.google.com/task/5495023041004605902) started by @dieterolson*