### PR TITLE
fix: replace bare assert statements with require() contracts (#163)

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -1694,7 +1694,7 @@ def create_app(
                         with contextlib.suppress(Exception):
                             daemon.cancel_task(task_obj.id)
             except Exception:
-                pass
+                log.warning("Error during abort: cancel tasks failed", exc_info=True)
 
         return ControlResponse(
             action=action,
@@ -2903,7 +2903,12 @@ def create_app(
                                     )
                                 )
                 except Exception:
-                    pass
+                    log.warning(
+                        "Failed to build leaderboard entry for %s/%s",
+                        backend,
+                        model,
+                        exc_info=True,
+                    )
 
         return {"suite_id": suite_id, "entries": [e.model_dump() for e in entries]}
 

--- a/maxwell_daemon/cli/tasks.py
+++ b/maxwell_daemon/cli/tasks.py
@@ -69,7 +69,9 @@ def list_tasks(
         p = _preset_store().get(preset)
         if p is None:
             _fail(f"preset {preset!r} not found — try `maxwell-daemon tasks preset list`")
-        assert p is not None
+        from maxwell_daemon.contracts import require
+        require(p is not None, "internal logic error: preset must exist after check")
+        assert p is not None  # for mypy
         status = status or p.status
         kind = kind or p.kind
         repo = repo or p.repo

--- a/maxwell_daemon/core/delegate_lifecycle.py
+++ b/maxwell_daemon/core/delegate_lifecycle.py
@@ -1039,7 +1039,7 @@ class DelegateLifecycleService:
         session = self._require_session(session_id)
         lease = self._store.current_lease(session_id)
         require(lease is not None, f"session {session_id!r} does not have an active lease")
-        assert lease is not None
+        assert lease is not None  # for mypy
         now = self._now()
         next_status = (
             DelegateSessionStatus.ABANDONED
@@ -1080,7 +1080,7 @@ class DelegateLifecycleService:
             latest_checkpoint is not None,
             "recovery requires at least one checkpoint",
         )
-        assert latest_checkpoint is not None
+        assert latest_checkpoint is not None  # for mypy
         now = self._now()
         recovered = DelegateSession.recover_from(
             prior,
@@ -1129,13 +1129,13 @@ class DelegateLifecycleService:
     def _require_session(self, session_id: str) -> DelegateSession:
         session = self._store.get_session(session_id)
         require(session is not None, f"delegate session {session_id!r} not found")
-        assert session is not None
+        assert session is not None  # for mypy
         return session
 
     def _require_active_lease(self, session_id: str, *, owner_id: str) -> AssignmentLease:
         lease = self._store.current_lease(session_id)
         require(lease is not None, f"session {session_id!r} does not have an active lease")
-        assert lease is not None
+        assert lease is not None  # for mypy
         require(
             lease.owner_id == owner_id,
             "only the current lease owner may update the session",

--- a/maxwell_daemon/core/template_store.py
+++ b/maxwell_daemon/core/template_store.py
@@ -12,6 +12,10 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from maxwell_daemon.logging import get_logger
+
+log = get_logger(__name__)
+
 
 class ParameterType(str, Enum):
     STRING = "string"
@@ -340,7 +344,7 @@ class TemplateStore:
                 template = TaskTemplate.model_validate(data)
                 self._templates[template.id] = template
             except Exception:
-                pass  # Ignore invalid files for now
+                log.warning("Failed to load template from %s", child.name, exc_info=True)
 
     def list_templates(self) -> list[TaskTemplate]:
         return list(self._templates.values())

--- a/maxwell_daemon/gh/executor.py
+++ b/maxwell_daemon/gh/executor.py
@@ -546,7 +546,9 @@ class IssueExecutor:
         Returns the final (plan, diff, test_result). Raises if tests still fail
         after ``max_retries`` refinements.
         """
-        assert self._test_runner is not None
+        from maxwell_daemon.contracts import require
+        require(self._test_runner is not None, "IssueExecutor: test_runner must be configured")
+        assert self._test_runner is not None  # for mypy
         attempt = 0
         current_plan, current_diff = plan, diff
         repo_path = self._workspace_path(repo, task_id)

--- a/maxwell_daemon/memory/repo_memory.py
+++ b/maxwell_daemon/memory/repo_memory.py
@@ -153,7 +153,7 @@ class MemoryEntry:
             isinstance(confidence, (float, int, str)),
             "confidence must be a float-compatible value",
         )
-        assert isinstance(confidence, (float, int, str))
+        assert isinstance(confidence, (float, int, str))  # for mypy
         return cls(
             id=_required_str(payload, "id"),
             scope=_required_str(payload, "scope"),
@@ -663,7 +663,7 @@ def _read_jsonl(path: Path) -> list[dict[str, object]]:
 def _required_str(payload: dict[str, object], key: str) -> str:
     value = payload.get(key)
     require(isinstance(value, str), f"{key} must be a string")
-    assert isinstance(value, str)
+    assert isinstance(value, str)  # for mypy
     require(bool(value.strip()), f"{key} must be non-empty")
     return value
 
@@ -673,13 +673,13 @@ def _optional_str(payload: dict[str, object], key: str) -> str | None:
     if value is None:
         return None
     require(isinstance(value, str), f"{key} must be a string or null")
-    assert isinstance(value, str)
+    assert isinstance(value, str)  # for mypy
     return value
 
 
 def _str_list(value: object, key: str) -> list[str]:
     require(isinstance(value, list), f"{key} must be a list")
-    assert isinstance(value, list)
+    assert isinstance(value, list)  # for mypy
     result: list[str] = []
     for item in value:
         require(isinstance(item, str), f"{key} items must be strings")
@@ -704,7 +704,7 @@ def _parse_optional_datetime(value: object) -> datetime | None:
     if value is None:
         return None
     require(isinstance(value, str), "datetime value must be a string or null")
-    assert isinstance(value, str)
+    assert isinstance(value, str)  # for mypy
     return _parse_datetime(value)
 
 


### PR DESCRIPTION
This PR replaces bare assert statements with formal require() contracts to satisfy Issue #163. It retains assertions with # for mypy comments where necessary for type narrowing.