### PR TITLE
⚡ Bolt: Prevent redundant API requests for unselected tasks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-10-24 - Layout Thrashing on WebSocket Event Streams
 **Learning:** Synchronous layout thrashing from rapidly updating DOM properties like `el.scrollTop = el.scrollHeight` and `el.textContent` during rapid WebSocket event streams causes severe UI lag and blocks the main thread.
 **Action:** Always use `requestAnimationFrame` to batch visual DOM manipulations (especially layout triggers like `scrollHeight`) resulting from rapid event streams, ensuring at most one layout calculation per visual frame.
+
+## 2024-10-25 - Redundant Data Fetching on Event Streams
+**Learning:** Fetching heavy detailed state for a resource (e.g. `fetchTaskDetail`) on every background event for that resource—regardless of whether it's currently visible in the UI—causes redundant API requests and wasteful re-renders. A global list fetch often handles the high-level status updates needed for hidden resources.
+**Action:** Always verify if a resource is actively being viewed (e.g. `state.selected === id`) before firing off detailed fetch operations in response to background event streams.

--- a/maxwell_daemon/api/ui/app.js
+++ b/maxwell_daemon/api/ui/app.js
@@ -1084,12 +1084,16 @@ function handleEvent(evt) {
     return;
   }
   if (p.id) {
-    // Debounce detail fetch per task ID
-    clearTimeout(_fetchTaskDetailTimers.get(p.id));
-    _fetchTaskDetailTimers.set(
-      p.id,
-      setTimeout(() => fetchTaskDetail(p.id).catch(() => {}), 300)
-    );
+    // ⚡ Bolt: Only fetch detailed task updates for the task actively being viewed.
+    // If a task is not selected, we don't need its heavy detailed state fetched
+    // on every event (the global tasks list fetch handles high-level status).
+    if (state.selected === p.id) {
+      clearTimeout(_fetchTaskDetailTimers.get(p.id));
+      _fetchTaskDetailTimers.set(
+        p.id,
+        setTimeout(() => fetchTaskDetail(p.id).catch(() => {}), 300)
+      );
+    }
 
     // Debounce global tasks list fetch
     clearTimeout(_fetchTasksTimer);


### PR DESCRIPTION
💡 What: Only fetch task details via `fetchTaskDetail()` on backend event updates if the target task is the currently selected task.
🎯 Why: Rapid event streams updating tasks not actively being viewed were triggering redundant API requests and wasteful re-renders. The global task list handles high-level status updates perfectly fine for hidden tasks.
📊 Impact: Reduces UI component updates, memory spikes, and API calls during flurry of background agent updates for tasks that are currently hidden.
🔬 Measurement: Verify by watching browser network calls during event stream with many background tasks being executed vs one being selected.

---
*PR created automatically by Jules for task [15841460615666632602](https://jules.google.com/task/15841460615666632602) started by @dieterolson*