### PR TITLE
⚡ Bolt: [performance improvement] Avoid O(N) array allocations for UI Map aggregates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-10-25 - Redundant Data Fetching on Event Streams
 **Learning:** Fetching heavy detailed state for a resource (e.g. `fetchTaskDetail`) on every background event for that resource—regardless of whether it's currently visible in the UI—causes redundant API requests and wasteful re-renders. A global list fetch often handles the high-level status updates needed for hidden resources.
 **Action:** Always verify if a resource is actively being viewed (e.g. `state.selected === id`) before firing off detailed fetch operations in response to background event streams.
+
+## 2024-10-26 - O(N) Array Allocations for Map Aggregates
+**Learning:** Spreading `Map.values()` into arrays repeatedly (e.g., `[...state.allTasks.values()].filter(...).length` or `.reduce(...)`) just to compute aggregates causes unnecessary O(N) memory allocations and garbage collection pressure, leading to UI frame drops when updates happen rapidly (like via WebSockets).
+**Action:** Always compute aggregate values over Map or Set structures using a single `for...of` loop or iterator instead of creating intermediate arrays.

--- a/maxwell_daemon/api/ui/app.js
+++ b/maxwell_daemon/api/ui/app.js
@@ -255,8 +255,19 @@ async function refreshAll() {
 
 function updateStatusResources(costOverride) {
   const taskCount = state.allTasks.size || state.tasks.size;
-  const running = [...state.allTasks.values()].filter((t) => t.status === "running").length;
-  const totalCost = costOverride ?? [...state.allTasks.values()].reduce((s, t) => s + (t.cost_usd || 0), 0);
+
+  // ⚡ Bolt: Use a single pass over Map.values() instead of spreading to arrays twice
+  // O(N) array allocation avoided, reducing GC pressure during rapid UI updates
+  let running = 0;
+  let totalCost = 0;
+  for (const t of state.allTasks.values()) {
+    if (t.status === "running") running++;
+    if (costOverride === undefined) totalCost += (t.cost_usd || 0);
+  }
+  if (costOverride !== undefined) {
+    totalCost = costOverride;
+  }
+
   const el = document.getElementById("status-resources");
   if (el) el.textContent = `Tasks ${taskCount} | Running ${running} | Cost ${fmtUsdShort(totalCost)}`;
 }
@@ -268,10 +279,17 @@ async function fetchCostDetail() {
   const detailEl = document.getElementById("cost-summary-detail");
   const byBackend = body.by_backend || {};
   const total = body.month_to_date_usd || 0;
-  const taskCount = [...state.allTasks.values()].length;
-  const avgCost = taskCount > 0
-    ? [...state.allTasks.values()].reduce((s, t) => s + (t.cost_usd || 0), 0) / taskCount
-    : 0;
+
+  // ⚡ Bolt: Use size instead of spreading to an array and getting length.
+  // Then use a for...of loop instead of spreading to an array for reduce.
+  const taskCount = state.allTasks.size;
+  let totalTasksCost = 0;
+  if (taskCount > 0) {
+    for (const t of state.allTasks.values()) {
+      totalTasksCost += (t.cost_usd || 0);
+    }
+  }
+  const avgCost = taskCount > 0 ? totalTasksCost / taskCount : 0;
 
   detailEl.innerHTML = `
     <div class="cost-stat">


### PR DESCRIPTION
**What:** Replaced the array spread operator (`[...Map.values()]`) on frontend task state objects during the computation of cost and task counts with direct `Map.size` lookups and `for...of` loops.

**Why:** Repeatedly spreading large object maps directly into arrays just to perform `.reduce()` calculations or access `.length` produces immense garbage collection pressure during high-frequency, WebSocket-driven event updates. This can cause severe UI layout thrashing and drop frames.

**Impact:** Avoids creating large O(N) intermediate arrays on the JS heap, which prevents UI latency and dropped frames when hundreds of tasks rapidly update via events.

**Measurement:** Loaded frontend via Playwright script, verified that the "Tasks", "Running", and "Cost" metrics in the top corner and in the Analytics view continue to update accurately under load. Evaluated the absence of memory bloat. Tested by starting the Daemon via `maxwell-daemon serve` and verifying changes work. Included a critical learnings entry in the journal.

---
*PR created automatically by Jules for task [6874523019165362824](https://jules.google.com/task/6874523019165362824) started by @dieterolson*