### PR TITLE
🎨 Palette: Add disabled button states and submit feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Keyboard Navigation for Command Palette
 **Learning:** Adding `keydown` listeners for `ArrowUp`/`ArrowDown` coupled with `element.focus()` and `:focus-visible` styles is an effective pattern for building accessible, keyboard-navigable list widgets like command palettes in vanilla JS.
 **Action:** Always check if custom drop-downs, search result lists, or palettes support arrow key navigation. If not, implement standard WAI-ARIA keyboard interaction patterns to allow power users and screen-reader users to interact smoothly.
+
+## 2024-05-25 - Prevent double submission via disabled state
+**Learning:** Adding `disabled` states to submit buttons when an async request is triggered, coupled with appropriate styling (`opacity`, `cursor: not-allowed`), prevents unintended double-submissions and provides valuable feedback that the system is processing the request. A `finally` block should always be used to restore the button to an enabled state regardless of whether the request succeeds or fails.
+**Action:** When reviewing or creating forms, ensure submit buttons have visual and logical disabled states during async operations. Ensure CSS styles natively support `button:disabled`.

--- a/maxwell_daemon/api/ui/app.js
+++ b/maxwell_daemon/api/ui/app.js
@@ -1552,6 +1552,7 @@ function wireKindSwitch() {
 async function submitNewTask(ev) {
   ev.preventDefault();
   const errEl = document.getElementById("new-task-error");
+  const submitBtn = document.getElementById("new-task-submit");
   errEl.hidden = true;
 
   const kind = document.querySelector('input[name="kind"]:checked').value;
@@ -1581,6 +1582,9 @@ async function submitNewTask(ev) {
     body = { prompt };
   }
 
+  submitBtn.disabled = true;
+  submitBtn.textContent = "Dispatching...";
+
   try {
     const r = await fetch(url, {
       method: "POST",
@@ -1597,6 +1601,9 @@ async function submitNewTask(ev) {
     errEl.textContent = `Network error: ${e.message}`;
     errEl.hidden = false;
     return;
+  } finally {
+    submitBtn.disabled = false;
+    submitBtn.textContent = "Dispatch";
   }
 
   closeNewTaskDialog();

--- a/maxwell_daemon/api/ui/style.css
+++ b/maxwell_daemon/api/ui/style.css
@@ -372,8 +372,9 @@ button {
   font: inherit;
   cursor: pointer;
 }
-button:hover { background: var(--border); }
+button:hover:not(:disabled) { background: var(--border); }
 button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+button:disabled { opacity: 0.6; cursor: not-allowed; }
 button.cancel { color: var(--err); }
 
 input,


### PR DESCRIPTION
💡 What: Added visual disabled styles (`button:disabled { opacity: 0.6; cursor: not-allowed; }`) and logically disable the task dispatch submit button (setting `disabled = true` and updating the text to `Dispatching...`) while an async task dispatch request is pending. Restored the button state on success or failure using a `finally` block.

🎯 Why: To provide immediate feedback that a task dispatch request has been initiated, preventing unintentional double submissions or multiple clicks while waiting for the server response.

📸 Before/After: Before this change, the dispatch button remained active during request execution, providing no feedback. Now, it immediately disables and changes text to "Dispatching...", and the cursor changes to `not-allowed`.

♿ Accessibility: Ensures interactive elements visually communicate their disabled/loading state, preventing confusion or errors for users who may click multiple times if no immediate feedback is provided.

---
*PR created automatically by Jules for task [15424594817709757681](https://jules.google.com/task/15424594817709757681) started by @dieterolson*