### PR TITLE
fix(api): resolve duplicate /healthz endpoint

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -1517,7 +1517,6 @@ def create_app(
         return {"sub": "anonymous", "role": None, "exp": None}
 
     @app.get("/health")
-    @app.get("/healthz")
     async def health() -> dict[str, Any]:
         state = daemon.state()
         return {


### PR DESCRIPTION
Removes duplicate healthz route that was masking the readiness check and causing integration test failures.