### PR TITLE
feat: task DAG dependencies, cron triggers, generic webhook ingestion

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -118,6 +118,10 @@ class TaskSubmit(BaseModel):
     issue_number: int | None = None
     issue_mode: Literal["plan", "implement"] | None = None
     priority: PriorityField = 100
+    depends_on: list[str] = Field(
+        default_factory=list,
+        description="Task IDs that must reach COMPLETED before this task starts.",
+    )
 
 
 class WorkItemCreate(BaseModel):
@@ -416,6 +420,7 @@ class TaskView(BaseModel):
     issue_number: int | None = None
     issue_mode: str | None = None
     ab_group: str | None = None
+    depends_on: list[str] = Field(default_factory=list)
     priority: int = 100
     pr_url: str | None = None
     dispatched_to: str | None = None
@@ -444,6 +449,7 @@ class TaskView(BaseModel):
             issue_number=t.issue_number,
             issue_mode=t.issue_mode,
             ab_group=t.ab_group,
+            depends_on=list(getattr(t, "depends_on", [])),
             priority=getattr(t, "priority", 100),
             pr_url=t.pr_url,
             dispatched_to=t.dispatched_to,
@@ -1633,6 +1639,7 @@ def create_app(
                     model=payload.model,
                     priority=payload.priority,
                     task_id=payload.task_id,
+                    depends_on=payload.depends_on or [],
                 )
         except DuplicateTaskIdError as exc:
             raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
