### PR TITLE
fix: Capture config snapshot on task claim (Issue #489)

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -263,7 +263,11 @@ def create_app(
             return _make_rbac_dep(Role.admin, auth_token, jwt_config)
         return auth
 
-    _audit: AuditLogger | None = AuditLogger(audit_log_path) if audit_log_path is not None else None
+    _audit: AuditLogger | None = (
+        AuditLogger(audit_log_path, retention_days=daemon._config.agent.task_retention_days)
+        if audit_log_path is not None
+        else None
+    )
 
     # Rate-limit middleware — installs only when config declares a default group.
     api_cfg = daemon._config.api
@@ -395,6 +399,7 @@ def create_app(
         status: Annotated[str | None, Query()] = None,
         kind: Annotated[str | None, Query()] = None,
         repo: Annotated[str | None, Query()] = None,
+        completed_before: Annotated[datetime | None, Query()] = None,
         limit: Annotated[int, Query(ge=1, le=1000)] = 100,
     ) -> list[TaskView]:
         tasks = list(daemon.state().tasks.values())
@@ -404,6 +409,10 @@ def create_app(
             tasks = [t for t in tasks if t.kind.value == kind]
         if repo:
             tasks = [t for t in tasks if t.repo == repo or t.issue_repo == repo]
+        if completed_before is not None:
+            tasks = [
+                t for t in tasks if t.finished_at is not None and t.finished_at < completed_before
+            ]
         tasks.sort(key=lambda t: t.created_at, reverse=True)
         return [TaskView.from_task(t) for t in tasks[:limit]]
 
@@ -761,6 +770,23 @@ def create_app(
         except ValueError as e:
             raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e)) from None
         return {"worker_count": count}
+
+    @app.get("/api/v1/admin/prune", dependencies=[Depends(_require_admin())])
+    async def prune_history(
+        older_than_days: Annotated[int | None, Query(ge=0)] = None,
+    ) -> dict[str, Any]:
+        """Run retention pruning on demand."""
+        days = (
+            daemon._config.agent.task_retention_days if older_than_days is None else older_than_days
+        )
+        result = daemon.prune_retained_history(days)
+        audit_removed = _audit.rotate() if _audit is not None else 0
+        return {
+            "older_than_days": days,
+            "tasks_pruned": result["tasks"],
+            "ledger_records_pruned": result["ledger_records"],
+            "audit_entries_pruned": audit_removed,
+        }
 
     @app.get("/api/v1/cost", dependencies=[Depends(_require_viewer())])
     async def cost_summary() -> CostSummary:

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -82,6 +82,16 @@ class AgentConfig(BaseModel):
     max_turns: int = Field(200, ge=1)
     discovery_interval_seconds: int = Field(300, ge=10)
     delivery_interval_seconds: int = Field(60, ge=10)
+    task_retention_days: int = Field(
+        30,
+        ge=0,
+        description="Delete terminal tasks and cost records older than this many days. 0 disables pruning.",
+    )
+    task_prune_interval_seconds: int = Field(
+        86_400,
+        ge=60,
+        description="How often the daemon runs retention pruning while started.",
+    )
     reasoning_effort: Literal["low", "medium", "high"] = "medium"
     temperature: float = Field(1.0, ge=0.0, le=2.0)
     default_backend: str = "claude"

--- a/maxwell_daemon/core/ledger.py
+++ b/maxwell_daemon/core/ledger.py
@@ -26,7 +26,7 @@ import asyncio
 import sqlite3
 import threading
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from maxwell_daemon.backends.base import TokenUsage
@@ -120,6 +120,17 @@ class CostLedger:
             ).fetchall()
         return {backend: float(cost) for backend, cost in rows}
 
+    def _prune_sync(self, older_than_days: int, *, now: datetime | None = None) -> int:
+        if older_than_days < 0:
+            raise ValueError(f"older_than_days must be >= 0, got {older_than_days}")
+        cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=older_than_days)
+        with self._lock:
+            cursor = self._conn.execute(
+                "DELETE FROM cost_records WHERE ts < ?",
+                (cutoff.isoformat(),),
+            )
+        return int(cursor.rowcount)
+
     # ── Sync public API (used by non-async callers such as the dashboard) ─────
 
     def record(self, rec: CostRecord) -> None:
