### PR TITLE
feat: Ollama local-model discovery and management

### DIFF
--- a/maxwell_daemon/backends/ollama_discovery.py
+++ b/maxwell_daemon/backends/ollama_discovery.py
@@ -1,0 +1,204 @@
+"""Ollama local-model discovery.
+
+Queries the Ollama REST API (``GET /api/tags``) to enumerate models that are
+available on the local machine.  The result is a typed ``OllamaModelInfo``
+list so callers can inspect name, size, and family without parsing raw dicts.
+
+Usage
+-----
+Synchronous (e.g. CLI, startup checks)::
+
+    from maxwell_daemon.backends.ollama_discovery import discover_ollama_models
+
+    models = discover_ollama_models()          # uses http://localhost:11434
+    for m in models:
+        print(m.name, m.size_gb, m.family)
+
+Async (inside an agent loop or FastAPI handler)::
+
+    models = await adiscover_ollama_models()
+
+Ollama not running
+------------------
+Both functions return an empty list when the Ollama server is unreachable
+or returns a non-200 status, rather than raising an exception.  Use
+``is_ollama_available()`` / ``ais_ollama_available()`` to probe liveness
+without fetching the full model list.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+import httpx
+
+from maxwell_daemon.logging import get_logger
+
+log = get_logger(__name__)
+
+__all__ = [
+    "OllamaModelInfo",
+    "adiscover_ollama_models",
+    "ais_ollama_available",
+    "discover_ollama_models",
+    "is_ollama_available",
+]
+
+_DEFAULT_ENDPOINT = "http://localhost:11434"
+_TIMEOUT = 5.0
+
+
+def _endpoint() -> str:
+    """Return the Ollama base URL, honouring ``OLLAMA_HOST`` if set."""
+    raw = os.environ.get("OLLAMA_HOST", _DEFAULT_ENDPOINT).strip().rstrip("/")
+    if raw and "://" not in raw:
+        raw = f"http://{raw}"
+    return raw or _DEFAULT_ENDPOINT
+
+
+@dataclass(slots=True, frozen=True)
+class OllamaModelInfo:
+    """Parsed information about a single Ollama model.
+
+    Attributes
+    ----------
+    name:
+        Full model tag as reported by Ollama (e.g. ``"llama3.1:8b"``).
+    size_bytes:
+        Model size in bytes (0 when not reported by the server).
+    size_gb:
+        Convenience property: size in gigabytes rounded to two decimal places.
+    family:
+        Model family extracted from the name prefix (e.g. ``"llama3.1"``).
+    digest:
+        Content digest string from the Ollama API (empty string if absent).
+    details:
+        Raw ``details`` dict from the API response for further inspection.
+    """
+
+    name: str
+    size_bytes: int = 0
+    digest: str = ""
+    details: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def size_gb(self) -> float:
+        """Model size in gigabytes, rounded to two decimal places."""
+        return round(self.size_bytes / 1_073_741_824, 2)
+
+    @property
+    def family(self) -> str:
+        """Model family: the part of the name before the first colon."""
+        return self.name.split(":")[0]
+
+
+def _parse_models(data: dict[str, object]) -> list[OllamaModelInfo]:
+    """Convert the raw ``/api/tags`` response into typed ``OllamaModelInfo`` objects."""
+    raw_models = data.get("models")
+    if not isinstance(raw_models, list):
+        return []
+    result: list[OllamaModelInfo] = []
+    for entry in raw_models:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name") or entry.get("model") or ""
+        if not name:
+            continue
+        result.append(
+            OllamaModelInfo(
+                name=str(name),
+                size_bytes=int(entry.get("size", 0)),
+                digest=str(entry.get("digest", "")),
+                details=dict(entry.get("details") or {}),
+            )
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Synchronous API
+# ---------------------------------------------------------------------------
+
+
+def discover_ollama_models(endpoint: str | None = None) -> list[OllamaModelInfo]:
+    """Return all models currently available in the local Ollama installation.
+
+    Parameters
+    ----------
+    endpoint:
+        Ollama base URL.  Defaults to ``$OLLAMA_HOST`` or
+        ``http://localhost:11434``.
+
+    Returns
+    -------
+    list[OllamaModelInfo]
+        Empty list when Ollama is unreachable or has no models.
+    """
+    base = (endpoint or _endpoint()).rstrip("/")
+    try:
+        with httpx.Client(timeout=_TIMEOUT) as client:
+            resp = client.get(f"{base}/api/tags")
+            resp.raise_for_status()
+            return _parse_models(resp.json())
+    except Exception as exc:
+        log.debug("ollama_discovery: could not reach %s: %s", base, exc)
+        return []
+
+
+def is_ollama_available(endpoint: str | None = None) -> bool:
+    """Return ``True`` when the Ollama server is reachable and healthy."""
+    base = (endpoint or _endpoint()).rstrip("/")
+    try:
+        with httpx.Client(timeout=_TIMEOUT) as client:
+            resp = client.get(f"{base}/api/tags")
+            return resp.status_code == 200
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Async API
+# ---------------------------------------------------------------------------
+
+
+async def adiscover_ollama_models(endpoint: str | None = None) -> list[OllamaModelInfo]:
+    """Async version of :func:`discover_ollama_models`.
+
+    Parameters
+    ----------
+    endpoint:
+        Ollama base URL.  Defaults to ``$OLLAMA_HOST`` or
+        ``http://localhost:11434``.
+    """
+    base = (endpoint or _endpoint()).rstrip("/")
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.get(f"{base}/api/tags")
+            resp.raise_for_status()
+            return _parse_models(resp.json())
+    except Exception as exc:
+        log.debug("ollama_discovery: could not reach %s: %s", base, exc)
+        return []
+
+
+async def ais_ollama_available(endpoint: str | None = None) -> bool:
+    """Async version of :func:`is_ollama_available`."""
+    base = (endpoint or _endpoint()).rstrip("/")
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.get(f"{base}/api/tags")
+            return resp.status_code == 200
+    except Exception:
+        return False
+
+
+if __name__ == "__main__":
+    # Quick CLI smoke test: python -m maxwell_daemon.backends.ollama_discovery
+    models = discover_ollama_models()
+    if not models:
+        print("No Ollama models found (is Ollama running?)")
+    else:
+        print(f"Found {len(models)} Ollama model(s):")
+        for m in models:
+            print(f"  {m.name:<40} {m.size_gb:>6.2f} GB  family={m.family}")

--- a/tests/unit/test_ollama_discovery.py
+++ b/tests/unit/test_ollama_discovery.py
@@ -1,0 +1,172 @@
+"""Tests for Ollama local-model discovery."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+import respx
+
+from maxwell_daemon.backends.ollama_discovery import (
+    OllamaModelInfo,
+    adiscover_ollama_models,
+    ais_ollama_available,
+    discover_ollama_models,
+    is_ollama_available,
+)
+
+_FAKE_BASE = "http://fake-ollama:11434"
+
+_TAGS_RESPONSE = {
+    "models": [
+        {
+            "name": "llama3.1:8b",
+            "size": 4_800_000_000,
+            "digest": "sha256:abc123",
+            "details": {"family": "llama", "parameter_size": "8B"},
+        },
+        {
+            "name": "mistral:7b",
+            "size": 4_100_000_000,
+            "digest": "sha256:def456",
+            "details": {"family": "mistral", "parameter_size": "7B"},
+        },
+    ]
+}
+
+
+class TestDiscoverOllamaModels:
+    def test_returns_list_of_model_info(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json=_TAGS_RESPONSE)
+            models = discover_ollama_models(_FAKE_BASE)
+        assert len(models) == 2
+        assert all(isinstance(m, OllamaModelInfo) for m in models)
+
+    def test_model_names_parsed(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json=_TAGS_RESPONSE)
+            models = discover_ollama_models(_FAKE_BASE)
+        assert models[0].name == "llama3.1:8b"
+        assert models[1].name == "mistral:7b"
+
+    def test_size_bytes_parsed(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json=_TAGS_RESPONSE)
+            models = discover_ollama_models(_FAKE_BASE)
+        assert models[0].size_bytes == 4_800_000_000
+
+    def test_size_gb_property(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json=_TAGS_RESPONSE)
+            models = discover_ollama_models(_FAKE_BASE)
+        # 4_800_000_000 / 1_073_741_824 ~ 4.47 GB
+        assert 4.0 < models[0].size_gb < 5.0
+
+    def test_family_property_strips_tag(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json=_TAGS_RESPONSE)
+            models = discover_ollama_models(_FAKE_BASE)
+        assert models[0].family == "llama3.1"
+        assert models[1].family == "mistral"
+
+    def test_digest_parsed(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json=_TAGS_RESPONSE)
+            models = discover_ollama_models(_FAKE_BASE)
+        assert models[0].digest == "sha256:abc123"
+
+    def test_details_parsed(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json=_TAGS_RESPONSE)
+            models = discover_ollama_models(_FAKE_BASE)
+        assert models[0].details["family"] == "llama"
+
+    def test_empty_models_list(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json={"models": []})
+            models = discover_ollama_models(_FAKE_BASE)
+        assert models == []
+
+    def test_network_error_returns_empty_list(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").mock(side_effect=httpx.ConnectError("refused"))
+            models = discover_ollama_models(_FAKE_BASE)
+        assert models == []
+
+    def test_non_200_returns_empty_list(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(500)
+            models = discover_ollama_models(_FAKE_BASE)
+        assert models == []
+
+    def test_trailing_slash_on_endpoint_handled(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json=_TAGS_RESPONSE)
+            models = discover_ollama_models(_FAKE_BASE + "/")
+        assert len(models) == 2
+
+
+class TestIsOllamaAvailable:
+    def test_returns_true_on_200(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json={"models": []})
+            assert is_ollama_available(_FAKE_BASE) is True
+
+    def test_returns_false_on_network_error(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").mock(side_effect=httpx.ConnectError("refused"))
+            assert is_ollama_available(_FAKE_BASE) is False
+
+    def test_returns_false_on_non_200(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(503)
+            assert is_ollama_available(_FAKE_BASE) is False
+
+
+class TestAsyncDiscover:
+    def test_async_returns_same_results(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json=_TAGS_RESPONSE)
+            models = asyncio.run(adiscover_ollama_models(_FAKE_BASE))
+        assert len(models) == 2
+        assert models[0].name == "llama3.1:8b"
+
+    def test_async_network_error_returns_empty(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").mock(side_effect=httpx.ConnectError("refused"))
+            models = asyncio.run(adiscover_ollama_models(_FAKE_BASE))
+        assert models == []
+
+    def test_async_is_available_true_on_200(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").respond(200, json={"models": []})
+            result = asyncio.run(ais_ollama_available(_FAKE_BASE))
+        assert result is True
+
+    def test_async_is_available_false_on_error(self) -> None:
+        with respx.mock(base_url=_FAKE_BASE) as mock:
+            mock.get("/api/tags").mock(side_effect=httpx.ConnectError("refused"))
+            result = asyncio.run(ais_ollama_available(_FAKE_BASE))
+        assert result is False
+
+
+class TestOllamaModelInfo:
+    def test_family_no_tag_returns_full_name(self) -> None:
+        m = OllamaModelInfo(name="devstral")
+        assert m.family == "devstral"
+
+    def test_size_gb_zero_when_no_size(self) -> None:
+        m = OllamaModelInfo(name="tiny-model")
+        assert m.size_gb == 0.0
+
+    def test_default_digest_is_empty_string(self) -> None:
+        m = OllamaModelInfo(name="x")
+        assert m.digest == ""
+
+    def test_env_var_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OLLAMA_HOST", _FAKE_BASE)
+        from maxwell_daemon.backends.ollama_discovery import _endpoint
+
+        assert _endpoint() == _FAKE_BASE


### PR DESCRIPTION
## Summary
- Adds `maxwell_daemon/backends/ollama_discovery.py` with `discover_ollama_models()` that calls `GET http://localhost:11434/api/tags` and returns a typed `OllamaModelInfo` list
- `OllamaModelInfo` includes `name`, `size_bytes`, `size_gb` (property), `family` (property), `digest`, and raw `details`
- `is_ollama_available()` for lightweight liveness probes
- Async variants: `adiscover_ollama_models()` / `ais_ollama_available()`
- Respects `OLLAMA_HOST` env var; returns empty list instead of raising on network errors
- 22 unit tests using `respx` mock covering happy path, empty results, HTTP errors, connection errors, async variants, model info properties

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)