### PR TITLE
docs: codify sibling-repos contract (Repo_Mgmt ↔ runner-dashboard ↔ Maxwell-Daemon)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,45 @@
 
 ---
 
+## 🗺️ Sibling repos & boundaries (read first)
+
+`Maxwell-Daemon` is the **autonomous AI control plane** in a three-repo
+fleet. The cross-repo contract is documented canonically in
+[`Repository_Management/docs/sibling-repos.md`](https://github.com/D-sorganization/Repository_Management/blob/main/docs/sibling-repos.md).
+
+| Repo                     | Role                                                         |
+| ------------------------ | ------------------------------------------------------------ |
+| [`Repository_Management`](https://github.com/D-sorganization/Repository_Management) | Fleet orchestrator (CI workflows, skills, templates, agent coordination). |
+| [`runner-dashboard`](https://github.com/D-sorganization/runner-dashboard) | Operator console; calls Maxwell-Daemon's HTTP API from its Maxwell tab. |
+| `Maxwell-Daemon` (here)  | Strategist / Implementer / Crucible state machine, ExecutionSandbox, BYO-CLI runtime, gate-aware `/ui/`. |
+
+**Rule that keeps the graph acyclic:** Maxwell-Daemon **never calls back**
+into `runner-dashboard` or `Repository_Management`. Cross-repo traffic is
+always *into* the daemon — never out. This is what lets the daemon stay
+reusable from any caller (CLI, dashboard, future clients).
+
+**HTTP surface this repo must keep stable** (consumed by the dashboard's
+Maxwell tab — see the sibling-repos doc for full schema):
+
+| Method | Path                                | Purpose                                       |
+| ------ | ----------------------------------- | --------------------------------------------- |
+| GET    | `/api/version`                      | Daemon semver + contract version              |
+| GET    | `/api/health`                       | Liveness, gate state, current focus           |
+| GET    | `/api/status`                       | Pipeline state, active task, gates, sandbox   |
+| GET    | `/api/tasks`                        | Recent task history (paginated)               |
+| GET    | `/api/tasks/{id}`                   | One task incl. transcript + artifacts         |
+| POST   | `/api/dispatch`                     | Submit a signed task envelope                 |
+| POST   | `/api/control/{pause,resume,abort}` | Pipeline control (privileged)                 |
+
+This contract is **append-only**: add endpoints freely; never break existing
+ones without a major-version bump advertised at `GET /api/version`.
+
+**Routing rule:** dashboard tabs / `/api/*` endpoints in `runner-dashboard` →
+that repo; fleet workflows / skills / templates → `Repository_Management`;
+pipeline state, gates, sandbox, BYO-CLI → here.
+
+---
+
 ## 🛡️ Safety & Security (CRITICAL)
 
 1. **Secrets Management**:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Maxwell-Daemon is a professionally packaged, autonomous local control plane that
 
 Unlike existing tools that are locked to the terminal, Maxwell-Daemon ships a browser-served **gate-aware dashboard** at `/ui/`, strict **Test-Driven Development (TDD)** enforcement, and **Bring-Your-Own-CLI (BYO-CLI)** flexibility. It ensures you never burn an API token on tasks you don't need to.
 
+## Sibling repos
+
+Maxwell-Daemon is the **AI control plane** in a three-repo fleet. The
+cross-repo contract is in
+[`Repository_Management/docs/sibling-repos.md`](https://github.com/D-sorganization/Repository_Management/blob/main/docs/sibling-repos.md).
+
+| Repo | Role |
+| --- | --- |
+| [`Repository_Management`](https://github.com/D-sorganization/Repository_Management) | Fleet orchestrator (CI workflows, skills, templates, agent coordination). |
+| [`runner-dashboard`](https://github.com/D-sorganization/runner-dashboard) | Operator console; its **Maxwell tab** consumes the daemon's HTTP API. |
+| `Maxwell-Daemon` (here) | Strategist / Implementer / Crucible pipeline + ExecutionSandbox + BYO-CLI runtime. |
+
+The daemon's **`/ui/`** is the daemon's own console (for direct/local use).
+The fleet-wide operator console is `runner-dashboard`. The daemon never
+calls back into the dashboard or Repository_Management — all cross-repo
+traffic is into the daemon.
+
 ## 🚀 Why Maxwell-Daemon?
 - **Canonical Dashboard Launcher**: Use `Launch-Maxwell.bat`, `Launch-Maxwell.command`, or `Launch-Maxwell.sh` from a source checkout to bootstrap Maxwell-Daemon and open the shipped `/ui/` dashboard on Windows, macOS, or Linux.
 - **The Cognitive Pipeline**: A state-machine orchestrated team:


### PR DESCRIPTION
## Summary

Documents the boundary between the three fleet repos so issues, PRs, and
code land in the right place. The canonical contract lives in
`Repository_Management/docs/sibling-repos.md`; the other two repos link to
it from CLAUDE.md / README.md / AGENTS.md / SPEC.md (DRY).

- **Repository_Management** — fleet orchestrator (workflows, skills,
  templates, agent coordination). Does not own dashboard or AI pipeline.
- **runner-dashboard** — operator console (every dashboard tab and `/api/*`
  endpoint).
- **Maxwell-Daemon** — autonomous AI control plane with a stable HTTP
  surface consumed by the dashboard's Maxwell tab.

## Companions

This PR ships in lockstep with sibling PRs in the other two repos. All
three should land together so the docs stay consistent.

## Test plan

- [ ] Markdown renders cleanly on GitHub.
- [ ] Spec-Check CI passes (Repository_Management changes are docs-only).
- [ ] No code paths affected; CI quality gates should pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)