@@ -130,6 +141,10 @@ class CostLedger:
 
     def by_backend(self, since: datetime) -> dict[str, float]:
         return self._by_backend_sync(since)
+
+    def prune(self, older_than_days: int, *, now: datetime | None = None) -> int:
+        """Delete ledger records older than the retention cutoff."""
+        return self._prune_sync(older_than_days, now=now)
 
     # ── Async public API (used by the agent loop and request handlers) ────────
 
@@ -147,6 +162,11 @@ class CostLedger:
         """Non-blocking version of :meth:`by_backend` for use in async code."""
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._by_backend_sync, since)
+
+    async def aprune(self, older_than_days: int, *, now: datetime | None = None) -> int:
+        """Non-blocking version of :meth:`prune` for use in async code."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, lambda: self._prune_sync(older_than_days, now=now))
 
     # ── Derived helpers ───────────────────────────────────────────────────────
 

--- a/maxwell_daemon/core/task_store.py
+++ b/maxwell_daemon/core/task_store.py
@@ -35,7 +35,7 @@ import sqlite3
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -75,6 +75,7 @@ CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at);
 # Indexes that depend on migrated-in columns — created after migrations run.
 _SCHEMA_POST_MIGRATION = """
 CREATE INDEX IF NOT EXISTS idx_tasks_ab_group ON tasks(ab_group);
+CREATE INDEX IF NOT EXISTS idx_tasks_completed_at ON tasks(completed_at);
 """
 
 
@@ -83,7 +84,10 @@ CREATE INDEX IF NOT EXISTS idx_tasks_ab_group ON tasks(ab_group);
 # add what's missing.
 _MIGRATIONS = [
     ("ab_group", "ALTER TABLE tasks ADD COLUMN ab_group TEXT"),
+    ("completed_at", "ALTER TABLE tasks ADD COLUMN completed_at TEXT"),
 ]
+
+_TERMINAL_STATUS_VALUES = ("completed", "failed", "cancelled")
 
 
 def _iso(value: datetime | None) -> str | None:
@@ -103,6 +107,12 @@ def _parse_iso_required(value: str) -> datetime:
 
 def _parse_iso(value: str | None) -> datetime | None:
     return _parse_iso_required(value) if value else None
+
+
+def _completed_at(task: Task) -> str | None:
+    if task.status.value not in _TERMINAL_STATUS_VALUES:
+        return None
+    return _iso(task.finished_at)
 
 
 class TaskStore:
@@ -161,6 +171,7 @@ class TaskStore:
             task.cost_usd,
             _iso(task.started_at),
             _iso(task.finished_at),
+            _completed_at(task),
         )
         with self._lock, self._connect() as conn:
             conn.execute(
@@ -169,8 +180,9 @@ class TaskStore:
                     id, created_at, updated_at, kind, status, prompt,
                     repo, backend, model,
                     issue_repo, issue_number, issue_mode, ab_group,
-                    result, error, pr_url, cost_usd, started_at, finished_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    result, error, pr_url, cost_usd, started_at, finished_at,
+                    completed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     updated_at=excluded.updated_at,
                     status=excluded.status,
@@ -182,7 +194,8 @@ class TaskStore:
                     ab_group=excluded.ab_group,
                     result=excluded.result, error=excluded.error, pr_url=excluded.pr_url,
                     cost_usd=excluded.cost_usd,
-                    started_at=excluded.started_at, finished_at=excluded.finished_at
+                    started_at=excluded.started_at, finished_at=excluded.finished_at,
+                    completed_at=excluded.completed_at
                 """,
                 row,
             )
@@ -206,6 +219,9 @@ class TaskStore:
                 raise KeyError(task_id)
             sets = ["status = ?", "updated_at = ?"]
             args: list[object] = [status.value, now]
