### PR TITLE
fix: Capture config snapshot on task claim (Issue #489)

### DIFF
--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -61,8 +61,10 @@ from maxwell_daemon.metrics import record_request
 
 log = get_logger("maxwell_daemon.daemon")
 
+
 class QueueSaturationError(Exception):
     """Raised when the priority queue is full and cannot accept more tasks."""
+
     def __init__(self, message: str, backoff_seconds: int = 60) -> None:
         super().__init__(message)
         self.backoff_seconds = backoff_seconds
@@ -133,6 +135,14 @@ class DaemonState:
     backends_available: list[str]
     worker_count: int = 0
     queue_depth: int = 0
+
+
+@dataclass
+class ConfigSnapshot:
+    config: MaxwellDaemonConfig
+    router: BackendRouter
+    budget: BudgetEnforcer
+    ledger: CostLedger
 
 
 class Daemon:
@@ -517,13 +527,17 @@ class Daemon:
         item = (priority, task)
         if self._queue.full():
             log.warning("queue is saturated (max_depth=%d)", self._config.agent.max_queue_depth)
-            raise QueueSaturationError("Task queue is full, please try again later", backoff_seconds=60)
+            raise QueueSaturationError(
+                "Task queue is full, please try again later", backoff_seconds=60
+            )
 
         if self._loop is None or not self._loop.is_running():
             try:
                 self._queue.put_nowait(item)
             except asyncio.QueueFull as exc:
-                raise QueueSaturationError("Task queue is full, please try again later", backoff_seconds=60) from exc
+                raise QueueSaturationError(
+                    "Task queue is full, please try again later", backoff_seconds=60
+                ) from exc
             return
         try:
             running_loop = asyncio.get_running_loop()
@@ -539,6 +553,7 @@ class Daemon:
                     self._queue.put_nowait(item)
                 except asyncio.QueueFull:
                     log.error("Queue saturated inline; dropped task %s", getattr(task, "id", None))
+
             self._loop.call_soon_threadsafe(_put_inline)
             return
 
@@ -548,7 +563,11 @@ class Daemon:
             try:
                 self._queue.put_nowait(item)
             except asyncio.QueueFull:
-                result.set_exception(QueueSaturationError("Task queue is full, please try again later", backoff_seconds=60))
+                result.set_exception(
+                    QueueSaturationError(
+                        "Task queue is full, please try again later", backoff_seconds=60
+                    )
+                )
             except BaseException as exc:  # pragma: no cover - surfaced via Future
                 result.set_exception(exc)
             else:
@@ -1308,6 +1327,14 @@ class Daemon:
                 task.status = TaskStatus.RUNNING
                 task.started_at = datetime.now(timezone.utc)
             with bind_context(task_id=task.id, worker_id=worker_id):
+                # Snapshot the config state to avoid races with hot reloads
+                with self._config_lock:
+                    snapshot = ConfigSnapshot(
+                        config=self._config,
+                        router=self._router,
+                        budget=self._budget,
+                        ledger=self._ledger,
+                    )
                 # Attempt to mark the task RUNNING in the durable store before
                 # executing.  If that write fails (disk full, lock contention),
                 # re-queue the task so it is retried rather than silently lost.
@@ -1330,9 +1357,9 @@ class Daemon:
                             task.started_at = None
                     await self._queue.put((task.priority, task))
                     continue
-                await self._execute(task)
+                await self._execute(task, snapshot)
 
-    async def _execute(self, task: Task) -> None:
+    async def _execute(self, task: Task, snapshot: ConfigSnapshot) -> None:
         task.status = TaskStatus.RUNNING
         task.started_at = datetime.now(timezone.utc)
         try:
@@ -1351,8 +1378,8 @@ class Daemon:
                     ),
                 )
             )