@@ -2550,6 +2557,74 @@ def create_app(
         return JSONResponse(
             {"event": event_type, "dispatched": len(dispatches)},
             status_code=status.HTTP_200_OK,
+        )
+
+    # ── Generic webhook trigger ──────────────────────────────────────────────
+
+    class _WebhookTriggerRequest(BaseModel):
+        """Body accepted by ``POST /api/webhooks/trigger``."""
+
+        prompt: str = Field(..., min_length=1)
+        repo: str | None = None
+        backend: str | None = None
+        priority: int = Field(default=100, ge=0, le=1000)
+
+    @app.post("/api/webhooks/trigger", dependencies=[Depends(_require_operator())])
+    async def generic_webhook_trigger(
+        request: Request,
+        body: Annotated[_WebhookTriggerRequest, Body()],
+    ) -> Response:
+        """Trigger a task from any external source via a generic HTTP webhook.
+
+        Unlike the GitHub endpoint this route is bearer-token authenticated
+        (operator role).  Optionally supply ``X-Maxwell-Signature: sha256=<hex>``
+        for an additional HMAC-SHA256 layer using the daemon's
+        ``webhook_secret`` config value, and ``X-Idempotency-Key`` to prevent
+        duplicate task creation on webhook retries.
+        """
+        from fastapi.responses import JSONResponse
+
+        from maxwell_daemon.triggers.webhook import (
+            WebhookTriggerPayload,
+            enqueue_webhook_task,
+            verify_webhook_signature,
+        )
+
+        # Optional extra HMAC layer — only enforced when a secret is configured.
+        webhook_secret: str | None = getattr(daemon._config, "webhook_secret", None)
+        if webhook_secret:
+            raw_body = await request.body()
+            sig_header = request.headers.get("x-maxwell-signature", "")
+            if not verify_webhook_signature(webhook_secret, raw_body, sig_header):
+                return JSONResponse(
+                    {"detail": "invalid signature"},
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                )
+
+        idempotency_key: str | None = request.headers.get("x-idempotency-key")
+
+        payload = WebhookTriggerPayload(
+            prompt=body.prompt,
+            repo=body.repo,
+            backend=body.backend,
+            priority=body.priority,
+            idempotency_key=idempotency_key,
+        )
+        result = enqueue_webhook_task(payload, daemon=daemon)
+
+        if result.error:
+            return JSONResponse(
+                {"detail": result.error},
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        if result.duplicate:
+            return JSONResponse(
+                {"duplicate": True, "task_id": None},
+                status_code=status.HTTP_200_OK,
+            )
+        return JSONResponse(
+            {"task_id": result.task_id, "duplicate": False},
+            status_code=status.HTTP_202_ACCEPTED,
         )
 
     # ── SSH endpoints ────────────────────────────────────────────────────────

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -103,6 +103,9 @@ class Task:
     issue_mode: str | None = None  # "plan" | "implement"
     # A/B grouping: sibling tasks share an ab_group so the UI pairs them.
     ab_group: str | None = None
+    # DAG dependencies: list of task IDs that must reach COMPLETED before this
+    # task is allowed to start.  An empty list (the default) means "no deps".
+    depends_on: list[str] = field(default_factory=list)
     # Priority: lower number = higher priority. 0=emergency, 50=high, 100=normal, 200=batch.
     priority: int = 100
     status: TaskStatus = TaskStatus.QUEUED
@@ -583,6 +586,7 @@ class Daemon:
         model: str | None = None,
         priority: int = 100,
         task_id: str | None = None,
+        depends_on: list[str] | None = None,
     ) -> Task:
         resolved_task_id = task_id or uuid.uuid4().hex[:12]
         task = Task(
@@ -593,6 +597,7 @@ class Daemon:
             backend=backend,
             model=model,
             priority=priority,
+            depends_on=list(depends_on) if depends_on else [],
         )
         # Persist and track the task under lock, then route the queue mutation
         # through the daemon loop if this caller is on a foreign thread.
@@ -1322,6 +1327,26 @@ class Daemon:
             with self._tasks_lock:
                 if task.status is not TaskStatus.QUEUED:
                     continue
+                # DAG dependency check: if any upstream task is not yet in a
+                # terminal-success state, requeue and wait for the next tick.
+                if task.depends_on:
+                    unfinished = [
+                        dep
+                        for dep in task.depends_on
+                        if self._tasks.get(dep, None) is None
+                        or self._tasks[dep].status is not TaskStatus.COMPLETED
+                    ]
+                    if unfinished:
+                        log.debug(
+                            "task %s waiting for dependencies %s; re-queuing",
+                            task.id,
+                            unfinished,
+                        )
+                        # Re-enqueue without changing status so the task stays QUEUED
+                        # and will be retried once the dependencies finish.
+                        self._queue.put_nowait((task.priority, task))
+                        self._queue.task_done()
+                        continue
                 task.status = TaskStatus.RUNNING
                 task.started_at = datetime.now(timezone.utc)
             with bind_context(task_id=task.id, worker_id=worker_id):

--- a/maxwell_daemon/triggers/__init__.py
+++ b/maxwell_daemon/triggers/__init__.py
@@ -1,0 +1,20 @@
+"""Trigger primitives for Maxwell-Daemon.
+
+Exposes time-based (cron) and HTTP webhook triggers that enqueue tasks
+without requiring GitHub as the event source.
+"""
+
+from maxwell_daemon.triggers.cron import CronScheduler, CronTrigger
+from maxwell_daemon.triggers.webhook import (
+    WebhookTriggerPayload,
+    WebhookTriggerResult,
+    enqueue_webhook_task,
+)
+
+__all__ = [
+    "CronScheduler",
+    "CronTrigger",
+    "WebhookTriggerPayload",
+    "WebhookTriggerResult",
+    "enqueue_webhook_task",
+]

--- a/maxwell_daemon/triggers/cron.py
+++ b/maxwell_daemon/triggers/cron.py
@@ -1,0 +1,224 @@
+"""Cron-based task scheduler.
+
+Parses standard 5-field cron expressions and enqueues tasks on schedule via
+the daemon's ``submit`` method.  Intentionally self-contained: uses only the
+stdlib ``datetime`` module to avoid mandatory third-party dependencies, but
+will delegate to ``croniter`` if it is installed for more exotic expressions.
+
+Cron field layout (all 1-indexed; ``*`` means "any"):
+
+    ┌───────────── minute        (0-59)
+    │ ┌─────────── hour          (0-23)
+    │ │ ┌───────── day-of-month  (1-31)
+    │ │ │ ┌─────── month         (1-12)
+    │ │ │ │ ┌───── day-of-week   (0-6, Sunday=0)
+    │ │ │ │ │
+    * * * * *
+
+Only single values, ``*``, and ``*/step`` are supported in the built-in
+parser.  Install ``croniter`` for full range/list syntax support.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from maxwell_daemon.contracts import require
+from maxwell_daemon.logging import get_logger
+
+__all__ = ["CronScheduler", "CronTrigger"]
+
+log = get_logger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class CronTrigger:
+    """Wires a cron expression to a task prompt.
+
+    Attributes:
+        cron: Five-field cron expression, e.g. ``"0 9 * * 1"`` (Mondays 09:00).
+        prompt: The task prompt text to enqueue when the trigger fires.
+        repo: Optional repository hint forwarded to ``daemon.submit``.
+        backend: Optional backend hint forwarded to ``daemon.submit``.
+        priority: Task priority (lower = higher priority; default 100).
+        tz: Timezone name understood by ``datetime``; only ``"UTC"`` is
+            supported by the built-in parser.  Install ``croniter`` for full
+            tz support.
+    """
+
+    cron: str
+    prompt: str
+    repo: str | None = None
+    backend: str | None = None
+    priority: int = 100
+    tz: str = "UTC"
+
+
+def _parse_field(value: str, lo: int, hi: int) -> set[int]:
+    """Parse a single cron field into the set of matching integers.
+
+    Supports ``*``, ``*/step``, and plain integers within ``[lo, hi]``.
+    Raises ``ValueError`` for anything else.
+    """
+    if value == "*":
+        return set(range(lo, hi + 1))
+    if value.startswith("*/"):
+        step = int(value[2:])
+        require(step > 0, f"cron step must be > 0, got {step!r}")
+        return set(range(lo, hi + 1, step))
+    v = int(value)
+    require(lo <= v <= hi, f"cron value {v} out of range [{lo}, {hi}]")
+    return {v}
+
+
+def _parse_cron(expr: str) -> tuple[set[int], set[int], set[int], set[int], set[int]]:
+    """Return (minutes, hours, mdays, months, wdays) sets for *expr*."""
+    parts = expr.strip().split()
+    require(len(parts) == 5, f"cron expression must have 5 fields, got {len(parts)}: {expr!r}")
+    minutes = _parse_field(parts[0], 0, 59)
+    hours = _parse_field(parts[1], 0, 23)
+    mdays = _parse_field(parts[2], 1, 31)
+    months = _parse_field(parts[3], 1, 12)
+    wdays = _parse_field(parts[4], 0, 6)
+    return minutes, hours, mdays, months, wdays
+
+
+def _matches(dt: datetime, cron: str) -> bool:
+    """Return True if *dt* (minute-precision) matches *cron*."""
+    try:
+        minutes, hours, mdays, months, wdays = _parse_cron(cron)
+    except (ValueError, Exception):
+        log.warning("invalid cron expression %r; skipping", cron)
+        return False
+    return (
+        dt.minute in minutes
+        and dt.hour in hours
+        and dt.day in mdays
+        and dt.month in months
+        and dt.isoweekday() % 7 in wdays  # isoweekday: Mon=1..Sun=7 → Sun=0
+    )
+
+
+def _next_tick_delay(now: datetime) -> float:
+    """Seconds until the start of the next whole minute."""
+    next_minute = (now + timedelta(minutes=1)).replace(second=0, microsecond=0)
+    return (next_minute - now).total_seconds()
+
+
+class CronScheduler:
+    """Runs registered :class:`CronTrigger` entries on a per-minute poll.
+
+    Usage::
+
+        scheduler = CronScheduler(daemon=daemon)
+        scheduler.add(CronTrigger(cron="0 9 * * 1", prompt="Weekly report"))
+        await scheduler.start()
+        ...
+        await scheduler.stop()
+
+    The scheduler fires ``daemon.submit`` on matching minutes.  Each tick
+    checks the wall-clock minute against every registered trigger expression.
+    Ticks are aligned to whole minutes (skew ≤ 1 s by design).
+    """
+
+    def __init__(self, *, daemon: Any) -> None:
+        self._daemon = daemon
+        self._triggers: list[CronTrigger] = []
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event: asyncio.Event | None = None
+
+    def add(self, trigger: CronTrigger) -> None:
+        """Register a cron trigger.  May be called before or after ``start``."""
+        self._triggers.append(trigger)
+
+    def remove(self, trigger: CronTrigger) -> None:
+        """Unregister a previously added trigger.  No-op if not found."""
+        with contextlib.suppress(ValueError):
+            self._triggers.remove(trigger)
+
+    async def start(self) -> None:
+        """Begin the per-minute cron loop in a background task.  Idempotent."""
+        if self._task is not None and not self._task.done():
+            return
+        self._stop_event = asyncio.Event()
+        self._task = asyncio.create_task(self._loop(), name="cron-scheduler")
+
+    async def stop(self) -> None:
+        """Signal the loop to exit and wait for it.  Idempotent."""
+        if self._stop_event is not None:
+            self._stop_event.set()
+        if self._task is not None:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._task
+            self._task = None
+        self._stop_event = None
+
+    async def tick(self) -> int:
+        """Fire all matching triggers for the current UTC minute.
+
+        Returns the number of tasks enqueued.  Exposed publicly so callers
+        can drive the scheduler from tests without relying on real-time waits.
+        """
+        now = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+        fired = 0
+        for trigger in list(self._triggers):
+            if _matches(now, trigger.cron):
+                try:
+                    self._daemon.submit(
+                        trigger.prompt,
+                        repo=trigger.repo,
+                        backend=trigger.backend,
+                        priority=trigger.priority,
+                    )
+                    fired += 1
+                    log.info(
+                        "cron trigger fired: cron=%r prompt=%r",
+                        trigger.cron,
+                        trigger.prompt[:60],
+                    )
+                except Exception:
+                    log.exception(
+                        "cron trigger submit failed: cron=%r prompt=%r",
+                        trigger.cron,
+                        trigger.prompt[:60],
+                    )
+        return fired
+
+    async def _loop(self) -> None:
+        if self._stop_event is None:
+            raise RuntimeError("_loop() called before start()")
+        while not self._stop_event.is_set():
+            delay = _next_tick_delay(datetime.now(timezone.utc))
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=delay)
+                return  # stop was signalled
+            except (TimeoutError, asyncio.TimeoutError):
+                pass  # delay elapsed — fire the tick
+            try:
+                await self.tick()
+            except Exception:
+                log.exception("cron tick raised unexpectedly; continuing")
+
+
+# ---------------------------------------------------------------------------
+# Convenience: use croniter when available for richer expression support
+# ---------------------------------------------------------------------------
+
+try:
+    from croniter import croniter as _croniter  # type: ignore[import-untyped]
+
+    def _matches(dt: datetime, cron: str) -> bool:  # redefine for croniter
+        """croniter-backed matcher supporting full cron syntax."""
+        try:
+            # croniter.match checks whether *dt* falls on the given cron tick
+            return bool(_croniter.match(cron, dt.replace(second=0, microsecond=0)))
+        except Exception:
+            log.warning("croniter could not parse cron=%r; skipping", cron)
+            return False
+
+except ImportError:
+    pass  # stdlib implementation already defined above

--- a/maxwell_daemon/triggers/webhook.py
+++ b/maxwell_daemon/triggers/webhook.py
@@ -1,0 +1,143 @@
+"""Generic (non-GitHub) webhook trigger logic.
+
+This module provides the pure request-handling logic for the
+``POST /api/webhooks/trigger`` endpoint.  It is intentionally separated from
+the FastAPI layer so it can be unit-tested without an ASGI test client.
+
+Security model
+--------------
+Callers may optionally supply an ``X-Maxwell-Signature`` header whose value
+is ``sha256=<hex>``, computed as HMAC-SHA256 over the raw request body with
+a shared secret configured per-daemon.  If the daemon has no
+``webhook_secret`` configured the endpoint accepts unsigned requests (useful
+for local or trusted-network deployments).
+
+Idempotency
+-----------
+Callers may supply an ``X-Idempotency-Key`` header.  If a key is presented
+and was already seen within the configurable dedup window (default 10 min),
+the endpoint returns 200 with ``{"duplicate": true}`` and does **not** enqueue
+a second task.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from maxwell_daemon.logging import get_logger
+
+__all__ = [
+    "WebhookTriggerPayload",
+    "WebhookTriggerResult",
+    "enqueue_webhook_task",
+]
+
+log = get_logger(__name__)
+
+
+@dataclass
+class WebhookTriggerPayload:
+    """Validated inbound payload for a generic webhook trigger.
+
+    Attributes:
+        prompt: The task prompt to enqueue.
+        repo: Optional repository hint (passed through to ``daemon.submit``).
+        backend: Optional backend hint.
+        priority: Task priority (lower = higher priority; default 100).
+        idempotency_key: Caller-supplied dedup key (optional).
+    """
+
+    prompt: str
+    repo: str | None = None
+    backend: str | None = None
+    priority: int = 100
+    idempotency_key: str | None = None
+
+
+@dataclass
+class WebhookTriggerResult:
+    """Outcome of processing one inbound webhook trigger."""
+
+    task_id: str | None
+    duplicate: bool = False
+    error: str | None = None
+
+
+# In-process dedup store: maps idempotency_key → expiry datetime (UTC).
+_DEDUP: dict[str, datetime] = {}
+_DEDUP_WINDOW: timedelta = timedelta(minutes=10)
+
+
+def _is_duplicate(key: str) -> bool:
+    """Return True if *key* was seen within the dedup window, pruning stale entries."""
+    now = datetime.now(timezone.utc)
+    # Prune expired entries to prevent unbounded growth.
+    expired = [k for k, exp in _DEDUP.items() if exp < now]
+    for k in expired:
+        del _DEDUP[k]
+    if key in _DEDUP:
+        return True
+    _DEDUP[key] = now + _DEDUP_WINDOW
+    return False
+
+
+def verify_webhook_signature(secret: str, body: bytes, signature_header: str) -> bool:
+    """Constant-time HMAC-SHA256 verification for ``X-Maxwell-Signature``.
+
+    Returns False for any malformed or missing input so callers can uniformly
+    respond 401 without distinguishing the failure mode.
+    """
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    presented = signature_header.removeprefix("sha256=")
+    return hmac.compare_digest(expected, presented)
+
+
+def enqueue_webhook_task(
+    payload: WebhookTriggerPayload,
+    *,
+    daemon: Any,
+) -> WebhookTriggerResult:
+    """Validate, dedup, and enqueue a task from a generic webhook trigger.
+
+    Args:
+        payload: The validated trigger payload.
+        daemon: A ``Daemon`` instance (or any object with a compatible
+            ``submit(prompt, *, repo, backend, priority)`` method).
+
+    Returns:
+        :class:`WebhookTriggerResult` indicating whether the task was enqueued
+        or was a duplicate.
+    """
+    if not payload.prompt or not payload.prompt.strip():
+        return WebhookTriggerResult(task_id=None, error="prompt must not be empty")
+
+    if payload.idempotency_key and _is_duplicate(payload.idempotency_key):
+        log.info(
+            "webhook trigger deduplicated: idempotency_key=%r",
+            payload.idempotency_key,
+        )
+        return WebhookTriggerResult(task_id=None, duplicate=True)
+
+    try:
+        task = daemon.submit(
+            payload.prompt,
+            repo=payload.repo,
+            backend=payload.backend,
+            priority=payload.priority,
+        )
+    except Exception as exc:
+        log.exception("webhook trigger submit failed")
+        return WebhookTriggerResult(task_id=None, error=str(exc))
+
+    log.info(
+        "webhook trigger enqueued task=%s prompt=%r",
+        task.id,
+        payload.prompt[:80],
+    )
+    return WebhookTriggerResult(task_id=task.id)


### PR DESCRIPTION
## Summary
- `depends_on` field in `Task` dataclass for DAG ordering; worker loop holds a task in QUEUED state until all upstream task IDs reach COMPLETED
- `CronScheduler` in `maxwell_daemon/triggers/cron.py` for time-based task triggers — parses 5-field cron expressions (stdlib, with `croniter` fallback when installed)
- Generic `POST /api/webhooks/trigger` endpoint (operator auth) that accepts any HTTP caller, with optional `X-Maxwell-Signature` HMAC verification and `X-Idempotency-Key` dedup
- `depends_on` exposed in both `TaskSubmit` request model and `TaskView` response

Closes #488

## Test plan
- [x] DAG dependencies respected: task stays QUEUED until all `depends_on` IDs reach COMPLETED
- [x] Cron expressions parsed by stdlib parser; `croniter` used when available
- [x] `POST /api/webhooks/trigger` endpoint created and wired to `daemon.submit`
- [x] Idempotency-key dedup prevents duplicate tasks on webhook retries
- [x] ruff format + ruff check both pass clean