### PR TITLE
test: add coverage for audit store write failures not breaking tools (#538)

### DIFF
--- a/tests/unit/test_tools_mcp.py
+++ b/tests/unit/test_tools_mcp.py
@@ -318,6 +318,24 @@ class TestToolPolicyAndInvocationAudit:
         assert record.status == "approval_required"
         assert record.redacted_arguments["headers"]["Authorization"] == "***"
 
+    async def test_audit_store_write_failure_does_not_break_tool(self, monkeypatch) -> None:
+        """Issue #538: audit-store persistence failures should not break the execution path."""
+        store = ToolInvocationStore()
+        
+        def _failing_append(*args: object, **kwargs: object) -> None:
+            raise OSError("Disk full")
+            
+        monkeypatch.setattr(store, "append", _failing_append)
+        
+        reg = ToolRegistry(invocation_store=store)
+        reg.register(_echo_spec())
+        
+        result = await reg.invoke("echo", {"message": "hi"})
+        
+        assert result.is_error is False
+        assert result.content == "echo: hi"
+
+
 
 class TestMcpToolDecorator:
     def test_decorator_attaches_spec(self) -> None:


### PR DESCRIPTION
Closes #538