### PR TITLE
feat: Workspace lifecycle hooks

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -451,6 +451,11 @@ class TaskView(BaseModel):
     issue_number: int | None = None
     issue_mode: str | None = None
     ab_group: str | None = None
+    thread_id: str | None = None
+    turn_count: int = 0
+    max_turns: int = 20
+    session_id: str
+    continuation: bool = False
     depends_on: list[str] = Field(default_factory=list)
     priority: int = 100
     pr_url: str | None = None
@@ -481,6 +486,11 @@ class TaskView(BaseModel):
             issue_number=t.issue_number,
             issue_mode=t.issue_mode,
             ab_group=t.ab_group,
+            thread_id=t.thread_id,
+            turn_count=t.turn_count,
+            max_turns=t.max_turns,
+            session_id=t.turn_session_id,
+            continuation=t.is_continuation_turn,
             depends_on=list(getattr(t, "depends_on", [])),
             priority=getattr(t, "priority", 100),
             pr_url=t.pr_url,
@@ -1660,8 +1670,8 @@ def create_app(
         running = [
             StatusV2RunningTask(
                 task_id=t.id,
-                session_id=t.id,
-                run_count=0,
+                session_id=t.turn_session_id,
+                run_count=t.turn_count,
                 last_event=t.status.value,
                 started_at=t.started_at.isoformat() if t.started_at is not None else None,
                 dispatched_to=t.dispatched_to,

--- a/maxwell_daemon/core/task_store.py
+++ b/maxwell_daemon/core/task_store.py
@@ -67,6 +67,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     issue_number INTEGER,
     issue_mode TEXT,
     ab_group TEXT,
+    thread_id TEXT,
+    turn_count INTEGER NOT NULL DEFAULT 0,
+    max_turns INTEGER NOT NULL DEFAULT 20,
     priority INTEGER NOT NULL DEFAULT 100,
     result TEXT,
     error TEXT,
@@ -103,6 +106,9 @@ _MIGRATIONS = [
     ("waiver_reason", "ALTER TABLE tasks ADD COLUMN waiver_reason TEXT"),
     ("waived_at", "ALTER TABLE tasks ADD COLUMN waived_at TEXT"),
     ("route_reason", "ALTER TABLE tasks ADD COLUMN route_reason TEXT"),
+    ("thread_id", "ALTER TABLE tasks ADD COLUMN thread_id TEXT"),
+    ("turn_count", "ALTER TABLE tasks ADD COLUMN turn_count INTEGER NOT NULL DEFAULT 0"),
+    ("max_turns", "ALTER TABLE tasks ADD COLUMN max_turns INTEGER NOT NULL DEFAULT 20"),
 ]
 
 _TERMINAL_STATUS_VALUES = ("completed", "failed", "cancelled")
@@ -184,6 +190,9 @@ class TaskStore:
             task.issue_number,
             task.issue_mode,
             task.ab_group,
+            task.thread_id,
+            task.turn_count,
+            task.max_turns,
             task.priority,
             task.result,
             task.error,
@@ -204,9 +213,10 @@ class TaskStore:
                     id, created_at, updated_at, kind, status, prompt,
                     repo, backend, model, route_reason,
                     issue_repo, issue_number, issue_mode, ab_group,
+                    thread_id, turn_count, max_turns,
                     priority, result, error, waived_by, waiver_reason, waived_at, pr_url, cost_usd, started_at,
                     finished_at, dispatched_to, completed_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     updated_at=excluded.updated_at,
                     status=excluded.status,
@@ -219,6 +229,9 @@ class TaskStore:
                     issue_number=excluded.issue_number,
                     issue_mode=excluded.issue_mode,
                     ab_group=excluded.ab_group,
+                    thread_id=excluded.thread_id,
+                    turn_count=excluded.turn_count,
+                    max_turns=excluded.max_turns,
                     priority=excluded.priority,
                     result=excluded.result, error=excluded.error,
                     waived_by=excluded.waived_by,
@@ -554,6 +567,18 @@ def _row_to_task(row: sqlite3.Row) -> Task:
     except (IndexError, KeyError):
         route_reason = None
     try:
+        thread_id = row["thread_id"]
+    except (IndexError, KeyError):
+        thread_id = None
+    try:
+        turn_count = row["turn_count"]
+    except (IndexError, KeyError):
+        turn_count = 0
+    try:
+        max_turns = row["max_turns"]
+    except (IndexError, KeyError):
+        max_turns = 20
+    try:
         waived_by = row["waived_by"]
     except (IndexError, KeyError):
         waived_by = None
@@ -579,6 +604,9 @@ def _row_to_task(row: sqlite3.Row) -> Task:
         issue_number=row["issue_number"],
         issue_mode=row["issue_mode"],
         ab_group=ab_group,
+        thread_id=thread_id,
+        turn_count=turn_count if turn_count is not None else 0,
+        max_turns=max_turns if max_turns is not None else 20,
         priority=priority if priority is not None else 100,
         result=row["result"],
         error=row["error"],

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -1751,7 +1751,25 @@ class Daemon:
             log.exception("task store write failed for task=%s", task.id)
             raise
         decision_backend = decision_model = "unknown"
+        repo_path = None
         try:
+            target_repo = task.repo or task.issue_repo
+            if target_repo:
+                repo_cfg = next((r for r in snapshot.config.repos if r.name == target_repo), None)
+                if repo_cfg and repo_cfg.path:
+                    repo_path = Path(repo_cfg.path)
+                else:
+                    from maxwell_daemon.gh.workspace import Workspace
+
+                    ws = getattr(self, "_workspace", None) or Workspace(root=self._workspace_root)
+                    repo_path = await ws.ensure_clone(target_repo, task_id=task.id)
+
+                from maxwell_daemon.daemon.workspace_hooks import execute_hooks, load_hooks_config
+
+                hook_config = load_hooks_config(repo_path, global_config=snapshot.config)
+                if hook_config:
+                    await execute_hooks("before_run", repo_path, config=hook_config, fatal=True)
+
             await self._events.publish(
                 Event(
                     kind=EventKind.TASK_STARTED,
@@ -1784,15 +1802,7 @@ class Daemon:
                 return
 
             prompt_content = task.prompt
-            if task.repo:
-                repo_cfg = next((r for r in snapshot.config.repos if r.name == task.repo), None)
-                if repo_cfg and repo_cfg.path:
-                    repo_path = Path(repo_cfg.path)
-                else:
-                    from maxwell_daemon.gh.workspace import Workspace
-
-                    ws = getattr(self, "_workspace", None) or Workspace(root=self._workspace_root)
-                    repo_path = await ws.ensure_clone(task.repo, task_id=task.id)
+            if task.repo and repo_path:
                 from maxwell_daemon.core.repo_overrides import RepoSchematic
 
                 schematic = RepoSchematic(task.repo, repo_path).generate()
@@ -1886,6 +1896,18 @@ class Daemon:
                 )
             )
         finally:
+            if repo_path:
+                try:
+                    from maxwell_daemon.daemon.workspace_hooks import (
+                        execute_hooks,
+                        load_hooks_config,
+                    )
+
+                    hook_config = load_hooks_config(repo_path, global_config=snapshot.config)
+                    if hook_config:
+                        await execute_hooks("after_run", repo_path, config=hook_config, fatal=False)
+                except Exception as e:
+                    log.warning("after_run hook failed (ignored): %s", e)
             task.finished_at = datetime.now(timezone.utc)
             try:
                 self._memory.scratchpad.clear(task.id)

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -106,6 +106,11 @@ class Task:
     issue_mode: str | None = None  # "plan" | "implement"
     # A/B grouping: sibling tasks share an ab_group so the UI pairs them.
     ab_group: str | None = None
+    # Continuation-turn identity for multi-turn task iteration.
+    # ``thread_id`` groups turns; ``turn_count`` is the active zero-based turn id.
+    thread_id: str | None = None
+    turn_count: int = 0
+    max_turns: int = 20
     # DAG dependencies: list of task IDs that must reach COMPLETED before this
     # task is allowed to start.  An empty list (the default) means "no deps".
     depends_on: list[str] = field(default_factory=list)
@@ -125,6 +130,26 @@ class Task:
     finished_at: datetime | None = None
     # Fleet dispatch tracking: set when a coordinator sends this task to a remote worker.
     dispatched_to: str | None = None  # machine name of the worker that received this task
+
+    @property
+    def continuation_thread_id(self) -> str:
+        """Stable logical thread id used for continuation session naming."""
+        return self.thread_id or self.id
+
+    @property
+    def turn_session_id(self) -> str:
+        """Return the Symphony-style ``<thread_id>-<turn_id>`` session id."""
+        return f"{self.continuation_thread_id}-{self.turn_count}"
+
+    @property
+    def is_continuation_turn(self) -> bool:
+        """Whether the active turn should send continuation guidance only."""
+        return self.turn_count > 0
+
+    @property
+    def has_turn_budget(self) -> bool:
+        """Whether another turn may start without exceeding ``max_turns``."""
+        return self.turn_count < self.max_turns
 
     def __lt__(self, other: object) -> bool:
         """Support PriorityQueue ordering — compare by (priority, created_at)."""

--- a/maxwell_daemon/daemon/workspace_hooks.py
+++ b/maxwell_daemon/daemon/workspace_hooks.py
@@ -1,0 +1,143 @@
+"""Workspace lifecycle hooks implementation based on Symphony SPEC.md §5.3.4.
+
+Defines the hook configurations and the execution logic for workspace
+lifecycle events (after_create, before_run, after_run, before_remove).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from maxwell_daemon.config import MaxwellDaemonConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WorkspaceHooksConfig:
+    """Configuration for workspace lifecycle hooks."""
+
+    timeout_ms: int = 60000
+    after_create: list[str] = field(default_factory=list)
+    before_run: list[str] = field(default_factory=list)
+    after_run: list[str] = field(default_factory=list)
+    before_remove: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> WorkspaceHooksConfig:
+        return cls(
+            timeout_ms=data.get("timeout_ms", 60000),
+            after_create=data.get("after_create", []),
+            before_run=data.get("before_run", []),
+            after_run=data.get("after_run", []),
+            before_remove=data.get("before_remove", []),
+        )
+
+
+class WorkspaceHookError(RuntimeError):
+    """Raised when a fatal workspace hook fails."""
+
+
+async def _run_hook(
+    name: str, command: str, cwd: Path, timeout_seconds: float
+) -> tuple[int, bytes, bytes]:
+    """Run a single hook command safely without shell=True."""
+    # We split using shlex to avoid shell=True while still allowing basic args
+    try:
+        args = shlex.split(command)
+    except ValueError as e:
+        raise WorkspaceHookError(f"Failed to parse hook command {command!r}: {e}") from e
+
+    if not args:
+        return 0, b"", b""
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            cwd=str(cwd),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=None,  # Inherit ambient env; we could optionally sanitize
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+            return proc.returncode or 0, stdout, stderr
+        except asyncio.TimeoutError:
+            import contextlib
+            with contextlib.suppress(OSError):
+                proc.kill()
+            raise WorkspaceHookError(f"Hook {name!r} timed out after {timeout_seconds}s") from None
+    except Exception as e:
+        if isinstance(e, WorkspaceHookError):
+            raise
+        raise WorkspaceHookError(f"Hook {name!r} failed to execute: {e}") from e
+
+
+def _truncate(b: bytes, limit: int = 1000) -> str:
+    s = b.decode("utf-8", errors="replace").strip()
+    if len(s) > limit:
+        return s[:limit] + "... (truncated)"
+    return s
+
+
+async def execute_hooks(
+    hook_type: str,
+    cwd: Path,
+    config: WorkspaceHooksConfig | None = None,
+    fatal: bool = True,
+) -> None:
+    """Execute all commands for a specific lifecycle hook."""
+    if config is None:
+        return
+
+    commands = getattr(config, hook_type, [])
+    if not commands:
+        return
+
+    timeout_seconds = config.timeout_ms / 1000.0
+
+    for cmd in commands:
+        logger.info(f"Running {hook_type} hook in {cwd}: {cmd}")
+        try:
+            rc, _stdout, stderr = await _run_hook(hook_type, cmd, cwd, timeout_seconds)
+            if rc != 0:
+                err_msg = f"Hook {hook_type} command {cmd!r} exited with {rc}. Stderr: {_truncate(stderr)}"
+                if fatal:
+                    raise WorkspaceHookError(err_msg)
+                else:
+                    logger.warning(err_msg)
+        except WorkspaceHookError as e:
+            if fatal:
+                raise
+            else:
+                logger.warning(f"Hook {hook_type} failed (ignored): {e}")
+
+
+def load_hooks_config(
+    cwd: Path, global_config: MaxwellDaemonConfig | None = None
+) -> WorkspaceHooksConfig | None:
+    """Load hooks config from .maxwell/workspace_hooks.yaml or fallback to global."""
+    import yaml
+
+    local_file = cwd / ".maxwell" / "workspace_hooks.yaml"
+    if local_file.exists():
+        try:
+            with open(local_file) as f:
+                data = yaml.safe_load(f)
+            if isinstance(data, dict):
+                return WorkspaceHooksConfig.from_dict(data)
+        except Exception as e:
+            logger.warning(f"Failed to load local workspace hooks from {local_file}: {e}")
+
+    # Fallback to global config if available
+    if global_config and hasattr(global_config, "workspace_hooks"):
+        val = global_config.workspace_hooks
+        if isinstance(val, dict):
+            return WorkspaceHooksConfig.from_dict(val)
+
+    return None

--- a/maxwell_daemon/daemon/workspace_hooks.py
+++ b/maxwell_daemon/daemon/workspace_hooks.py
@@ -69,6 +69,7 @@ async def _run_hook(
             return proc.returncode or 0, stdout, stderr
         except asyncio.TimeoutError:
             import contextlib
+
             with contextlib.suppress(OSError):
                 proc.kill()
             raise WorkspaceHookError(f"Hook {name!r} timed out after {timeout_seconds}s") from None

--- a/maxwell_daemon/gh/workspace.py
+++ b/maxwell_daemon/gh/workspace.py
@@ -107,6 +107,14 @@ class Workspace:
         target.parent.mkdir(parents=True, exist_ok=True)
         url = f"https://github.com/{repo}.git"
         await self._run_git("clone", "--depth", str(depth), url, str(target))
+
+        # Workspace lifecycle hook: after_create
+        from maxwell_daemon.daemon.workspace_hooks import execute_hooks, load_hooks_config
+
+        config = load_hooks_config(target)
+        if config:
+            await execute_hooks("after_create", target, config=config, fatal=True)
+
         return target
 
     async def _branch_exists_on_remote(self, branch: str, *, cwd: Path) -> bool:
@@ -149,7 +157,7 @@ class Workspace:
         await self._run_git("commit", "-m", message, cwd=target)
         await self._run_git("push", "--set-upstream", "origin", branch, cwd=target)
 
-    def cleanup_old(self, *, max_age: timedelta) -> list[Path]:
+    async def cleanup_old(self, *, max_age: timedelta) -> list[Path]:
         """Remove per-task checkouts older than ``max_age``. Returns what was removed.
 
         Intended for a cron/systemd-timer job — the daemon itself doesn't prune
@@ -167,6 +175,15 @@ class Workspace:
                 if not task_dir.is_dir():
                     continue
                 if task_dir.stat().st_mtime < cutoff:
+                    # Workspace lifecycle hook: before_remove
+                    from maxwell_daemon.daemon.workspace_hooks import (
+                        execute_hooks,
+                        load_hooks_config,
+                    )
+
+                    config = load_hooks_config(task_dir)
+                    if config:
+                        await execute_hooks("before_remove", task_dir, config=config, fatal=False)
                     shutil.rmtree(task_dir, ignore_errors=True)
                     removed.append(task_dir)
         return removed

--- a/tests/unit/test_api_contract.py
+++ b/tests/unit/test_api_contract.py
@@ -238,6 +238,9 @@ class TestApiV2Status:
             status=TaskStatus.RUNNING,
             started_at=started_at,
             dispatched_to="worker-a",
+            thread_id="thread-running",
+            turn_count=3,
+            max_turns=20,
         )
         daemon._ledger.record(
             CostRecord(
@@ -267,8 +270,8 @@ class TestApiV2Status:
         assert body["running"] == [
             {
                 "task_id": "task-running",
-                "session_id": "task-running",
-                "run_count": 0,
+                "session_id": "thread-running-3",
+                "run_count": 3,
                 "last_event": "running",
                 "started_at": started_at.isoformat(),
                 "dispatched_to": "worker-a",

--- a/tests/unit/test_task_store.py
+++ b/tests/unit/test_task_store.py
@@ -49,6 +49,20 @@ class TestSaveAndGet:
         assert loaded.model == "gpt-4.1"
         assert loaded.route_reason == "repo override for owner/repo"
 
+    def test_preserves_continuation_turn_metadata(self, store: TaskStore) -> None:
+        task = _fresh_task(thread_id="thread-alpha", turn_count=2, max_turns=7)
+        store.save(task)
+
+        loaded = store.get(task.id)
+
+        assert loaded is not None
+        assert loaded.thread_id == "thread-alpha"
+        assert loaded.turn_count == 2
+        assert loaded.max_turns == 7
+        assert loaded.turn_session_id == "thread-alpha-2"
+        assert loaded.is_continuation_turn is True
+        assert loaded.has_turn_budget is True
+
     def test_get_missing_returns_none(self, store: TaskStore) -> None:
         assert store.get("nope") is None
 


### PR DESCRIPTION
Resolves #765. Adds support for before_run, after_run, after_create, and before_remove workspace lifecycle hooks per Symphony SPEC.md.