### PR TITLE
fix: retire PyQt launcher stub and publish backend catalog

### DIFF
--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -60,7 +60,7 @@ The schema includes these route families:
 
 - Health and readiness: `/health`, `/readyz`
 - Auth and RBAC identity: `/api/v1/auth/token`, `/api/v1/auth/me`
-- Backends and task execution: `/api/v1/backends`, `/api/v1/tasks`
+- Backends and task execution: `/api/v1/backends`, `/api/v1/backends/available`, `/api/v1/tasks`
 - Gate control plane: `/api/v1/control-plane/gauntlet`
 - Actions, work items, task graphs, and artifacts
 - Issue dispatch and batch dispatch
@@ -91,6 +91,7 @@ This inventory is checked against `create_app(...).openapi()` by `tests/unit/tes
 | `/api/v1/auth/me` | `GET` | Auth |
 | `/api/v1/auth/token` | `POST` | Auth |
 | `/api/v1/backends` | `GET` | Backends |
+| `/api/v1/backends/available` | `GET` | Backends |
 | `/api/v1/control-plane/gauntlet` | `GET` | Gate runtime |
 | `/api/v1/control-plane/gauntlet/{task_id}/cancel` | `POST` | Gate runtime |
 | `/api/v1/control-plane/gauntlet/{task_id}/retry` | `POST` | Gate runtime |

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -3,6 +3,7 @@
 Endpoints (v1):
     GET  /health
     GET  /api/v1/backends
+    GET  /api/v1/backends/available
     POST /api/v1/tasks           — submit a task
     GET  /api/v1/tasks           — list tasks
     GET  /api/v1/tasks/{id}      — fetch a task
@@ -38,6 +39,7 @@ from pydantic import BaseModel, Field, field_validator
 from maxwell_daemon import __version__
 from maxwell_daemon.audit import AuditLogger
 from maxwell_daemon.auth import JWTConfig, Role
+from maxwell_daemon.backends import BackendManifest, registry
 from maxwell_daemon.core.actions import Action, ActionStatus
 from maxwell_daemon.core.artifacts import Artifact, ArtifactIntegrityError, ArtifactKind
 from maxwell_daemon.core.delegate_lifecycle import DelegateSessionSnapshot, DelegateSessionStatus
@@ -420,6 +422,51 @@ class TaskView(BaseModel):
             started_at=t.started_at,
             finished_at=t.finished_at,
         )
+
+
+class BackendCatalogEntryView(BaseModel):
+    name: str
+    display_name: str
+    description: str
+    requires_api_key: bool
+    local_only: bool
+    default_endpoint: str | None = None
+    api_key_env_var: str | None = None
+    endpoint_env_var: str | None = None
+    install_extra: str | None = None
+    command: str | None = None
+    configured_aliases: tuple[str, ...] = ()
+    loaded: bool
+    connected: bool
+
+    @classmethod
+    def from_manifest(
+        cls,
+        manifest: BackendManifest,
+        *,
+        configured_aliases: tuple[str, ...],
+        loaded: bool,
+        connected: bool,
+    ) -> BackendCatalogEntryView:
+        return cls(
+            name=manifest.name,
+            display_name=manifest.display_name,
+            description=manifest.description,
+            requires_api_key=manifest.requires_api_key,
+            local_only=manifest.local_only,
+            default_endpoint=manifest.default_endpoint,
+            api_key_env_var=manifest.api_key_env_var,
+            endpoint_env_var=manifest.endpoint_env_var,
+            install_extra=manifest.install_extra,
+            command=manifest.command,
+            configured_aliases=configured_aliases,
+            loaded=loaded,
+            connected=connected,
+        )
+
+
+class BackendCatalogResponse(BaseModel):
+    backends: tuple[BackendCatalogEntryView, ...]
 
 
 class GateTimelineEntry(BaseModel):
@@ -1119,6 +1166,32 @@ def create_app(
     @app.get("/api/v1/backends", dependencies=[Depends(_require_viewer())])
     async def list_backends() -> dict[str, Any]:
         return {"backends": daemon.state().backends_available}
+
+    @app.get(
+        "/api/v1/backends/available",
+        dependencies=[Depends(_require_viewer())],
+        response_model=BackendCatalogResponse,
+    )
+    async def list_available_backends() -> BackendCatalogResponse:
+        configured_aliases_by_type: dict[str, list[str]] = {}
+        for alias, backend_cfg in daemon._config.backends.items():
+            configured_aliases_by_type.setdefault(backend_cfg.type, []).append(alias)
+
+        connected_aliases = set(daemon.state().backends_available)
+        loaded_backend_types = set(registry.available())
+        catalog = tuple(
+            BackendCatalogEntryView.from_manifest(
+                manifest,
+                configured_aliases=tuple(sorted(configured_aliases_by_type.get(manifest.name, ()))),
+                loaded=manifest.name in loaded_backend_types,
+                connected=any(
+                    alias in connected_aliases
+                    for alias in configured_aliases_by_type.get(manifest.name, ())
+                ),
+            )
+            for manifest in registry.catalog()
+        )
+        return BackendCatalogResponse(backends=catalog)
 
     @app.post(
         "/api/v1/tasks",

--- a/maxwell_daemon/backends/__init__.py
+++ b/maxwell_daemon/backends/__init__.py
@@ -13,11 +13,12 @@ from maxwell_daemon.backends.base import (
     MessageRole,
     TokenUsage,
 )
-from maxwell_daemon.backends.registry import BackendRegistry, registry
+from maxwell_daemon.backends.registry import BackendManifest, BackendRegistry, registry
 
 __all__ = [
     "BackendCapabilities",
     "BackendError",
+    "BackendManifest",
     "BackendRegistry",
     "BackendResponse",
     "BackendUnavailableError",

--- a/maxwell_daemon/backends/registry.py
+++ b/maxwell_daemon/backends/registry.py
@@ -9,23 +9,122 @@ from __future__ import annotations
 
 import importlib
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 from maxwell_daemon.backends.base import BackendError, ILLMBackend
 
 log = logging.getLogger(__name__)
 
-_BUILTIN_BACKENDS = (
-    "claude",
-    "openai",
-    "azure",
-    "ollama",
-    "claude_code",
-    "codex_cli",
-    "continue_cli",
-    "jules_cli",
-    "agent_loop",
+
+@dataclass(frozen=True, slots=True)
+class BackendManifest:
+    module_name: str | None
+    name: str
+    display_name: str
+    description: str
+    requires_api_key: bool
+    local_only: bool
+    default_endpoint: str | None = None
+    api_key_env_var: str | None = None
+    endpoint_env_var: str | None = None
+    install_extra: str | None = None
+    command: str | None = None
+
+
+_BUILTIN_MANIFESTS = (
+    BackendManifest(
+        module_name="claude",
+        name="claude",
+        display_name="Anthropic Claude",
+        description="Anthropic-hosted Claude models over the public API.",
+        requires_api_key=True,
+        local_only=False,
+        api_key_env_var="ANTHROPIC_API_KEY",
+    ),
+    BackendManifest(
+        module_name="openai",
+        name="openai",
+        display_name="OpenAI",
+        description="OpenAI-hosted models or OpenAI-compatible endpoints.",
+        requires_api_key=True,
+        local_only=False,
+        api_key_env_var="OPENAI_API_KEY",
+    ),
+    BackendManifest(
+        module_name="azure",
+        name="azure",
+        display_name="Azure OpenAI",
+        description="Azure OpenAI deployments with endpoint and key configuration.",
+        requires_api_key=True,
+        local_only=False,
+        api_key_env_var="AZURE_OPENAI_API_KEY",
+        endpoint_env_var="AZURE_OPENAI_ENDPOINT",
+        install_extra="azure",
+    ),
+    BackendManifest(
+        module_name="ollama",
+        name="ollama",
+        display_name="Ollama",
+        description="Local Ollama inference over the default localhost HTTP API.",
+        requires_api_key=False,
+        local_only=True,
+        default_endpoint="http://localhost:11434",
+        endpoint_env_var="OLLAMA_HOST",
+        install_extra="ollama",
+    ),
+    BackendManifest(
+        module_name="claude_code",
+        name="claude-code-cli",
+        display_name="Claude Code CLI",
+        description="Local Claude Code executable using the caller's existing Claude account.",
+        requires_api_key=False,
+        local_only=False,
+        command="claude",
+    ),
+    BackendManifest(
+        module_name="codex_cli",
+        name="codex-cli",
+        display_name="Codex CLI",
+        description="Local Codex executable using the caller's existing OpenAI account.",
+        requires_api_key=False,
+        local_only=False,
+        command="codex",
+    ),
+    BackendManifest(
+        module_name="continue_cli",
+        name="continue-cli",
+        display_name="Continue CLI",
+        description="Local Continue executable wired through the user's existing Continue setup.",
+        requires_api_key=False,
+        local_only=False,
+        command="continue",
+    ),
+    BackendManifest(
+        module_name="jules_cli",
+        name="jules-cli",
+        display_name="Jules CLI",
+        description="Local Jules executable using the caller's existing Jules installation.",
+        requires_api_key=False,
+        local_only=False,
+        command="jules",
+    ),
+    BackendManifest(
+        module_name="agent_loop",
+        name="agent-loop",
+        display_name="Anthropic Agent Loop",
+        description="Anthropic tool-use loop backend for multi-step autonomous work.",
+        requires_api_key=True,
+        local_only=False,
+        api_key_env_var="ANTHROPIC_API_KEY",
+    ),
 )
+_BUILTIN_MANIFESTS_BY_NAME = {manifest.name: manifest for manifest in _BUILTIN_MANIFESTS}
+
+
+def _display_name_for_runtime_backend(name: str) -> str:
+    display = name.replace("-", " ").replace("_", " ").title()
+    return display.replace("Api", "API").replace("Cli", "CLI").replace("Mcp", "MCP")
 
 
 class BackendRegistry:
@@ -48,16 +147,35 @@ class BackendRegistry:
     def available(self) -> list[str]:
         return sorted(self._factories)
 
+    def catalog(self) -> list[BackendManifest]:
+        manifests = list(_BUILTIN_MANIFESTS)
+        for name in sorted(self._factories):
+            if name in _BUILTIN_MANIFESTS_BY_NAME:
+                continue
+            manifests.append(
+                BackendManifest(
+                    module_name=None,
+                    name=name,
+                    display_name=_display_name_for_runtime_backend(name),
+                    description="Runtime-registered backend.",
+                    requires_api_key=False,
+                    local_only=False,
+                )
+            )
+        return manifests
+
 
 registry = BackendRegistry()
 
 
 def _autoload() -> None:
-    for name in _BUILTIN_BACKENDS:
+    for manifest in _BUILTIN_MANIFESTS:
+        if manifest.module_name is None:
+            continue
         try:
-            importlib.import_module(f"maxwell_daemon.backends.{name}")
+            importlib.import_module(f"maxwell_daemon.backends.{manifest.module_name}")
         except ImportError as e:
-            log.debug("backend %r not loaded (missing SDK): %s", name, e)
+            log.debug("backend %r not loaded (missing SDK): %s", manifest.name, e)
 
 
 _autoload()

--- a/maxwell_daemon/launcher.py
+++ b/maxwell_daemon/launcher.py
@@ -12,10 +12,14 @@ import argparse
 import os
 import subprocess
 import sys
+import threading
+import time
 import venv
-from collections.abc import Sequence
+import webbrowser
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from urllib import error, parse, request
 
 
 @dataclass(frozen=True, slots=True)
@@ -28,6 +32,7 @@ class LauncherPlan:
     doctor_args: tuple[str, ...]
     serve_args: tuple[str, ...]
     config_path: Path
+    ui_url: str
 
 
 def _venv_python(venv_path: Path) -> Path:
@@ -87,6 +92,7 @@ def build_plan(
             str(port),
         ),
         config_path=config,
+        ui_url=f"http://127.0.0.1:{port}/ui/",
     )
 
 
@@ -119,7 +125,41 @@ def ensure_venv(plan: LauncherPlan) -> None:
     builder.create(plan.venv_path)
 
 
-def execute_plan(plan: LauncherPlan, *, skip_install: bool = False) -> None:
+def _open_dashboard_when_ready(
+    ui_url: str,
+    *,
+    opener: Callable[[str], bool] = webbrowser.open_new_tab,
+    attempts: int = 40,
+    delay_seconds: float = 0.25,
+) -> None:
+    parsed = parse.urlparse(ui_url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Unsafe URL scheme: {parsed.scheme}")
+
+    for _ in range(attempts):
+        try:
+            with request.urlopen(ui_url, timeout=0.5) as _:  # nosec B310
+                opener(ui_url)
+                return
+        except (error.URLError, TimeoutError, OSError):
+            time.sleep(delay_seconds)
+
+
+def _launch_dashboard_thread(plan: LauncherPlan) -> None:
+    threading.Thread(
+        target=_open_dashboard_when_ready,
+        args=(plan.ui_url,),
+        daemon=True,
+        name="maxwell-dashboard-launcher",
+    ).start()
+
+
+def execute_plan(
+    plan: LauncherPlan,
+    *,
+    skip_install: bool = False,
+    open_browser: bool = True,
+) -> None:
     ensure_venv(plan)
     if not skip_install:
         _run(plan.install_args, cwd=plan.repo_root)
@@ -127,6 +167,8 @@ def execute_plan(plan: LauncherPlan, *, skip_install: bool = False) -> None:
         plan.config_path.parent.mkdir(parents=True, exist_ok=True)
         _run(plan.init_args, cwd=plan.repo_root)
     _run(plan.doctor_args, cwd=plan.repo_root)
+    if open_browser:
+        _launch_dashboard_thread(plan)
     _run(plan.serve_args, cwd=plan.repo_root)
 
 
@@ -142,6 +184,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--port", type=int, default=8080, help="API port for maxwell-daemon serve.")
     parser.add_argument("--dev", action="store_true", help="Install developer extras.")
     parser.add_argument("--skip-install", action="store_true", help="Skip pip install.")
+    parser.add_argument(
+        "--no-open-browser",
+        action="store_true",
+        help="Do not open the canonical /ui/ dashboard in a browser.",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Print the launch plan and exit.")
     args = parser.parse_args(argv)
 
@@ -159,9 +206,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"init={' '.join(plan.init_args)}")
         print(f"doctor={' '.join(plan.doctor_args)}")
         print(f"serve={' '.join(plan.serve_args)}")
+        print(f"ui={plan.ui_url}")
         return 0
 
-    execute_plan(plan, skip_install=args.skip_install)
+    execute_plan(plan, skip_install=args.skip_install, open_browser=not args.no_open_browser)
     return 0
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ google = ["google-cloud-aiplatform>=1.70.0"]
 azure = ["azure-identity>=1.18.0"]
 grpc = ["grpcio>=1.66.0", "grpcio-tools>=1.66.0", "protobuf>=5.28.0"]
 ssh = ["asyncssh>=2.14.0"]
-desktop = ["PyQt6>=6.7.0"]
 browser = ["playwright>=1.45.0"]
 docs = [
     "mkdocs>=1.6.0",
@@ -67,7 +66,7 @@ dev = [
     "tomli>=2.0.0",
     "types-pyyaml",
 ]
-all = ["maxwell-daemon[ollama,google,azure,grpc,ssh,desktop,browser,dev]"]
+all = ["maxwell-daemon[ollama,google,azure,grpc,ssh,browser,dev]"]
 
 [project.scripts]
 maxwell-daemon = "maxwell_daemon.cli.main:app"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Iterator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +13,15 @@ import pytest
 from fastapi.testclient import TestClient
 
 from maxwell_daemon.api import create_app
+from maxwell_daemon.api import server as api_server
+from maxwell_daemon.backends import (
+    BackendCapabilities,
+    BackendRegistry,
+    BackendResponse,
+    ILLMBackend,
+    Message,
+    TokenUsage,
+)
 from maxwell_daemon.config import MaxwellDaemonConfig
 from maxwell_daemon.core.actions import ActionKind
 from maxwell_daemon.core.artifacts import ArtifactKind
@@ -107,6 +116,75 @@ class TestBackends:
         r = client.get("/api/v1/backends")
         assert r.status_code == 200
         assert "primary" in r.json()["backends"]
+
+    def test_available_returns_backend_catalog_for_onboarding(
+        self,
+        client: TestClient,
+        daemon: Daemon,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class CatalogBackend(ILLMBackend):
+            async def complete(
+                self,
+                messages: list[Message],
+                *,
+                model: str,
+                **_: Any,
+            ) -> BackendResponse:
+                return BackendResponse(
+                    content="ok",
+                    finish_reason="stop",
+                    usage=TokenUsage(total_tokens=1),
+                    model=model,
+                    backend="catalog-test",
+                )
+
+            async def stream(
+                self,
+                messages: list[Message],
+                *,
+                model: str,
+                **_: Any,
+            ) -> AsyncIterator[str]:
+                if False:
+                    yield model
+
+            async def health_check(self) -> bool:
+                return True
+
+            def capabilities(self, model: str) -> BackendCapabilities:
+                return BackendCapabilities()
+
+        daemon._config = MaxwellDaemonConfig.model_validate(
+            {
+                "backends": {
+                    "cloud": {"type": "claude", "model": "claude-sonnet-4-6"},
+                    "local": {"type": "ollama", "model": "llama3.2"},
+                },
+                "agent": {"default_backend": "cloud"},
+            }
+        )
+        fake_registry = BackendRegistry()
+        fake_registry.register("claude", CatalogBackend)
+        fake_registry.register("ollama", CatalogBackend)
+        monkeypatch.setattr(api_server, "registry", fake_registry)
+        monkeypatch.setattr(daemon, "state", lambda: SimpleNamespace(backends_available=["cloud"]))
+
+        response = client.get("/api/v1/backends/available")
+
+        assert response.status_code == 200
+        catalog = {item["name"]: item for item in response.json()["backends"]}
+        assert catalog["claude"]["configured_aliases"] == ["cloud"]
+        assert catalog["claude"]["loaded"] is True
+        assert catalog["claude"]["connected"] is True
+        assert catalog["claude"]["api_key_env_var"] == "ANTHROPIC_API_KEY"
+        assert catalog["ollama"]["configured_aliases"] == ["local"]
+        assert catalog["ollama"]["loaded"] is True
+        assert catalog["ollama"]["connected"] is False
+        assert catalog["ollama"]["default_endpoint"] == "http://localhost:11434"
+        assert catalog["openai"]["configured_aliases"] == []
+        assert catalog["openai"]["loaded"] is False
+        assert catalog["openai"]["connected"] is False
 
 
 class TestTaskSubmission:

--- a/tests/unit/test_backends.py
+++ b/tests/unit/test_backends.py
@@ -14,6 +14,7 @@ import pytest
 from maxwell_daemon.backends import (
     BackendCapabilities,
     BackendError,
+    BackendManifest,
     BackendRegistry,
     BackendResponse,
     ILLMBackend,
@@ -108,6 +109,48 @@ class TestBackendRegistry:
         reg.register("zulu", FakeBackend)
         reg.register("alpha", FakeBackend)
         assert reg.available() == ["alpha", "zulu"]
+
+    def test_catalog_includes_builtin_manifest_metadata(self) -> None:
+        reg = BackendRegistry()
+
+        catalog = {entry.name: entry for entry in reg.catalog()}
+
+        assert catalog["claude"] == BackendManifest(
+            module_name="claude",
+            name="claude",
+            display_name="Anthropic Claude",
+            description="Anthropic-hosted Claude models over the public API.",
+            requires_api_key=True,
+            local_only=False,
+            default_endpoint=None,
+            api_key_env_var="ANTHROPIC_API_KEY",
+            endpoint_env_var=None,
+            install_extra=None,
+            command=None,
+        )
+        assert catalog["ollama"].local_only is True
+        assert catalog["ollama"].default_endpoint == "http://localhost:11434"
+        assert catalog["codex-cli"].command == "codex"
+
+    def test_catalog_appends_runtime_registered_backends(self) -> None:
+        reg = BackendRegistry()
+        reg.register("custom-backend", FakeBackend)
+
+        catalog = {entry.name: entry for entry in reg.catalog()}
+
+        assert catalog["custom-backend"] == BackendManifest(
+            module_name=None,
+            name="custom-backend",
+            display_name="Custom Backend",
+            description="Runtime-registered backend.",
+            requires_api_key=False,
+            local_only=False,
+            default_endpoint=None,
+            api_key_env_var=None,
+            endpoint_env_var=None,
+            install_extra=None,
+            command=None,
+        )
 
 
 class TestCostEstimation:

--- a/tests/unit/test_launcher.py
+++ b/tests/unit/test_launcher.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from maxwell_daemon.launcher import _subprocess_env, build_plan, default_config_path
+from maxwell_daemon.launcher import (
+    _open_dashboard_when_ready,
+    _subprocess_env,
+    build_plan,
+    default_config_path,
+    execute_plan,
+)
 
 
 def test_runtime_install_is_default(tmp_path: Path) -> None:
@@ -38,6 +44,7 @@ def test_plan_runs_doctor_before_serve(tmp_path: Path) -> None:
     assert plan.init_args[-2:] == ("--path", str(config))
     assert plan.doctor_args[-2:] == ("--config", str(config))
     assert plan.serve_args[-4:] == ("--config", str(config), "--port", "9090")
+    assert plan.ui_url == "http://127.0.0.1:9090/ui/"
 
 
 def test_default_config_path_is_platform_specific() -> None:
@@ -53,6 +60,56 @@ def test_root_wrappers_delegate_to_python_launcher() -> None:
     assert "maxwell_daemon.launcher" in (repo / "Launch-Maxwell.bat").read_text()
     assert "maxwell_daemon.launcher" in (repo / "Launch-Maxwell.sh").read_text()
     assert "maxwell_daemon.launcher" in (repo / "Launch-Maxwell.command").read_text()
+
+
+def test_open_dashboard_when_ready_uses_browser_opener(monkeypatch) -> None:
+    opened: list[str] = []
+
+    class _Response:
+        def __enter__(self) -> _Response:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "maxwell_daemon.launcher.request.urlopen", lambda *args, **kwargs: _Response()
+    )
+
+    _open_dashboard_when_ready(
+        "http://127.0.0.1:8080/ui/",
+        opener=opened.append,
+        attempts=1,
+        delay_seconds=0,
+    )
+
+    assert opened == ["http://127.0.0.1:8080/ui/"]
+
+
+def test_execute_plan_can_skip_browser_open(monkeypatch, tmp_path: Path) -> None:
+    plan = build_plan(repo_root=tmp_path)
+    calls: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr("maxwell_daemon.launcher.ensure_venv", lambda _plan: None)
+    monkeypatch.setattr(
+        "maxwell_daemon.launcher._launch_dashboard_thread", lambda _plan: calls.append(("browser",))
+    )
+    monkeypatch.setattr(
+        "maxwell_daemon.launcher._run", lambda args, *, cwd: calls.append(tuple(args))
+    )
+
+    execute_plan(plan, skip_install=True, open_browser=False)
+
+    assert ("browser",) not in calls
+    assert plan.doctor_args in calls
+    assert plan.serve_args in calls
+
+
+def test_pyproject_no_longer_advertises_pyqt_desktop_extra() -> None:
+    pyproject = Path("pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'desktop = ["PyQt6>=6.7.0"]' not in pyproject
+    assert "PyQt6>=" not in pyproject
 
 
 def test_launcher_subprocess_env_defaults_to_utf8(monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1542,7 +1542,6 @@ all = [
     { name = "opentelemetry-sdk" },
     { name = "playwright" },
     { name = "protobuf" },
-    { name = "pyqt6" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1557,9 +1556,6 @@ azure = [
 ]
 browser = [
     { name = "playwright" },
-]
-desktop = [
-    { name = "pyqt6" },
 ]
 dev = [
     { name = "mypy" },
@@ -1604,7 +1600,7 @@ requires-dist = [
     { name = "grpcio-tools", marker = "extra == 'grpc'", specifier = ">=1.66.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "keyring", specifier = ">=25.0.0" },
-    { name = "maxwell-daemon", extras = ["ollama", "google", "azure", "grpc", "ssh", "desktop", "browser", "dev"], marker = "extra == 'all'" },
+    { name = "maxwell-daemon", extras = ["ollama", "google", "azure", "grpc", "ssh", "browser", "dev"], marker = "extra == 'all'" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
@@ -1618,7 +1614,6 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.0" },
-    { name = "pyqt6", marker = "extra == 'desktop'", specifier = ">=6.7.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1636,7 +1631,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.45.0" },
     { name = "websockets", specifier = ">=13.0" },
 ]
-provides-extras = ["ollama", "google", "azure", "grpc", "ssh", "desktop", "browser", "docs", "dev", "all"]
+provides-extras = ["ollama", "google", "azure", "grpc", "ssh", "browser", "docs", "dev", "all"]
 
 [[package]]
 name = "mdurl"
@@ -2223,68 +2218,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
-]
-
-[[package]]
-name = "pyqt6"
-version = "6.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyqt6-qt6" },
-    { name = "pyqt6-sip" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/47/b25c13eca5bebc6505394d0223e46d7ebf0c57dcac2ed908d7d19b18ab6b/pyqt6-6.11.0.tar.gz", hash = "sha256:45dd60aa69976de1918b5ced6b4e7b6a25abd2a919ecef5fd5826ecc76718889", size = 1087430, upload-time = "2026-03-30T09:16:13.543Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/44/fcd3dd3f64c83c96bf9bce76ec16cca64bd9b91702c3d08fd8e3dafc73d9/pyqt6-6.11.0-cp310-abi3-macosx_10_14_universal2.whl", hash = "sha256:f7100bc7f72b12581ec479a733f4ad11b8002668e6786e8a445ab6f4d1c743d4", size = 12429735, upload-time = "2026-03-30T09:16:03.713Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/a0/bd1399740dfa80c0a94d20b02d89962a31458233dcf70eaa09bfbccf3d0f/pyqt6-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8555277989fa7d114cb3c3443fd261d566909f7268ceedd41d93a5f02d37ec05", size = 8334632, upload-time = "2026-03-30T09:16:06.066Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/db/425b184ac2430ba1978bb507ffd285ec007a872644e2ae5df13332dbcb05/pyqt6-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:0734959955adde095af9a074213a7f73386d1bbbddfc27346b4c0621641a692e", size = 8321484, upload-time = "2026-03-30T09:16:08.135Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/85/dd9f03d78d87460e109e0121cd6201c5802bdd655656bf2780e964870fea/pyqt6-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:bd11b459c54dca068e988a42cf838303334f0d441b9d16d92ae6719fcb5ac6ba", size = 6844358, upload-time = "2026-03-30T09:16:09.766Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/75/970b041bde4372cc6739c5ef9db1de83a6b36e788e4992e598baa35b2255/pyqt6-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:b6324e3501b19b4292c7a55b1f22e82d3e80e519e383ce4fe79b4a754c6f0288", size = 5933984, upload-time = "2026-03-30T09:16:11.817Z" },
-]
-
-[[package]]
-name = "pyqt6-qt6"
-version = "6.11.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/5e/9e65b87ba746bb3a2ee81d6f3b2a8a7a4dfc33335c0a6afa15e8621e5fe9/pyqt6_qt6-6.11.0-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:447b04baf9bfd800410dc6a3b6faf24a2b754bd6e1c5d0dc609e6935362828f3", size = 70238920, upload-time = "2026-03-24T15:01:22.753Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b2/a15f88a0d9f550b9581592f79fb64b827ab3d3343cbb2af05912e6c77d26/pyqt6_qt6-6.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b510d0cb8f4d3f4306b6ff33a63234139c9c87c160909d3853e4deb1094782c2", size = 64036460, upload-time = "2026-03-24T15:01:42.951Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/f9/99696e6b2325ae54868111f581c59a8a6283b8f21bc931837f49093bc582/pyqt6_qt6-6.11.0-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:c2c3a14714536256a9fd761a8ac8e030dfed7b991200a220ca79d399fcc3d265", size = 85757517, upload-time = "2026-03-24T15:02:11.86Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/3c/a420d08723d4ab1998afead3e6f643333e93a9eadfde3486bdec25acfff0/pyqt6_qt6-6.11.0-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:acc5b78d7f718a5642f14b37928e074b048751cc86edb4c539e4425bfbd26827", size = 84854032, upload-time = "2026-03-24T15:03:26.991Z" },
-    { url = "https://files.pythonhosted.org/packages/36/cd/da0147d331b44587a7214c7f59719ac4f8e9433b268016962b02067007d1/pyqt6_qt6-6.11.0-py3-none-win_amd64.whl", hash = "sha256:b0e42629cef2575f2178aaeb32b0e539291df869f91f4df48983da3ccaad05af", size = 78309473, upload-time = "2026-03-24T15:03:53.396Z" },
-    { url = "https://files.pythonhosted.org/packages/72/9a/8d09ca47a61c2504b49e16c97ccde99b120ceec323d97f7ca776f8331213/pyqt6_qt6-6.11.0-py3-none-win_arm64.whl", hash = "sha256:bcfa594171408319935c25afc7f82a3ae3ba90678ea194631bbca1c6f68daa6d", size = 59848654, upload-time = "2026-03-24T15:04:18.117Z" },
-]
-
-[[package]]
-name = "pyqt6-sip"
-version = "13.11.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/24/a753e1af94b9ae5b2da63d4598457308da3cdbf0838c959381db086ccc86/pyqt6_sip-13.11.1.tar.gz", hash = "sha256:869c5b48afe38e55b1ee0dd72182b0886e968cc509b98023ff50010b013ce1be", size = 92574, upload-time = "2026-03-09T13:01:35.418Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/5b/99ffdc6382fcd3bc9da24a024ce2ba61e93c9d92ca85f99f381f2e2c8cac/pyqt6_sip-13.11.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a2456a8a68de43f400ffd13f7f8728713434ded374e45fa7754afb9e087b2421", size = 110999, upload-time = "2026-03-09T13:01:01.107Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ed/1dbe26f5757ad19601b260cebba0b40c0d868639e3253b26f80e8a1cd9f8/pyqt6_sip-13.11.1-cp310-cp310-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7a1b08421967e68a821d3ea97fcdc8413671aec817a0dc46b844ab4bb2ebab66", size = 280567, upload-time = "2026-03-09T13:01:04.616Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/30/cded90fa556be3f6836c44bab5dd06b47664a20ffb47e7fdfa9538d7c5db/pyqt6_sip-13.11.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd8be768799be1a29857ea0125b1d365021a8a014c1d746f0df6b7ba0400edef", size = 304088, upload-time = "2026-03-09T13:01:02.89Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/bb/05665db5d674c557562ec47e5703823e37c4bc943f7b3466c730a0fdeb15/pyqt6_sip-13.11.1-cp310-cp310-win_amd64.whl", hash = "sha256:7677fa1d0e3f933838e5dd8e03ebd6cd4dfc994c9e9b24e8aabd1b3ccecb2430", size = 54032, upload-time = "2026-03-09T13:01:06.316Z" },
-    { url = "https://files.pythonhosted.org/packages/46/fa/049879f61888462099dcbab495ad16df770cca2432330cca0767ab8e87cb/pyqt6_sip-13.11.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c0ec2128c174db352bec1c8d23a437e970e8d5a78ac50315d8dfc671fcf7a7da", size = 111056, upload-time = "2026-03-09T13:01:07.998Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/6ee861c53f3f7e6c5dd34a441d17aad1dfb3d50ce1f1a024cc9194ac3db3/pyqt6_sip-13.11.1-cp311-cp311-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6aa6c15ad3a9bb86e69119baff77b4ac17c47e55ee567abff616a4652051a6cc", size = 289930, upload-time = "2026-03-09T13:01:11.122Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/39/c975733d7204a594e6ae51d3a810aad539d09718aa3ceeb0dd28cb3276bd/pyqt6_sip-13.11.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ee652b272373c4f9287625ef32ad4ec1f0755c24928dc958a870b7a928b288c", size = 315827, upload-time = "2026-03-09T13:01:09.48Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d6/c40e8ae38a6e2bce9e837b64688f55746bfdad1aa557eb733fb5e90edd7c/pyqt6_sip-13.11.1-cp311-cp311-win_amd64.whl", hash = "sha256:98db8ed37cf08130e1ee74b8ff47a6bfb8c3cdfe826310597a630a50e47feedc", size = 54029, upload-time = "2026-03-09T13:01:12.261Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/63/ec8c21ef9edffb55af42c637325d72eca4ea90a73ab714aaa1429c757e85/pyqt6_sip-13.11.1-cp311-cp311-win_arm64.whl", hash = "sha256:3af7a49dce4c35c5464309232c81cc1da5ec6074f46d2957831ee4031b8eefa6", size = 48458, upload-time = "2026-03-09T13:01:13.689Z" },
-    { url = "https://files.pythonhosted.org/packages/46/27/47598e701d284497216bf97bf8b6a69f5e61412e716c232ff2b7e6cb2100/pyqt6_sip-13.11.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ba9d362dd1e54b43bc2594f8841e1e39d24789716d28f08e5c9282af9fca342c", size = 112564, upload-time = "2026-03-09T13:01:14.628Z" },
-    { url = "https://files.pythonhosted.org/packages/95/cb/116f9b328636765f3bce97d9e10ec041c54bbe92beb0617edb86c2b615c1/pyqt6_sip-13.11.1-cp312-cp312-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0df15849946cea969d3ff2b24b76149262b6044aea2c5403e4f70c24c973a4c8", size = 299564, upload-time = "2026-03-09T13:01:17.292Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/be/fe2321285e8f683e705d199dbb458131f1850dc5966155a19c40100c85bb/pyqt6_sip-13.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c52b2b27fc77d9447a8dc1c6de1aaccc22d41e48697aafb2f2f20b8984bb02a5", size = 321210, upload-time = "2026-03-09T13:01:15.904Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/9b/7d4b10f9cba1b6f581dfb4860b9d11898da55a5ed3b8a6e7a1bf9f7084d0/pyqt6_sip-13.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d1c67179c1924b28e3d7f04585639e7a7c0946f62390efc6ccf2a6206e595d3", size = 53351, upload-time = "2026-03-09T13:01:19.327Z" },
-    { url = "https://files.pythonhosted.org/packages/06/72/6c4e6f21cafa4bed40d2b0c1563525b0d8bfcb5734493696f4cfd043b45f/pyqt6_sip-13.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:d83543125fe9fdb153e7e446c3b4d056d80ab5953644660633ab3f80e7784194", size = 48746, upload-time = "2026-03-09T13:01:20.248Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/0b/dc76c463c203e630b2c6417d4d5e337e919a265ac1c10127ef413551f5de/pyqt6_sip-13.11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0c6d097aae7df312519e2b36e001bd796f6a2ce060ab8b9ed793daa8f407fe2e", size = 112552, upload-time = "2026-03-09T13:01:21.493Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/e3/65b605759859d38231ce7544065d4c61f891eb7766c351318e2a0b08a473/pyqt6_sip-13.11.1-cp313-cp313-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a72f4ebdab16a8a484019ff593de90d8013d3286b678c6ba1c0bdb117f4fcb13", size = 299932, upload-time = "2026-03-09T13:01:24.912Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f7/c10d2dd5bf503a1de83bd163467bd323f12af016866c2814743b5b1efe1c/pyqt6_sip-13.11.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b68e442efc4275651bf63f2c43713e242924fd948909e31cf8f20d783ca505e9", size = 321497, upload-time = "2026-03-09T13:01:22.724Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/1f/e7e5ad77a76c00db5c8c1b9960f2b0672ec1978b971bb3509858cd7a9458/pyqt6_sip-13.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:ca24bfd4d5d8274e338433df9ac41930650088c00018d3313c6bd8de21772a02", size = 53371, upload-time = "2026-03-09T13:01:26.286Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ef/a7acaf44980aed6fe26f1320e265db528fecb6a47ac67829c7cd011e9821/pyqt6_sip-13.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:f532144c43f2fddcccf2e25df50cdb4a744edb4ce4ba5ed2d0f2cef825197f2f", size = 48745, upload-time = "2026-03-09T13:01:27.212Z" },
-    { url = "https://files.pythonhosted.org/packages/20/1d/62c633faedef5bb3b8c7486a72e8a6466adaa2a14efcfccf85bb23426748/pyqt6_sip-13.11.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:cb931c1af45294bbe8039c5cfda184e3023f5dc766fc884964010eedd8fd85db", size = 112678, upload-time = "2026-03-09T13:01:28.15Z" },
-    { url = "https://files.pythonhosted.org/packages/03/72/5a3d9ffef0caa7e1bc7a35d6300f6099bfccd1d8a485b4320ba20013a2d9/pyqt6_sip-13.11.1-cp314-cp314-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:353d613129316e9f7eda6bbe821deb7b7ffa14483499189171fd8a246873f9ac", size = 299560, upload-time = "2026-03-09T13:01:32.134Z" },
-    { url = "https://files.pythonhosted.org/packages/98/f4/886f901f1e04da717a11e180ba19a9c7fc62da170966d57206006f173bda/pyqt6_sip-13.11.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fcadd68e09ee24cdda8f8bfcba52e59c9b297055d2c450f0eb89afa61a8dc31a", size = 321846, upload-time = "2026-03-09T13:01:29.817Z" },
-    { url = "https://files.pythonhosted.org/packages/96/f2/b68fd566f7f86dbb53d933489e70487cabaea0e0161690e4899653bbc7fb/pyqt6_sip-13.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:581e287bf42587593b88b30d9db06ed0fccbf40f345a5bd3ec3f00a5692e2430", size = 55055, upload-time = "2026-03-09T13:01:33.467Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/42/efb7ced69f7d1d31eb8f19b2d778aeb182be7e070569d02b9057ac478e3e/pyqt6_sip-13.11.1-cp314-cp314-win_arm64.whl", hash = "sha256:42b62530a9b6a9c6e29c2941b8ab78258652da0aeae4eb1fc9a0631d19a7a7b2", size = 49597, upload-time = "2026-03-09T13:01:34.49Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Consolidates UI and API fixes:

**PyQt Launcher Stub Retirement**
- Remove legacy PyQt launcher stub  
- Add security validation for UI components
- Prepare for canonical UI migration

**Backend Catalog Publication**
- Publish backend catalog for improved onboarding
- Enable external integrations to discover available services

## Changes
- Retire PyQt UI stub code
- Add security validation to launcher components
- Enable backend service catalog publication

Ready for review and merge.