### PR TITLE
feat: backup/restore/export for config, memory, audit log, cost ledger

### DIFF
--- a/maxwell_daemon/cli/backup.py
+++ b/maxwell_daemon/cli/backup.py
@@ -1,0 +1,189 @@
+"""CLI commands for backup, restore, and JSON export of Maxwell-Daemon state."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from maxwell_daemon.core.backup import BackupManager, RestoreError
+
+backup_app = typer.Typer(
+    help="Backup, restore, and export Maxwell-Daemon state.",
+    no_args_is_help=True,
+)
+console = Console()
+err_console = Console(stderr=True)
+
+
+def _make_manager(
+    config: Path | None,
+    data_dir: Path | None,
+) -> BackupManager:
+    return BackupManager(config_path=config, data_dir=data_dir)
+
+
+@backup_app.command("export")
+def export_cmd(
+    out: Annotated[
+        Path | None,
+        typer.Option("--out", "-o", help="Destination archive path (.tar.gz)"),
+    ] = None,
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Config file path"),
+    ] = None,
+    data_dir: Annotated[
+        Path | None,
+        typer.Option("--data-dir", help="Data directory override"),
+    ] = None,
+) -> None:
+    """Export all Maxwell-Daemon state to a timestamped .tar.gz archive."""
+    mgr = _make_manager(config, data_dir)
+    try:
+        archive = mgr.export(out)
+    except Exception as exc:
+        err_console.print(f"[red]Export failed:[/red] {exc}")
+        raise typer.Exit(1) from None
+
+    console.print(
+        Panel.fit(
+            f"[green]✓[/green] Archive written to [bold]{archive}[/bold]",
+            title="Backup export",
+            border_style="green",
+        )
+    )
+
+
+@backup_app.command("restore")
+def restore_cmd(
+    archive: Annotated[Path, typer.Argument(help="Path to the .tar.gz backup archive")],
+    force: Annotated[
+        bool,
+        typer.Option("--force", "-f", help="Overwrite existing data without prompting"),
+    ] = False,
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Config file path"),
+    ] = None,
+    data_dir: Annotated[
+        Path | None,
+        typer.Option("--data-dir", help="Data directory override"),
+    ] = None,
+) -> None:
+    """Restore Maxwell-Daemon state from a backup archive.
+
+    Validates every file hash before writing anything to disk.
+    Use --force to overwrite existing state.
+    """
+    mgr = _make_manager(config, data_dir)
+    try:
+        mgr.restore(archive, force=force)
+    except RestoreError as exc:
+        err_console.print(f"[red]Restore failed:[/red] {exc}")
+        raise typer.Exit(1) from None
+    except Exception as exc:
+        err_console.print(f"[red]Unexpected error during restore:[/red] {exc}")
+        raise typer.Exit(1) from None
+
+    console.print(
+        Panel.fit(
+            "[green]✓[/green] State restored successfully.",
+            title="Backup restore",
+            border_style="green",
+        )
+    )
+
+
+@backup_app.command("export-json")
+def export_json_cmd(
+    component: Annotated[
+        str,
+        typer.Argument(
+            help=(
+                "Component to export: config, audit, ledger, tasks, work_items, "
+                "task_graphs, actions, artifacts_db, delegate_sessions, "
+                "auth_sessions, memory_db"
+            )
+        ),
+    ],
+    out: Annotated[
+        Path | None,
+        typer.Option("--out", "-o", help="Write JSON to this file instead of stdout"),
+    ] = None,
+    config: Annotated[
+        Path | None,
+        typer.Option("--config", "-c", help="Config file path"),
+    ] = None,
+    data_dir: Annotated[
+        Path | None,
+        typer.Option("--data-dir", help="Data directory override"),
+    ] = None,
+) -> None:
+    """Export a single component to JSON for inspection.
+
+    Example: maxwell-daemon backup export-json ledger --out ledger.json
+    """
+    mgr = _make_manager(config, data_dir)
+    try:
+        data = mgr.export_json(component)
+    except ValueError as exc:
+        err_console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from None
+    except Exception as exc:
+        err_console.print(f"[red]Unexpected error:[/red] {exc}")
+        raise typer.Exit(1) from None
+
+    serialised = json.dumps(data, indent=2, default=str)
+
+    if out:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(serialised, encoding="utf-8")
+        console.print(f"[green]✓[/green] Wrote {component} JSON to [bold]{out}[/bold]")
+    else:
+        sys.stdout.write(serialised + "\n")
+
+
+@backup_app.command("info")
+def info_cmd(
+    archive: Annotated[Path, typer.Argument(help="Path to the .tar.gz backup archive")],
+) -> None:
+    """Show the manifest and component summary of a backup archive."""
+    import tarfile
+
+    archive = archive.expanduser().resolve()
+    if not archive.exists():
+        err_console.print(f"[red]Archive not found:[/red] {archive}")
+        raise typer.Exit(1)
+
+    try:
+        with tarfile.open(archive, "r:gz") as tar:
+            manifest_member = tar.getmember("maxwell-backup/manifest.json")
+            fh = tar.extractfile(manifest_member)
+            if fh is None:
+                raise RuntimeError("Could not read manifest.json from archive")
+            manifest_data = json.loads(fh.read().decode("utf-8"))
+    except Exception as exc:
+        err_console.print(f"[red]Failed to read archive:[/red] {exc}")
+        raise typer.Exit(1) from None
+
+    table = Table(title="Backup manifest", header_style="bold cyan")
+    table.add_column("Field")
+    table.add_column("Value")
+    table.add_row("Created at", manifest_data.get("created_at", "?"))
+    table.add_row("Schema version", manifest_data.get("schema_version", "?"))
+    table.add_row("Config path", manifest_data.get("config_path", "?"))
+    table.add_row("Data dir", manifest_data.get("data_dir", "?"))
+
+    hashes = manifest_data.get("hashes", {})
+    components = [k for k in hashes if k not in ("artifacts", "memory")]
+    components += ["artifacts", "memory"] if "artifacts" in hashes else []
+    components += ["memory"] if "memory" in hashes else []
+    table.add_row("Components", ", ".join(components))
+    console.print(table)

--- a/maxwell_daemon/cli/main.py
+++ b/maxwell_daemon/cli/main.py
@@ -18,6 +18,7 @@ from maxwell_daemon import __version__
 from maxwell_daemon.backends import Message, MessageRole
 from maxwell_daemon.backends.registry import registry
 from maxwell_daemon.cli.actions import action_app
+from maxwell_daemon.cli.backup import backup_app
 from maxwell_daemon.cli.checks import checks_app
 from maxwell_daemon.cli.delegates import delegate_app
 from maxwell_daemon.cli.evals import eval_app
@@ -45,6 +46,7 @@ app = typer.Typer(
     no_args_is_help=False,
     rich_markup_mode="rich",
 )
+app.add_typer(backup_app, name="backup")
 app.add_typer(issue_app, name="issue")
 app.add_typer(eval_app, name="eval")
 app.add_typer(spec_app, name="spec")

--- a/maxwell_daemon/core/__init__.py
+++ b/maxwell_daemon/core/__init__.py
@@ -6,6 +6,7 @@ from maxwell_daemon.core.action_store import ActionStore
 from maxwell_daemon.core.actions import Action, ActionKind, ActionRiskLevel, ActionStatus
 from maxwell_daemon.core.artifacts import Artifact, ArtifactKind, ArtifactStore
 from maxwell_daemon.core.auth_session_store import AuthSessionStore
+from maxwell_daemon.core.backup import BackupManager, BackupManifest, RestoreError
 from maxwell_daemon.core.budget import BudgetCheck, BudgetEnforcer, BudgetExceededError
 from maxwell_daemon.core.cost_analytics import (
     CacheHitMetrics,
@@ -75,6 +76,8 @@ __all__ = [
     "AssignmentLease",
     "AuthSessionStore",
     "BackendRouter",
+    "BackupManager",
+    "BackupManifest",
     "BudgetCheck",
     "BudgetEnforcer",
     "BudgetExceededError",
@@ -104,6 +107,7 @@ __all__ = [
     "RepoOverrides",
     "ResourceAccount",
     "ResourceBroker",
+    "RestoreError",
     "RoutingAlternative",
     "RoutingDecision",
     "RoutingPolicy",

--- a/maxwell_daemon/core/backup.py
+++ b/maxwell_daemon/core/backup.py
@@ -1,0 +1,553 @@
+"""Backup, restore, and JSON-export for all Maxwell-Daemon state.
+
+Components covered
+------------------
+- Config file  (~/.config/maxwell-daemon/maxwell-daemon.yaml)
+- SQLite databases: tasks, work items, task graphs, actions, artifacts,
+  delegate sessions, auth sessions, cost ledger, memory
+- Audit log     (.jsonl hash-chained file)
+- Artifact blobs (directory tree)
+- Memory markdowns (.maxwell/memory & .maxwell/raw_logs)
+
+Archive format
+--------------
+A gzip-compressed tar archive containing:
+  manifest.json        — schema version, component paths, BLAKE3→SHA-256 hashes, timestamp
+  secrets.env.example  — placeholder listing secret refs that must be re-entered after restore
+  config/              — config YAML (secrets stripped)
+  data/                — all SQLite DBs (via sqlite3 Online Backup API)
+  audit/               — audit JSONL
+  artifacts/           — blob files
+  memory/              — markdown & raw-log files
+
+Usage::
+
+    mgr = BackupManager()
+    path = mgr.export(Path("~/maxwell-backup.tar.gz"))
+    mgr.restore(path)
+    data = mgr.export_json("ledger")
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sqlite3
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "BackupManager",
+    "BackupManifest",
+    "RestoreError",
+]
+
+_SCHEMA_VERSION = "1"
+
+# Default data-store root (mirrors daemon/runner.py defaults)
+_DEFAULT_DATA_DIR = Path.home() / ".local/share/maxwell-daemon"
+_DEFAULT_CONFIG_PATH = Path.home() / ".config/maxwell-daemon/maxwell-daemon.yaml"
+
+# Components that correspond to SQLite DBs inside the data dir
+_SQLITE_COMPONENTS: dict[str, str] = {
+    "tasks": "tasks.db",
+    "work_items": "work_items.db",
+    "task_graphs": "task_graphs.db",
+    "actions": "actions.db",
+    "artifacts_db": "artifacts.db",
+    "delegate_sessions": "delegate_sessions.db",
+    "auth_sessions": "auth_sessions.db",
+    "ledger": "ledger.db",
+    "memory_db": "memory.db",
+}
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _sha256_dir(directory: Path) -> dict[str, str]:
+    """Return {relative_posix_path: sha256} for all files under *directory*."""
+    result: dict[str, str] = {}
+    for p in sorted(directory.rglob("*")):
+        if p.is_file():
+            result[p.relative_to(directory).as_posix()] = _sha256_file(p)
+    return result
+
+
+def _safe_sqlite_backup(src: Path, dst: Path) -> None:
+    """Copy *src* SQLite database to *dst* using the Online Backup API."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src_conn = sqlite3.connect(str(src), uri=True)
+    dst_conn = sqlite3.connect(str(dst))
+    try:
+        src_conn.backup(dst_conn)
+    finally:
+        dst_conn.close()
+        src_conn.close()
+
+
+class RestoreError(RuntimeError):
+    """Raised when restore validation fails."""
+
+
+class BackupManifest:
+    """Lightweight manifest written into and read from the archive."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    @classmethod
+    def create(cls, hashes: dict[str, Any], config_path: Path, data_dir: Path) -> BackupManifest:
+        return cls(
+            {
+                "schema_version": _SCHEMA_VERSION,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "config_path": str(config_path),
+                "data_dir": str(data_dir),
+                "hashes": hashes,
+            }
+        )
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BackupManifest:
+        return cls(d)
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self._data)
+
+    @property
+    def schema_version(self) -> str:
+        return str(self._data.get("schema_version", ""))
+
+    @property
+    def config_path(self) -> Path:
+        return Path(self._data.get("config_path", str(_DEFAULT_CONFIG_PATH)))
+
+    @property
+    def data_dir(self) -> Path:
+        return Path(self._data.get("data_dir", str(_DEFAULT_DATA_DIR)))
+
+    @property
+    def hashes(self) -> dict[str, Any]:
+        return dict(self._data.get("hashes", {}))
+
+
+class BackupManager:
+    """Backup, restore, and JSON-export controller for Maxwell-Daemon state.
+
+    Parameters
+    ----------
+    config_path:
+        Path to ``maxwell-daemon.yaml``.  Defaults to the XDG/home standard location.
+    data_dir:
+        Parent directory that holds the SQLite databases, audit log, artifact blobs,
+        and memory markdowns.  Defaults to ``~/.local/share/maxwell-daemon``.
+    """
+
+    def __init__(
+        self,
+        config_path: Path | None = None,
+        data_dir: Path | None = None,
+    ) -> None:
+        self._config_path = (config_path or _DEFAULT_CONFIG_PATH).expanduser()
+        self._data_dir = (data_dir or _DEFAULT_DATA_DIR).expanduser()
+
+    # ── public API ────────────────────────────────────────────────────────────
+
+    def export(self, out: Path | str | None = None) -> Path:
+        """Create a timestamped .tar.gz backup archive.
+
+        Parameters
+        ----------
+        out:
+            Destination path.  If omitted a timestamped file is created in the
+            current working directory.
+
+        Returns
+        -------
+        Path
+            Absolute path to the created archive.
+        """
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        dest = Path(out).expanduser() if out else Path(f"maxwell-backup-{stamp}.tar.gz")
+        dest = dest.resolve()
+
+        with tempfile.TemporaryDirectory(prefix="maxwell-backup-") as tmp_str:
+            tmp = Path(tmp_str)
+            hashes: dict[str, Any] = {}
+
+            # 1. Config (secrets stripped)
+            self._export_config(tmp / "config", hashes)
+
+            # 2. SQLite databases
+            for component, filename in _SQLITE_COMPONENTS.items():
+                src = self._data_dir / filename
+                if src.exists():
+                    dst = tmp / "data" / filename
+                    _safe_sqlite_backup(src, dst)
+                    hashes[component] = _sha256_file(dst)
+
+            # 3. Audit log
+            self._export_audit(tmp / "audit", hashes)
+
+            # 4. Artifact blobs
+            self._export_artifacts(tmp / "artifacts", hashes)
+
+            # 5. Memory markdowns
+            self._export_memory(tmp / "memory", hashes)
+
+            # 6. Manifest
+            manifest = BackupManifest.create(hashes, self._config_path, self._data_dir)
+            manifest_path = tmp / "manifest.json"
+            manifest_path.write_text(json.dumps(manifest.to_dict(), indent=2), encoding="utf-8")
+
+            # 7. secrets.env.example
+            self._write_secrets_example(tmp / "secrets.env.example")
+
+            # 8. Pack
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with tarfile.open(dest, "w:gz") as tar:
+                tar.add(tmp, arcname="maxwell-backup")
+
+        return dest
+
+    def restore(self, archive: Path | str, *, force: bool = False) -> None:
+        """Restore state from a backup archive.
+
+        Parameters
+        ----------
+        archive:
+            Path to the ``.tar.gz`` produced by :meth:`export`.
+        force:
+            If *False* (default) the restore is aborted when existing data would
+            be overwritten and the archive predates the current files.
+
+        Raises
+        ------
+        RestoreError
+            When the manifest is missing, the schema version is unrecognised, or
+            any file hash fails verification.
+        """
+        archive = Path(archive).expanduser().resolve()
+        if not archive.exists():
+            raise RestoreError(f"archive not found: {archive}")
+
+        with tempfile.TemporaryDirectory(prefix="maxwell-restore-") as tmp_str:
+            tmp = Path(tmp_str)
+
+            # Unpack
+            with tarfile.open(archive, "r:gz") as tar:
+                tar.extractall(tmp)
+
+            root = tmp / "maxwell-backup"
+
+            # Load manifest
+            manifest_path = root / "manifest.json"
+            if not manifest_path.exists():
+                raise RestoreError("archive is missing manifest.json")
+            manifest = BackupManifest.from_dict(
+                json.loads(manifest_path.read_text(encoding="utf-8"))
+            )
+
+            # Schema check
+            if manifest.schema_version != _SCHEMA_VERSION:
+                raise RestoreError(
+                    f"unsupported backup schema version {manifest.schema_version!r} "
+                    f"(expected {_SCHEMA_VERSION!r})"
+                )
+
+            # Verify hashes
+            self._verify_hashes(root, manifest.hashes)
+
+            # Restore each component
+            self._restore_config(root / "config", force=force)
+            self._restore_sqlite(root / "data", force=force)
+            self._restore_audit(root / "audit", force=force)
+            self._restore_artifacts(root / "artifacts", force=force)
+            self._restore_memory(root / "memory", force=force)
+
+    def export_json(self, component: str) -> dict[str, Any]:
+        """Export a single component to a JSON-serialisable dict.
+
+        Parameters
+        ----------
+        component:
+            One of: ``config``, ``audit``, ``ledger``, ``tasks``, ``work_items``,
+            ``task_graphs``, ``actions``, ``artifacts_db``, ``delegate_sessions``,
+            ``auth_sessions``, ``memory_db``.
+
+        Returns
+        -------
+        dict
+            JSON-serialisable representation of the component.
+        """
+        component = component.lower().strip()
+
+        if component == "config":
+            return self._export_config_json()
+        if component == "audit":
+            return self._export_audit_json()
+        if component in _SQLITE_COMPONENTS:
+            return self._export_sqlite_json(component)
+        raise ValueError(
+            f"unknown component {component!r}. "
+            f"Valid values: config, audit, {', '.join(sorted(_SQLITE_COMPONENTS))}"
+        )
+
+    # ── export helpers ────────────────────────────────────────────────────────
+
+    def _export_config(self, dst_dir: Path, hashes: dict[str, Any]) -> None:
+        """Copy config YAML (with secrets redacted) into the staging area."""
+        if not self._config_path.exists():
+            return
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        dst = dst_dir / self._config_path.name
+        raw = self._redact_config(self._config_path.read_text(encoding="utf-8"))
+        dst.write_text(raw, encoding="utf-8")
+        hashes["config"] = _sha256_file(dst)
+
+    def _export_audit(self, dst_dir: Path, hashes: dict[str, Any]) -> None:
+        audit_src = self._data_dir / "audit.jsonl"
+        if not audit_src.exists():
+            return
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        dst = dst_dir / "audit.jsonl"
+        shutil.copy2(audit_src, dst)
+        hashes["audit"] = _sha256_file(dst)
+
+    def _export_artifacts(self, dst_dir: Path, hashes: dict[str, Any]) -> None:
+        artifacts_src = self._data_dir / "artifacts"
+        if not artifacts_src.exists():
+            return
+        shutil.copytree(artifacts_src, dst_dir, dirs_exist_ok=True)
+        hashes["artifacts"] = _sha256_dir(dst_dir)
+
+    def _export_memory(self, dst_dir: Path, hashes: dict[str, Any]) -> None:
+        memory_src = self._data_dir / ".maxwell"
+        if not memory_src.exists():
+            return
+        shutil.copytree(memory_src, dst_dir / ".maxwell", dirs_exist_ok=True)
+        hashes["memory"] = _sha256_dir(dst_dir)
+
+    # ── restore helpers ───────────────────────────────────────────────────────
+
+    def _restore_config(self, src_dir: Path, *, force: bool) -> None:
+        if not src_dir.exists():
+            return
+        for src_file in src_dir.iterdir():
+            dst = self._config_path.parent / src_file.name
+            if dst.exists() and not force:
+                raise RestoreError(f"config file {dst} already exists; pass --force to overwrite")
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src_file, dst)
+
+    def _restore_sqlite(self, src_dir: Path, *, force: bool) -> None:
+        if not src_dir.exists():
+            return
+        for src_db in src_dir.glob("*.db"):
+            dst = self._data_dir / src_db.name
+            if dst.exists() and not force:
+                raise RestoreError(f"database {dst} already exists; pass --force to overwrite")
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            _safe_sqlite_backup(src_db, dst)
+
+    def _restore_audit(self, src_dir: Path, *, force: bool) -> None:
+        if not src_dir.exists():
+            return
+        src = src_dir / "audit.jsonl"
+        if not src.exists():
+            return
+        dst = self._data_dir / "audit.jsonl"
+        if dst.exists() and not force:
+            raise RestoreError(f"audit log {dst} already exists; pass --force to overwrite")
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+    def _restore_artifacts(self, src_dir: Path, *, force: bool) -> None:
+        if not src_dir.exists():
+            return
+        dst_root = self._data_dir / "artifacts"
+        if dst_root.exists() and not force:
+            raise RestoreError(
+                f"artifacts directory {dst_root} already exists; pass --force to overwrite"
+            )
+        shutil.copytree(src_dir, dst_root, dirs_exist_ok=True)
+
+    def _restore_memory(self, src_dir: Path, *, force: bool) -> None:
+        if not src_dir.exists():
+            return
+        maxwell_src = src_dir / ".maxwell"
+        if not maxwell_src.exists():
+            return
+        dst_root = self._data_dir / ".maxwell"
+        if dst_root.exists() and not force:
+            raise RestoreError(
+                f"memory directory {dst_root} already exists; pass --force to overwrite"
+            )
+        shutil.copytree(maxwell_src, dst_root, dirs_exist_ok=True)
+
+    # ── JSON export helpers ───────────────────────────────────────────────────
+
+    def _export_config_json(self) -> dict[str, Any]:
+        if not self._config_path.exists():
+            return {}
+        import yaml  # already a dep via config loader
+
+        raw = yaml.safe_load(self._config_path.read_text(encoding="utf-8")) or {}
+        return self._redact_config_dict(raw)
+
+    def _export_audit_json(self) -> dict[str, Any]:
+        from maxwell_daemon.audit import AuditLogger
+
+        path = self._data_dir / "audit.jsonl"
+        if not path.exists():
+            return {"entries": []}
+        logger = AuditLogger(path)
+        # Paginate with a generous limit
+        entries = logger.entries(limit=100_000, offset=0)
+        return {"entries": entries, "count": len(entries)}
+
+    def _export_sqlite_json(self, component: str) -> dict[str, Any]:
+        """Dump every table from a SQLite DB as a list of row-dicts."""
+        filename = _SQLITE_COMPONENTS[component]
+        db_path = self._data_dir / filename
+        if not db_path.exists():
+            return {"tables": {}, "component": component}
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        tables: dict[str, list[dict[str, Any]]] = {}
+        try:
+            cursor = conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            for (table_name,) in cursor.fetchall():
+                rows = conn.execute(f"SELECT * FROM {table_name}").fetchall()
+                tables[table_name] = [dict(r) for r in rows]
+        finally:
+            conn.close()
+        return {"component": component, "tables": tables}
+
+    # ── hash verification ─────────────────────────────────────────────────────
+
+    def _verify_hashes(self, root: Path, hashes: dict[str, Any]) -> None:
+        """Check every recorded hash against the unpacked files."""
+        # Config
+        if "config" in hashes:
+            cfg_file = root / "config" / self._config_path.name
+            if cfg_file.exists():
+                actual = _sha256_file(cfg_file)
+                if actual != hashes["config"]:
+                    raise RestoreError(
+                        f"config hash mismatch: expected {hashes['config']}, got {actual}"
+                    )
+
+        # SQLite DBs
+        for component, filename in _SQLITE_COMPONENTS.items():
+            if component in hashes:
+                db_file = root / "data" / filename
+                if db_file.exists():
+                    actual = _sha256_file(db_file)
+                    if actual != hashes[component]:
+                        raise RestoreError(
+                            f"{component} hash mismatch: expected {hashes[component]}, got {actual}"
+                        )
+
+        # Audit log
+        if "audit" in hashes:
+            audit_file = root / "audit" / "audit.jsonl"
+            if audit_file.exists():
+                actual = _sha256_file(audit_file)
+                if actual != hashes["audit"]:
+                    raise RestoreError(
+                        f"audit hash mismatch: expected {hashes['audit']}, got {actual}"
+                    )
+
+        # Artifact blobs (per-file hash map)
+        if "artifacts" in hashes and isinstance(hashes["artifacts"], dict):
+            artifacts_dir = root / "artifacts"
+            if artifacts_dir.exists():
+                actual_hashes = _sha256_dir(artifacts_dir)
+                for rel, expected in hashes["artifacts"].items():
+                    if rel not in actual_hashes:
+                        raise RestoreError(f"artifact blob missing from archive: {rel}")
+                    if actual_hashes[rel] != expected:
+                        raise RestoreError(
+                            f"artifact blob hash mismatch for {rel}: "
+                            f"expected {expected}, got {actual_hashes[rel]}"
+                        )
+
+        # Memory files (per-file hash map)
+        if "memory" in hashes and isinstance(hashes["memory"], dict):
+            memory_dir = root / "memory"
+            if memory_dir.exists():
+                actual_hashes = _sha256_dir(memory_dir)
+                for rel, expected in hashes["memory"].items():
+                    if rel not in actual_hashes:
+                        raise RestoreError(f"memory file missing from archive: {rel}")
+                    if actual_hashes[rel] != expected:
+                        raise RestoreError(
+                            f"memory file hash mismatch for {rel}: "
+                            f"expected {expected}, got {actual_hashes[rel]}"
+                        )
+
+    # ── secrets helpers ───────────────────────────────────────────────────────
+
+    @staticmethod
+    def _redact_config(yaml_text: str) -> str:
+        """Strip plaintext api_key values from YAML text."""
+        import re
+
+        # Replace literal api_key values that are NOT env-var references
+        return re.sub(
+            r"(api_key\s*:\s*)(?!\$\{)(.+)",
+            r"\1<REDACTED>",
+            yaml_text,
+        )
+
+    @staticmethod
+    def _redact_config_dict(raw: dict[str, Any]) -> dict[str, Any]:
+        """Recursively redact sensitive keys from a config dict."""
+        sensitive_keys = {"api_key", "password", "token", "secret"}
+        result: dict[str, Any] = {}
+        for key, value in raw.items():
+            if key.lower() in sensitive_keys and isinstance(value, str):
+                result[key] = "<REDACTED>"
+            elif isinstance(value, dict):
+                result[key] = BackupManager._redact_config_dict(value)
+            else:
+                result[key] = value
+        return result
+
+    def _write_secrets_example(self, dst: Path) -> None:
+        """Write a placeholder file listing secret refs the user must re-enter."""
+        if not self._config_path.exists():
+            return
+        try:
+            import yaml
+
+            raw = yaml.safe_load(self._config_path.read_text(encoding="utf-8")) or {}
+        except Exception:
+            return
+
+        lines = [
+            "# Re-enter the following secrets after restoring on a new machine.",
+            "# Set each as an environment variable or re-run `maxwell-daemon init`.",
+            "",
+        ]
+        backends = raw.get("backends", {})
+        if isinstance(backends, dict):
+            for name, cfg in backends.items():
+                if isinstance(cfg, dict):
+                    ref = cfg.get("api_key_secret_ref")
+                    if ref:
+                        lines.append(f"# backend '{name}' — secret ref: {ref}")
+                    elif cfg.get("api_key"):
+                        lines.append(f"# backend '{name}' — set ANTHROPIC_API_KEY (or equivalent)")
+        dst.write_text("\n".join(lines) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary

- `BackupManager` in `maxwell_daemon/core/backup.py` with three public methods:
  - `export(path)` — creates a timestamped `.tar.gz` containing config (secrets redacted), all SQLite DBs (via Online Backup API), audit JSONL, artifact blobs, and memory markdowns; writes `manifest.json` with SHA-256 hashes and `secrets.env.example`
  - `restore(path, force=False)` — unpacks archive, verifies every hash in the manifest, then restores each component; refuses to overwrite without `--force`
  - `export_json(component)` — dumps a single component (config, audit, ledger, tasks, etc.) to a JSON-serialisable dict for inspection
- `BackupManager` / `BackupManifest` / `RestoreError` exported from `maxwell_daemon/core`
- `maxwell_daemon/cli/backup.py` — `backup_app` Typer sub-app with four commands:
  - `maxwell-daemon backup export [--out path]`
  - `maxwell-daemon backup restore <archive> [--force]`
  - `maxwell-daemon backup export-json <component> [--out path]`
  - `maxwell-daemon backup info <archive>` (shows manifest summary)
- Wired into the main CLI alongside existing sub-apps

Closes #484

## Test plan
- [x] `BackupManager.export()` produces a valid `.tar.gz` with `manifest.json`
- [x] `BackupManager.restore()` validates hashes before writing anything
- [x] Hash mismatch raises `RestoreError`; missing archive raises `RestoreError`
- [x] `export_json()` works for all named components
- [x] `ruff format` + `ruff check` pass with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)