### PR TITLE
fix: resolve bandit B110 try_except_pass warnings

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -1694,7 +1694,7 @@ def create_app(
                         with contextlib.suppress(Exception):
                             daemon.cancel_task(task_obj.id)
             except Exception:
-                pass
+                log.warning("Error during abort: cancel tasks failed", exc_info=True)
 
         return ControlResponse(
             action=action,
@@ -2903,7 +2903,12 @@ def create_app(
                                     )
                                 )
                 except Exception:
-                    pass
+                    log.warning(
+                        "Failed to build leaderboard entry for %s/%s",
+                        backend,
+                        model,
+                        exc_info=True,
+                    )
 
         return {"suite_id": suite_id, "entries": [e.model_dump() for e in entries]}
 

--- a/maxwell_daemon/core/template_store.py
+++ b/maxwell_daemon/core/template_store.py
@@ -12,6 +12,10 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from maxwell_daemon.logging import get_logger
+
+log = get_logger(__name__)
+
 
 class ParameterType(str, Enum):
     STRING = "string"
@@ -340,7 +344,7 @@ class TemplateStore:
                 template = TaskTemplate.model_validate(data)
                 self._templates[template.id] = template
             except Exception:
-                pass  # Ignore invalid files for now
+                log.warning("Failed to load template from %s", child.name, exc_info=True)
 
     def list_templates(self) -> list[TaskTemplate]:
         return list(self._templates.values())


### PR DESCRIPTION
Resolves bandit B110 (try_except_pass) security warnings by replacing bare except/pass blocks with proper logging in server.py and template_store.py.