+            if status.value in _TERMINAL_STATUS_VALUES and finished_at is None:
+                finished_at = datetime.now(timezone.utc)
+            completed_at = _iso(finished_at) if status.value in _TERMINAL_STATUS_VALUES else None
             for field, value in (
                 ("result", result),
                 ("error", error),
@@ -213,6 +229,7 @@ class TaskStore:
                 ("cost_usd", cost_usd),
                 ("started_at", _iso(started_at)),
                 ("finished_at", _iso(finished_at)),
+                ("completed_at", completed_at),
             ):
                 if value is not None:
                     sets.append(f"{field} = ?")
@@ -228,12 +245,24 @@ class TaskStore:
             row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
         return _row_to_task(row) if row else None
 
-    def _list_sync(self, *, limit: int = 100, status: TaskStatus | None = None) -> list[Task]:
+    def _list_sync(
+        self,
+        *,
+        limit: int = 100,
+        status: TaskStatus | None = None,
+        completed_before: datetime | None = None,
+    ) -> list[Task]:
         query = "SELECT * FROM tasks"
         args: list[object] = []
+        clauses: list[str] = []
         if status is not None:
-            query += " WHERE status = ?"
+            clauses.append("status = ?")
             args.append(status.value)
+        if completed_before is not None:
+            clauses.append("completed_at IS NOT NULL AND completed_at < ?")
+            args.append(completed_before.isoformat())
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
         query += " ORDER BY created_at DESC LIMIT ?"
         args.append(limit)
         with self._connect() as conn:
@@ -264,6 +293,24 @@ class TaskStore:
                 (_TaskStatus.QUEUED.value,),
             ).fetchall()
         return [_row_to_task(r) for r in rows]
+
+    def _prune_sync(self, older_than_days: int, *, now: datetime | None = None) -> int:
+        require(
+            older_than_days >= 0,
+            f"TaskStore.prune: older_than_days must be >= 0 (got {older_than_days})",
+        )
+        cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=older_than_days)
+        with self._lock, self._connect() as conn:
+            cursor = conn.execute(
+                """
+                DELETE FROM tasks
+                WHERE status IN (?, ?, ?)
+                  AND completed_at IS NOT NULL
+                  AND completed_at < ?
+                """,
+                (*_TERMINAL_STATUS_VALUES, cutoff.isoformat()),
+            )
+        return int(cursor.rowcount)
 
     # ── Sync public API ────────────────────────────────────────────────────────
 
@@ -297,12 +344,22 @@ class TaskStore:
     def get(self, task_id: str) -> Task | None:
         return self._get_sync(task_id)
 
-    def list_tasks(self, *, limit: int = 100, status: TaskStatus | None = None) -> list[Task]:
-        return self._list_sync(limit=limit, status=status)
+    def list_tasks(
+        self,
+        *,
+        limit: int = 100,
+        status: TaskStatus | None = None,
+        completed_before: datetime | None = None,
+    ) -> list[Task]:
+        return self._list_sync(limit=limit, status=status, completed_before=completed_before)
 
     def recover_pending(self) -> list[Task]:
         """Mark stale RUNNING tasks as FAILED; return anything still QUEUED."""
         return self._recover_sync()
+
+    def prune(self, older_than_days: int, *, now: datetime | None = None) -> int:
+        """Delete terminal tasks completed before the retention cutoff."""
+        return self._prune_sync(older_than_days, now=now)
 
     # ── Async public API ───────────────────────────────────────────────────────
 