-            self._budget.require_under_budget()
-            decision = self._router.route(
+            snapshot.budget.require_under_budget()
+            decision = snapshot.router.route(
                 repo=task.repo,
                 backend_override=task.backend,
                 model_override=task.model,
@@ -1369,7 +1396,7 @@ class Daemon:
                 log.exception("task store write failed while recording route for task=%s", task.id)
 
             if task.kind is TaskKind.ISSUE:
-                await self._execute_issue(task, decision)
+                await self._execute_issue(task, decision, snapshot)
                 return
 
             resp = await decision.backend.complete(
@@ -1380,7 +1407,7 @@ class Daemon:
             estimated_cost = decision.backend.estimate_cost(resp.usage, decision.model)
             task.cost_usd = estimated_cost if estimated_cost is not None else 0.0
             task.status = TaskStatus.COMPLETED
-            self._ledger.record(
+            snapshot.ledger.record(
                 CostRecord(
                     ts=datetime.now(timezone.utc),
                     backend=decision.backend_name,
@@ -1485,7 +1512,7 @@ class Daemon:
                     # Scratchpad API mismatch — log but don't crash the task.
                     log.warning("scratchpad.clear API not available for task %s", task.id)
 
-    async def _execute_issue(self, task: Task, decision: Any) -> None:
+    async def _execute_issue(self, task: Task, decision: Any, snapshot: ConfigSnapshot) -> None:
         """Run the issue → PR flow. Called with status already RUNNING."""
         from maxwell_daemon.core.repo_overrides import resolve_overrides
         from maxwell_daemon.gh import GitHubClient
@@ -1512,13 +1539,13 @@ class Daemon:
         )
 
         mode = task.issue_mode if task.issue_mode in {"plan", "implement"} else "plan"
-        overrides = resolve_overrides(self._config, repo=task.issue_repo)
+        overrides = resolve_overrides(snapshot.config, repo=task.issue_repo)
 
         # Smart model selection: if the task didn't specify a model AND the
         # backend has a tier_map, pick by issue complexity. Otherwise fall back
         # to whatever the router resolved.
         effective_model = decision.model
-        backend_cfg = self._router._backend_config(decision.backend_name)
+        backend_cfg = snapshot.config.backends.get(decision.backend_name)
         if not task.model and backend_cfg is not None and backend_cfg.tier_map:
             from maxwell_daemon.core.model_selector import pick_model_for_issue
 

--- a/tests/unit/test_config_hot_reload.py
+++ b/tests/unit/test_config_hot_reload.py
@@ -312,3 +312,118 @@ class TestReloadEndpoint:
         with TestClient(create_app(file_daemon)) as c:
             r = c.post("/api/reload")
         assert r.json()["config_path"] == str(config_file)
+
+
+class TestConfigSnapshotInFlight:
+    """Verify that in-flight tasks are shielded from hot-reloads via ConfigSnapshot."""
+
+    @pytest.mark.asyncio
+    async def test_reload_does_not_affect_in_flight_task(
+        self, file_daemon: Daemon, config_file: Path
+    ) -> None:
+        """
+        Start a long-running task; reload config; assert the task used the old router
+        and old config snapshot for its entire execution.
+        """
+        old_router = file_daemon._router
+
+        task = file_daemon.submit("test prompt")
+
+        # We need to hook into _execute to simulate a long-running task and capture
+        # the snapshot it was passed.
+        original_execute = file_daemon._execute
+
+        captured_snapshot = None
+        execute_event = asyncio.Event()
+        proceed_event = asyncio.Event()
+
+        async def _mock_execute(t: Any, snapshot: Any) -> None:
+            nonlocal captured_snapshot
+            captured_snapshot = snapshot
+
+            # Signal that execution has started and snapshot is captured
+            execute_event.set()
+
+            # Wait for the hot-reload to occur in the main thread
+            await proceed_event.wait()
+
+            # Proceed with execution
+            await original_execute(t, snapshot)
+
+        with patch.object(file_daemon, "_execute", new=_mock_execute):
+            worker_task = asyncio.create_task(file_daemon._worker_loop(0))
+
+            # Wait for the worker to claim the task and enter _execute
+            await asyncio.wait_for(execute_event.wait(), timeout=2.0)
+
+            # Worker is now blocked in _execute, holding the snapshot.
+            # Perform a hot-reload.
+            updated = {
+                "backends": {
+                    "primary": {"type": "recording", "model": "test-model-updated"},
+                },
+                "agent": {"default_backend": "primary"},
+            }
+            _write_config(config_file, updated)
+            file_daemon.reload_config()
+
+            # Verify the daemon's active router has changed
+            assert file_daemon._router is not old_router
+
+            # Unblock the worker
+            proceed_event.set()
+
+            # Enqueue exit sentinel to stop worker
+            await file_daemon._queue.put((999, None))
+            await worker_task
+
+            # Verify the snapshot captured by the worker contains the OLD router
+            assert captured_snapshot is not None
+            assert captured_snapshot.router is old_router
+
+            # Verify the task actually completed
+            t = file_daemon.get_task(task.id)
+            assert t is not None
+            assert t.status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_reload_applies_to_next_task(
+        self, file_daemon: Daemon, config_file: Path
+    ) -> None:
+        """submit a task after reload; assert new config applied."""
+        old_router = file_daemon._router
+
+        updated = {
+            "backends": {
+                "primary": {"type": "recording", "model": "test-model-newer"},
+            },
+            "agent": {"default_backend": "primary"},
+        }
+        _write_config(config_file, updated)
+        file_daemon.reload_config()
+
+        assert file_daemon._router is not old_router
+        new_router = file_daemon._router
+
+        task = file_daemon.submit("test prompt")
+
+        original_execute = file_daemon._execute
+
+        execute_event = asyncio.Event()
+
+        async def _mock_execute(t: Any, snapshot: Any) -> None:
+            assert snapshot.router is new_router
+            await original_execute(t, snapshot)
+            execute_event.set()
+
+        with patch.object(file_daemon, "_execute", new=_mock_execute):
+            worker_task = asyncio.create_task(file_daemon._worker_loop(0))
+
+            await asyncio.wait_for(execute_event.wait(), timeout=2.0)
+
+            await file_daemon._queue.put((999, None))
+            await worker_task
+
+            t = file_daemon.get_task(task.id)
+            assert t is not None
+            assert t.status == "completed"


### PR DESCRIPTION
Resolves #489 by capturing a ConfigSnapshot containing config, router, budget, and ledger when a worker claims a task, ensuring hot-reloads do not corrupt in-flight execution state.

Fixes #489.