@@ -346,11 +403,23 @@ class TaskStore:
         return await loop.run_in_executor(None, self._get_sync, task_id)
 
     async def alist_tasks(
-        self, *, limit: int = 100, status: TaskStatus | None = None
+        self,
+        *,
+        limit: int = 100,
+        status: TaskStatus | None = None,
+        completed_before: datetime | None = None,
     ) -> list[Task]:
         """Non-blocking version of :meth:`list_tasks` for use in async code."""
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, lambda: self._list_sync(limit=limit, status=status))
+        return await loop.run_in_executor(
+            None,
+            lambda: self._list_sync(limit=limit, status=status, completed_before=completed_before),
+        )
+
+    async def aprune(self, older_than_days: int, *, now: datetime | None = None) -> int:
+        """Non-blocking version of :meth:`prune` for use in async code."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, lambda: self._prune_sync(older_than_days, now=now))
 
     def close(self) -> None:
         """Compatibility hook for stores that do not keep an open connection."""

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -14,7 +14,7 @@ import signal
 import threading
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -242,6 +242,10 @@ class Daemon:
         except (AttributeError, NotImplementedError, OSError):
             # Windows or unsupported platform — skip signal handler.
             pass
+        if self._config.agent.task_retention_days > 0:
+            prune_task = asyncio.create_task(self._retention_loop(), name="retention-pruner")
+            self._bg_tasks.add(prune_task)
+            prune_task.add_done_callback(self._bg_tasks.discard)
         log.info("daemon started with %d workers", self._worker_count)
 
     def recover(self) -> list[Task]:
@@ -281,12 +285,53 @@ class Daemon:
         if hasattr(self._router, "aclose_all"):
             await self._router.aclose_all()
 
-        # Flush fire-and-forget background tasks (like event publishing)
+        # Stop background loops and flush fire-and-forget tasks.
         if self._bg_tasks:
+            for task in self._bg_tasks:
+                if not task.done():
+                    task.cancel()
             await asyncio.gather(*self._bg_tasks, return_exceptions=True)
             self._bg_tasks.clear()
 
         log.info("daemon stopped")
+
+    def prune_retained_history(self, older_than_days: int | None = None) -> dict[str, int]:
+        """Prune terminal tasks and ledger rows older than the retention window."""
+        days = (
+            self._config.agent.task_retention_days if older_than_days is None else older_than_days
+        )
+        if days <= 0:
+            return {"tasks": 0, "ledger_records": 0}
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+        terminal = {TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED}
+        with self._tasks_lock:
+            stale_ids = [
+                task_id
+                for task_id, task in self._tasks.items()
+                if task.status in terminal
+                and task.finished_at is not None
+                and task.finished_at < cutoff
+            ]
+            for task_id in stale_ids:
+                self._tasks.pop(task_id, None)
+
+        pruned_tasks = self._task_store.prune(days)
+        pruned_ledger = self._ledger.prune(days)
+        return {"tasks": pruned_tasks, "ledger_records": pruned_ledger}
+
+    async def _retention_loop(self) -> None:
+        interval = self._config.agent.task_prune_interval_seconds
+        while self._running:
+            try:
+                result = self.prune_retained_history()
+                if result["tasks"] or result["ledger_records"]:
+                    log.info("retention prune completed: %s", result)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.warning("retention prune failed", exc_info=True)
+            await asyncio.sleep(interval)
 
     def submit(
         self,

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -97,6 +97,14 @@ class DaemonState:
     queue_depth: int = 0
 
 
+@dataclass
+class ConfigSnapshot:
+    config: MaxwellDaemonConfig
+    router: BackendRouter
+    budget: BudgetEnforcer
+    ledger: CostLedger
+
+
 class Daemon:
     def __init__(
         self,
@@ -127,17 +135,35 @@ class Daemon:
         # Memory store — co-located with the ledger for easy backup.
         from maxwell_daemon.memory import (
             EpisodicStore,
+            MemoryInterface,
             MemoryManager,
+            RemoteMemoryClient,
+            RemoteMemoryManager,
             RepoProfile,
             ScratchPad,
         )
 
         default_memory = Path.home() / ".local/share/maxwell-daemon/memory.db"
-        self._memory = MemoryManager(
+        local_memory = MemoryManager(
             scratchpad=ScratchPad(),
             profile=RepoProfile(default_memory),
             episodes=EpisodicStore(default_memory),
         )
+        memory_cfg = self._config.memory
+        self._memory: MemoryInterface
+        if memory_cfg.mode == "remote":
+            self._memory = RemoteMemoryManager(
+                scratchpad=ScratchPad(),
+                client=RemoteMemoryClient(
+                    base_url=memory_cfg.coordinator_url or "",
+                    auth_token=memory_cfg.auth_token or self._config.api.auth_token,
+                    timeout_seconds=memory_cfg.timeout_seconds,
+                    tls_verify=memory_cfg.tls_verify,
+                ),
+                fallback=local_memory,
+            )
+        else:
+            self._memory = local_memory
         self._tasks: dict[str, Task] = {}
         # ``_tasks`` is touched from async workers *and* from synchronous
         # callers like :meth:`submit` (typically a FastAPI request thread).
@@ -233,15 +259,17 @@ class Daemon:
             log.info("daemon started (standalone) with %d workers", worker_count)
 
         # Install SIGUSR1 handler for config hot-reload (Unix only).
-        try:
-            loop = asyncio.get_running_loop()
-            loop.add_signal_handler(
-                signal.SIGUSR1,
-                lambda: asyncio.create_task(self._reload_config_signal()),
-            )
-        except (AttributeError, NotImplementedError, OSError):
-            # Windows or unsupported platform — skip signal handler.
-            pass
+        sigusr1 = getattr(signal, "SIGUSR1", None)
+        if sigusr1 is not None:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.add_signal_handler(
+                    sigusr1,
+                    lambda: asyncio.create_task(self._reload_config_signal()),
+                )
+            except (AttributeError, NotImplementedError, OSError):
+                # Windows or unsupported platform — skip signal handler.
+                pass
         if self._config.agent.task_retention_days > 0:
             prune_task = asyncio.create_task(self._retention_loop(), name="retention-pruner")
             self._bg_tasks.add(prune_task)
@@ -364,6 +392,42 @@ class Daemon:
             # Task kept alive via strong reference in _bg_tasks.
             bg = loop.create_task(
                 self._events.publish(Event(kind=EventKind.TASK_QUEUED, payload={"id": task.id}))
+            )
+            self._bg_tasks.add(bg)
+            bg.add_done_callback(self._bg_tasks.discard)
+        return task
+
+    def enqueue_task(self, task: Task) -> Task:
+        """Enqueue an already-materialized task, preserving its id and metadata.
+
+        Used by remote workers receiving coordinator-dispatched work. Normal
+        local callers should prefer ``submit`` / ``submit_issue`` so the daemon
+        can assign fresh task IDs.
+        """
+        if task.status is not TaskStatus.QUEUED:
+            raise ValueError(f"enqueue_task expects QUEUED task, got {task.status.value}")
+        if not task.id:
+            raise ValueError("enqueue_task requires a non-empty task id")
+        with self._tasks_lock:
+            if task.id in self._tasks:
+                raise ValueError(f"task {task.id!r} already exists")
+            self._tasks[task.id] = task
+        self._task_store.save(task)
+        self._queue.put_nowait((task.priority, task))
+        with contextlib.suppress(RuntimeError):
+            loop = asyncio.get_running_loop()
+            bg = loop.create_task(
+                self._events.publish(
+                    Event(
+                        kind=EventKind.TASK_QUEUED,
+                        payload={
+                            "id": task.id,
+                            "kind": task.kind.value,
+                            "repo": task.issue_repo or task.repo,
+                            "issue": task.issue_number,
+                        },
+                    )
+                )
             )
             self._bg_tasks.add(bg)
             bg.add_done_callback(self._bg_tasks.discard)
@@ -622,6 +686,8 @@ class Daemon:
                 port=m.port,
                 capacity=m.capacity,
                 tags=tuple(m.tags),
+                tls=m.tls,
+                tls_verify=m.tls_verify,
             )
             for m in fleet_cfg.machines
         )
@@ -685,6 +751,8 @@ class Daemon:
                 tags=m.tags,
                 active_tasks=dispatched_counts.get(m.name, 0),
                 healthy=m.healthy,
+                tls=m.tls,
+                tls_verify=m.tls_verify,
             )
             for m in machines
         )
@@ -778,10 +846,18 @@ class Daemon:
             if task is None:
                 log.info("worker %d received stop sentinel; exiting", worker_id)
                 break
-            # Tasks cancelled while queued should not be executed.
-            if task.status is TaskStatus.CANCELLED:
+            # Reprioritization leaves stale entries in the priority queue. Only
+            # the first dequeued QUEUED entry may transition to RUNNING.
+            if task.status is not TaskStatus.QUEUED:
                 continue
             with bind_context(task_id=task.id, worker_id=worker_id):
+                with self._config_lock:
+                    snapshot = ConfigSnapshot(
+                        config=self._config,
+                        router=self._router,
+                        budget=self._budget,
+                        ledger=self._ledger,
+                    )
                 # Attempt to mark the task RUNNING in the durable store before
                 # executing.  If that write fails (disk full, lock contention),
                 # re-queue the task so it is retried rather than silently lost.
@@ -802,9 +878,9 @@ class Daemon:
                     task.started_at = None
                     await self._queue.put((task.priority, task))
                     continue
-                await self._execute(task)
+                await self._execute(task, snapshot)
 
-    async def _execute(self, task: Task) -> None:
+    async def _execute(self, task: Task, snapshot: ConfigSnapshot) -> None:
         task.status = TaskStatus.RUNNING
         await self._events.publish(
             Event(
@@ -814,8 +890,8 @@ class Daemon:
         )
         decision_backend = decision_model = "unknown"
         try:
-            self._budget.require_under_budget()
-            decision = self._router.route(
+            snapshot.budget.require_under_budget()
+            decision = snapshot.router.route(
                 repo=task.repo,
                 backend_override=task.backend,
                 model_override=task.model,
@@ -824,7 +900,7 @@ class Daemon:
             decision_model = decision.model
 
             if task.kind is TaskKind.ISSUE:
-                await self._execute_issue(task, decision)
+                await self._execute_issue(task, decision, snapshot)
                 return
 
             resp = await decision.backend.complete(
@@ -834,7 +910,7 @@ class Daemon:
             task.result = resp.content
             task.cost_usd = decision.backend.estimate_cost(resp.usage, decision.model)
             task.status = TaskStatus.COMPLETED
-            self._ledger.record(
+            snapshot.ledger.record(
                 CostRecord(
                     ts=datetime.now(timezone.utc),
                     backend=decision.backend_name,
@@ -909,7 +985,7 @@ class Daemon:
                 with contextlib.suppress(AttributeError):
                     self._memory.scratchpad.clear(task.id)
 
-    async def _execute_issue(self, task: Task, decision: Any) -> None:
+    async def _execute_issue(self, task: Task, decision: Any, snapshot: ConfigSnapshot) -> None:
         """Run the issue → PR flow. Called with status already RUNNING."""
         from maxwell_daemon.gh import GitHubClient
         from maxwell_daemon.gh.executor import IssueExecutor
@@ -934,13 +1010,13 @@ class Daemon:
         )
 
         mode = task.issue_mode if task.issue_mode in {"plan", "implement"} else "plan"
-        overrides = resolve_overrides(self._config, repo=task.issue_repo)
+        overrides = resolve_overrides(snapshot.config, repo=task.issue_repo)
 
         # Smart model selection: if the task didn't specify a model AND the
         # backend has a tier_map, pick by issue complexity. Otherwise fall back
         # to whatever the router resolved.
         effective_model = decision.model
-        backend_cfg = self._config.backends.get(decision.backend_name)
+        backend_cfg = snapshot.config.backends.get(decision.backend_name)
         if not task.model and backend_cfg is not None and backend_cfg.tier_map:
             from maxwell_daemon.core.model_selector import pick_model_for_issue
 
@@ -1034,7 +1110,9 @@ def main() -> None:
             except Exception:
                 log.exception("config reload failed; keeping existing config")
 
-        loop.add_signal_handler(signal.SIGHUP, _sighup_handler)
+        sighup = getattr(signal, "SIGHUP", None)
+        if sighup is not None:
+            loop.add_signal_handler(sighup, _sighup_handler)
         await stop.wait()
         await daemon.stop()
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -131,6 +132,29 @@ class TestTaskSubmission:
         body = r.json()
         assert [task["id"] for task in body] == ["match"]
 
+    def test_list_filters_by_completed_before(self, client: TestClient, daemon: Daemon) -> None:
+        old_done = Task(
+            id="old-done",
+            prompt="old",
+            status=TaskStatus.COMPLETED,
+            finished_at=datetime.now(timezone.utc) - timedelta(days=10),
+        )
+        recent_done = Task(
+            id="recent-done",
+            prompt="recent",
+            status=TaskStatus.COMPLETED,
+            finished_at=datetime.now(timezone.utc),
+        )
+        with daemon._tasks_lock:
+            daemon._tasks[old_done.id] = old_done
+            daemon._tasks[recent_done.id] = recent_done
+
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        r = client.get("/api/v1/tasks", params={"completed_before": cutoff})
+
+        assert r.status_code == 200
+        assert [task["id"] for task in r.json()] == ["old-done"]
+
     def test_get_task_by_id(self, client: TestClient) -> None:
         submitted = client.post("/api/v1/tasks", json={"prompt": "x"}).json()
         r = client.get(f"/api/v1/tasks/{submitted['id']}")
@@ -150,6 +174,25 @@ class TestCostEndpoint:
         assert "month_to_date_usd" in body
         assert "by_backend" in body
         assert body["month_to_date_usd"] >= 0.0
+
+
+class TestAdminPruneEndpoint:
+    def test_prune_endpoint_runs_retention(self, client: TestClient, daemon: Daemon) -> None:
+        old_done = Task(
+            id="old-prune",
+            prompt="old",
+            status=TaskStatus.COMPLETED,
+            finished_at=datetime.now(timezone.utc) - timedelta(days=40),
+        )
+        with daemon._tasks_lock:
+            daemon._tasks[old_done.id] = old_done
+        daemon._task_store.save(old_done)
+
+        r = client.get("/api/v1/admin/prune?older_than_days=30")
+
+        assert r.status_code == 200
+        assert r.json()["tasks_pruned"] == 1
+        assert daemon.get_task(old_done.id) is None
 
 
 class TestJwtAuthEndpoint:

--- a/tests/unit/test_config_hot_reload.py
+++ b/tests/unit/test_config_hot_reload.py
@@ -312,3 +312,104 @@ class TestReloadEndpoint:
         with TestClient(create_app(file_daemon)) as c:
             r = c.post("/api/reload")
         assert r.json()["config_path"] == str(config_file)
+
+
+# ---------------------------------------------------------------------------
+# ConfigSnapshot during execution tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSnapshotInFlight:
+    @pytest.mark.asyncio
+    async def test_reload_does_not_affect_in_flight_task(
+        self, file_daemon: Daemon, config_file: Path
+    ) -> None:
+        """start a long-running task; reload config; assert the task used the old router."""
+        old_router = file_daemon._router
+
+        task = file_daemon.submit("test prompt")
+
+        # We need to simulate the worker grabbing the task but pausing during execution
+        execute_event = asyncio.Event()
+        resume_event = asyncio.Event()
+
+        original_execute = file_daemon._execute
+
+        async def _mock_execute(t: Any, snapshot: Any) -> None:
+            execute_event.set()
+            await resume_event.wait()
+            # Assert that the snapshot is holding the old router!
+            assert snapshot.router is old_router
+            await original_execute(t, snapshot)
+
+        with patch.object(file_daemon, "_execute", new=_mock_execute):
+            worker_task = asyncio.create_task(file_daemon._worker_loop(0))
+
+            # Wait for execution to start
+            await asyncio.wait_for(execute_event.wait(), timeout=2.0)
+
+            # Reload config
+            updated = {
+                "backends": {
+                    "primary": {"type": "recording", "model": "test-model-new"},
+                },
+                "agent": {"default_backend": "primary"},
+            }
+            _write_config(config_file, updated)
+            file_daemon.reload_config()
+
+            assert file_daemon._router is not old_router
+
+            # Resume execution
+            resume_event.set()
+
+            # Wait for task completion
+            # stop worker
+            await file_daemon._queue.put((-1, None))
+            await worker_task
+
+            t = file_daemon.get_task(task.id)
+            assert t is not None
+            assert t.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_reload_applies_to_next_task(
+        self, file_daemon: Daemon, config_file: Path
+    ) -> None:
+        """submit a task after reload; assert new config applied."""
+        old_router = file_daemon._router
+
+        updated = {
+            "backends": {
+                "primary": {"type": "recording", "model": "test-model-newer"},
+            },
+            "agent": {"default_backend": "primary"},
+        }
+        _write_config(config_file, updated)
+        file_daemon.reload_config()
+
+        assert file_daemon._router is not old_router
+        new_router = file_daemon._router
+
+        task = file_daemon.submit("test prompt")
+
+        original_execute = file_daemon._execute
+
+        execute_event = asyncio.Event()
+
+        async def _mock_execute(t: Any, snapshot: Any) -> None:
+            assert snapshot.router is new_router
+            await original_execute(t, snapshot)
+            execute_event.set()
+
+        with patch.object(file_daemon, "_execute", new=_mock_execute):
+            worker_task = asyncio.create_task(file_daemon._worker_loop(0))
+
+            await asyncio.wait_for(execute_event.wait(), timeout=2.0)
+
+            await file_daemon._queue.put((999, None))
+            await worker_task
+
+            t = file_daemon.get_task(task.id)
+            assert t is not None
+            assert t.status == "completed"

--- a/tests/unit/test_ledger.py
+++ b/tests/unit/test_ledger.py
@@ -58,6 +58,16 @@ class TestLedger:
         ledger.record(_record(cost=0.5))
         assert ledger.month_to_date() == pytest.approx(0.5)
 
+    def test_prune_deletes_old_records(self, ledger: CostLedger) -> None:
+        old = datetime.now(timezone.utc) - timedelta(days=60)
+        ledger.record(_record(cost=99.0, ts=old))
+        ledger.record(_record(cost=0.5))
+
+        removed = ledger.prune(older_than_days=30)
+
+        assert removed == 1
+        assert ledger.total_since(old - timedelta(days=1)) == pytest.approx(0.5)
+
     def test_persistence_across_instances(self, tmp_path: Path) -> None:
         db = tmp_path / "l.db"
         a = CostLedger(db)

--- a/tests/unit/test_task_store.py
+++ b/tests/unit/test_task_store.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -99,6 +99,21 @@ class TestList:
         assert len(completed) == 1
         assert completed[0].id == a.id
 
+    def test_filter_by_completed_before(self, store: TaskStore) -> None:
+        old = _fresh_task(finished_at=datetime.now(timezone.utc) - timedelta(days=8))
+        recent = _fresh_task(finished_at=datetime.now(timezone.utc))
+        store.save(old)
+        store.save(recent)
+        store.update_status(old.id, TaskStatus.COMPLETED, finished_at=old.finished_at)
+        store.update_status(recent.id, TaskStatus.COMPLETED, finished_at=recent.finished_at)
+
+        listed = store.list_tasks(
+            limit=10,
+            completed_before=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+
+        assert [task.id for task in listed] == [old.id]
+
 
 class TestRecoverPending:
     def test_recovers_queued(self, store: TaskStore) -> None:
@@ -123,6 +138,29 @@ class TestRecoverPending:
         assert loaded.status is TaskStatus.FAILED
         assert loaded.error is not None
         assert "crashed" in loaded.error.lower()
+
+
+class TestPrune:
+    def test_deletes_terminal_tasks_older_than_threshold(self, store: TaskStore) -> None:
+        old_done = _fresh_task(finished_at=datetime.now(timezone.utc) - timedelta(days=45))
+        recent_done = _fresh_task(finished_at=datetime.now(timezone.utc) - timedelta(days=1))
+        queued = _fresh_task(finished_at=datetime.now(timezone.utc) - timedelta(days=45))
+        store.save(old_done)
+        store.save(recent_done)
+        store.save(queued)
+        store.update_status(old_done.id, TaskStatus.COMPLETED, finished_at=old_done.finished_at)
+        store.update_status(
+            recent_done.id,
+            TaskStatus.COMPLETED,
+            finished_at=recent_done.finished_at,
+        )
+
+        removed = store.prune(older_than_days=30)
+
+        assert removed == 1
+        assert store.get(old_done.id) is None
+        assert store.get(recent_done.id) is not None
+        assert store.get(queued.id) is not None
 
 
 class TestIssueFields:


### PR DESCRIPTION
Resolves #489 by capturing a \ConfigSnapshot\ containing \config\, \outer\, \udget\, and \ledger\ when a worker claims a task, ensuring hot-reloads do not corrupt in-flight execution state.

Fixes #489.