### PR TITLE
feat(tools): add gh_proxy tool to hide GitHub tokens from agents (#763)

### DIFF
--- a/maxwell_daemon/gh/client.py
+++ b/maxwell_daemon/gh/client.py
@@ -423,3 +423,43 @@ class GitHubClient:
         out = await self._request_with_retry(*argv)
         url = out.decode().strip().splitlines()[-1]
         return PullRequest.from_url(url, draft=draft)
+
+    async def create_comment(
+        self,
+        repo: str,
+        *,
+        issue_number: int,
+        body: str,
+    ) -> str:
+        """Create a comment on an issue or PR and return the comment URL."""
+        self._validate_repo(repo)
+        out = await self._request_with_retry(
+            "issue",
+            "comment",
+            str(int(issue_number)),
+            "--repo",
+            repo,
+            "--body",
+            body,
+        )
+        return out.decode().strip()
+
+    async def set_issue_state(
+        self,
+        repo: str,
+        issue_number: int,
+        state: str,
+    ) -> str:
+        """Close or reopen an issue and return the issue URL."""
+        self._validate_repo(repo)
+        if state not in {"open", "closed"}:
+            raise ValueError(f"state must be 'open' or 'closed', got {state!r}")
+        out = await self._request_with_retry(
+            "issue",
+            "edit",
+            str(int(issue_number)),
+            "--repo",
+            repo,
+            f"--state={state}",
+        )
+        return out.decode().strip()

--- a/maxwell_daemon/tools/builtins.py
+++ b/maxwell_daemon/tools/builtins.py
@@ -40,6 +40,8 @@ from maxwell_daemon.tools.mcp import (
 
 if TYPE_CHECKING:
     from maxwell_daemon.core.action_service import ActionService
+    from maxwell_daemon.gh import GitHubClient
+    from maxwell_daemon.tools.gh_proxy import GhProxyAllowlist
 
 __all__ = [
     "BashRunner",
@@ -47,6 +49,7 @@ __all__ = [
     "build_default_registry",
     "make_browser_screenshot",
     "make_edit_file",
+    "make_gh_proxy",
     "make_glob_files",
     "make_grep_files",
     "make_open_browser_url",
@@ -615,6 +618,28 @@ def make_browser_screenshot(
     return browser_screenshot
 
 
+# ── gh_proxy ────────────────────────────────────────────────────────────────
+def make_gh_proxy(
+    *,
+    github_client: GitHubClient,
+    allowlist: GhProxyAllowlist | None = None,
+    task_id: str | None = None,
+) -> Callable[..., Awaitable[str]]:
+    """Factory returning the ``gh_proxy`` tool bound to a GitHubClient."""
+    from typing import cast
+
+    from maxwell_daemon.tools.gh_proxy import make_gh_proxy as _make_gh_proxy
+
+    return cast(
+        Callable[..., Awaitable[str]],
+        _make_gh_proxy(
+            client=github_client,
+            allowlist=allowlist,
+            task_id=task_id,
+        ),
+    )
+
+
 # ── default registry ────────────────────────────────────────────────────────
 def build_default_registry(
     root: Path,
@@ -626,6 +651,7 @@ def build_default_registry(
     policy: ToolPolicy | None = None,
     invocation_store: ToolInvocationStore | None = None,
     browser_service: BrowserService | None = None,
+    github_client: GitHubClient | None = None,
     dry_run: bool = False,
 ) -> ToolRegistry:
     """Return a ``ToolRegistry`` with built-in tools bound to ``root``.
@@ -663,4 +689,6 @@ def build_default_registry(
     if browser_service is not None:
         reg.register_from_function(make_open_browser_url(browser_service))
         reg.register_from_function(make_browser_screenshot(browser_service))
+    if github_client is not None:
+        reg.register_from_function(make_gh_proxy(github_client=github_client, task_id=task_id))
     return reg

--- a/maxwell_daemon/tools/gh_proxy.py
+++ b/maxwell_daemon/tools/gh_proxy.py
@@ -1,0 +1,274 @@
+"""Built-in ``gh_proxy`` tool — agents call GitHub through the daemon, never hold tokens.
+
+Mirrors the Symphony §10.5 ``linear_graphql`` pattern: the runtime holds the
+credential, the agent sees only a structured tool, and every call is written to
+the audit ledger.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from maxwell_daemon.audit import AuditLogger
+from maxwell_daemon.gh import GitHubClient
+from maxwell_daemon.logging import get_logger
+from maxwell_daemon.tools.mcp import ToolParam, mcp_tool
+
+log = get_logger("maxwell_daemon.tools.gh_proxy")
+
+# Operations that an agent may request.  Keys are the ``operation`` field in the
+# tool call payload; values describe which GitHubClient method is used.
+#
+# Each entry maps to:
+#   method:  the async method name on GitHubClient
+#   params:  required parameter names for that operation
+#   returns: human-readable description of the return shape
+_GH_PROXY_OPERATIONS: dict[str, dict[str, Any]] = {
+    "create_pr": {
+        "method": "create_pull_request",
+        "params": ["repo", "head", "base", "title", "body"],
+        "optional": ["draft"],
+        "returns": "pr_url",
+    },
+    "create_issue": {
+        "method": "create_issue",
+        "params": ["repo", "title", "body"],
+        "optional": ["labels"],
+        "returns": "issue_url",
+    },
+    "comment": {
+        "method": "create_comment",
+        "params": ["repo", "issue_number", "body"],
+        "returns": "comment_url",
+    },
+    "set_state": {
+        "method": "set_issue_state",
+        "params": ["repo", "issue_number", "state"],
+        "returns": "issue_url",
+    },
+}
+
+
+class GhProxyError(ValueError):
+    """Raised when the gh_proxy tool receives an invalid operation or params."""
+
+
+@dataclass(frozen=True, slots=True)
+class GhProxyAllowlist:
+    """Per-task allowlist for gh_proxy operations."""
+
+    operations: frozenset[str]
+
+    @classmethod
+    def default(cls) -> GhProxyAllowlist:
+        """Default allowlist: PR and comment operations only."""
+        return cls(frozenset({"create_pr", "create_issue", "comment"}))
+
+    def allowed(self, operation: str) -> bool:
+        return operation in self.operations
+
+
+def _validate_params(operation: str, params: dict[str, Any]) -> None:
+    """Ensure all required params are present and no unknown params leak."""
+    meta = _GH_PROXY_OPERATIONS.get(operation)
+    if meta is None:
+        raise GhProxyError(
+            f"unknown operation {operation!r}; supported: {sorted(_GH_PROXY_OPERATIONS)}"
+        )
+
+    required = set(meta["params"])
+    optional = set(meta.get("optional", []))
+    present = set(params)
+
+    missing = required - present
+    if missing:
+        raise GhProxyError(f"operation {operation!r} missing required params: {sorted(missing)}")
+
+    unknown = present - required - optional
+    if unknown:
+        raise GhProxyError(f"operation {operation!r} received unknown params: {sorted(unknown)}")
+
+
+async def _call_gh(
+    client: GitHubClient,
+    operation: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch to the underlying GitHubClient method."""
+    meta = _GH_PROXY_OPERATIONS[operation]
+    method_name = meta["method"]
+
+    # GitHubClient may not yet implement every operation; guard gracefully.
+    method = getattr(client, method_name, None)
+    if method is None:
+        raise GhProxyError(
+            f"operation {operation!r} is declared but not yet implemented "
+            f"(missing {method_name} on GitHubClient)"
+        )
+
+    result = await method(**params)
+
+    # Normalise the result to a plain dict for the agent.
+    if hasattr(result, "url"):
+        return {"success": True, "url": result.url}
+    if hasattr(result, "number"):
+        return {"success": True, "number": result.number}
+    if isinstance(result, str):
+        return {"success": True, "url": result}
+    return {"success": True, "result": str(result)}
+
+
+def make_gh_proxy(
+    *,
+    client: GitHubClient,
+    allowlist: GhProxyAllowlist | None = None,
+    audit: AuditLogger | None = None,
+    task_id: str | None = None,
+) -> Any:
+    """Factory returning the ``gh_proxy`` tool function bound to a GitHubClient.
+
+    :param client: The GitHubClient instance that holds the live token.
+    :param allowlist: Set of permitted operations for this task.  When ``None``
+        the :meth:`GhProxyAllowlist.default` is used.
+    :param audit: Optional audit logger for append-only ledger entries.
+    :param task_id: Current task id, included in audit entries.
+    """
+    whitelist = allowlist or GhProxyAllowlist.default()
+
+    @mcp_tool(
+        name="gh_proxy",
+        description=(
+            "Execute a GitHub operation through the daemon's authenticated client. "
+            "The agent never sees the GitHub token.  Supported operations: "
+            f"{sorted(_GH_PROXY_OPERATIONS)}. "
+            "Each call is logged to the audit ledger."
+        ),
+        capabilities=frozenset({"github_read", "github_write"}),
+        risk_level="network_write",
+        requires_approval=True,
+        params=[
+            ToolParam(
+                name="operation",
+                type="string",
+                description="Operation name",
+            ),
+            ToolParam(
+                name="params",
+                type="object",
+                description="Operation-specific parameters",
+            ),
+        ],
+    )
+    async def gh_proxy(operation: str, params: dict[str, Any]) -> str:
+        """Run a GitHub operation via the proxy.
+
+        :param operation: one of the supported operation names.
+        :param params: dict of operation-specific keyword arguments.
+        :returns: JSON string with the result or an error description.
+        """
+        if not whitelist.allowed(operation):
+            log.warning(
+                "gh_proxy denied",
+                task_id=task_id,
+                operation=operation,
+                reason="not_in_allowlist",
+            )
+            _audit(
+                audit,
+                task_id,
+                operation,
+                params,
+                False,
+                "denied: not in allowlist",
+            )
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": (
+                        f"operation {operation!r} is not allowed for this task. "
+                        f"permitted: {sorted(whitelist.operations)}"
+                    ),
+                }
+            )
+
+        try:
+            _validate_params(operation, params)
+        except GhProxyError as exc:
+            log.warning(
+                "gh_proxy validation failed",
+                task_id=task_id,
+                operation=operation,
+                error=str(exc),
+            )
+            _audit(
+                audit,
+                task_id,
+                operation,
+                params,
+                False,
+                str(exc),
+            )
+            return json.dumps({"success": False, "error": str(exc)})
+
+        try:
+            result = await _call_gh(client, operation, params)
+        except Exception as exc:  # pragma: no cover
+            log.warning(
+                "gh_proxy execution failed",
+                task_id=task_id,
+                operation=operation,
+                error=str(exc),
+                exc_info=True,
+            )
+            _audit(
+                audit,
+                task_id,
+                operation,
+                params,
+                False,
+                str(exc),
+            )
+            return json.dumps({"success": False, "error": str(exc)})
+
+        log.info("gh_proxy success", task_id=task_id, operation=operation)
+        _audit(
+            audit,
+            task_id,
+            operation,
+            params,
+            True,
+            "ok",
+        )
+        return json.dumps(result)
+
+    return gh_proxy
+
+
+def _audit(
+    audit: AuditLogger | None,
+    task_id: str | None,
+    operation: str,
+    params: dict[str, Any],
+    success: bool,
+    summary: str,
+) -> None:
+    """Write a single gh_proxy call to the audit ledger if one is configured."""
+    if audit is None:
+        return
+    try:
+        audit.log_api_call(
+            method="POST",
+            path="/api/v1/gh_proxy",
+            status=200 if success else 403,
+            request_id=task_id,
+            details={
+                "operation": operation,
+                "params": params,
+                "success": success,
+                "summary": summary,
+            },
+        )
+    except Exception:
+        log.warning("gh_proxy audit write failed", exc_info=True)

--- a/tests/unit/test_gh_proxy.py
+++ b/tests/unit/test_gh_proxy.py
@@ -1,0 +1,176 @@
+"""Tests for the ``gh_proxy`` tool."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from maxwell_daemon.tools.gh_proxy import (
+    GhProxyAllowlist,
+    GhProxyError,
+    _validate_params,
+    make_gh_proxy,
+)
+
+
+class FakeGitHubClient:
+    """Stub GitHubClient for unit tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def create_pull_request(self, **kwargs: Any) -> Any:
+        self.calls.append(("create_pull_request", kwargs))
+        return type("PR", (), {"url": "https://github.com/test/pr/1"})()
+
+    async def create_issue(self, **kwargs: Any) -> str:
+        self.calls.append(("create_issue", kwargs))
+        return "https://github.com/test/issues/1"
+
+    async def create_comment(self, **kwargs: Any) -> str:
+        self.calls.append(("create_comment", kwargs))
+        return "https://github.com/test/issues/1#issuecomment-1"
+
+
+@pytest.fixture
+def fake_client() -> FakeGitHubClient:
+    return FakeGitHubClient()
+
+
+class TestValidateParams:
+    def test_valid_create_pr(self) -> None:
+        _validate_params(
+            "create_pr",
+            {
+                "repo": "owner/repo",
+                "head": "feature",
+                "base": "main",
+                "title": "add feature",
+                "body": "details",
+            },
+        )
+
+    def test_missing_required_param(self) -> None:
+        with pytest.raises(GhProxyError, match="missing required params"):
+            _validate_params("create_pr", {"repo": "owner/repo"})
+
+    def test_unknown_param(self) -> None:
+        with pytest.raises(GhProxyError, match="unknown params"):
+            _validate_params(
+                "create_pr",
+                {
+                    "repo": "owner/repo",
+                    "head": "feature",
+                    "base": "main",
+                    "title": "add feature",
+                    "body": "details",
+                    "extra": "bad",
+                },
+            )
+
+    def test_unknown_operation(self) -> None:
+        with pytest.raises(GhProxyError, match="unknown operation"):
+            _validate_params("delete_repo", {})
+
+
+class TestGhProxyAllowlist:
+    def test_default_allowlist(self) -> None:
+        allowlist = GhProxyAllowlist.default()
+        assert allowlist.allowed("create_pr")
+        assert allowlist.allowed("create_issue")
+        assert allowlist.allowed("comment")
+        assert not allowlist.allowed("set_state")
+        assert not allowlist.allowed("delete_repo")
+
+    def test_custom_allowlist(self) -> None:
+        allowlist = GhProxyAllowlist(frozenset({"comment"}))
+        assert allowlist.allowed("comment")
+        assert not allowlist.allowed("create_pr")
+
+
+class TestMakeGhProxy:
+    @pytest.mark.asyncio
+    async def test_denied_operation_returns_error(self, fake_client: FakeGitHubClient) -> None:
+        tool = make_gh_proxy(
+            client=fake_client,  # type: ignore[arg-type]
+            allowlist=GhProxyAllowlist(frozenset({"comment"})),
+            task_id="t-123",
+        )
+        result = await tool(
+            "create_pr", {"repo": "owner/repo", "head": "f", "base": "m", "title": "t", "body": "b"}
+        )
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "not allowed" in parsed["error"]
+
+    @pytest.mark.asyncio
+    async def test_allowed_operation_succeeds(self, fake_client: FakeGitHubClient) -> None:
+        tool = make_gh_proxy(
+            client=fake_client,  # type: ignore[arg-type]
+            allowlist=GhProxyAllowlist.default(),
+            task_id="t-123",
+        )
+        result = await tool(
+            "create_pr",
+            {
+                "repo": "owner/repo",
+                "head": "feature",
+                "base": "main",
+                "title": "add feature",
+                "body": "details",
+            },
+        )
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        assert parsed["url"] == "https://github.com/test/pr/1"
+        assert fake_client.calls == [
+            (
+                "create_pull_request",
+                {
+                    "repo": "owner/repo",
+                    "head": "feature",
+                    "base": "main",
+                    "title": "add feature",
+                    "body": "details",
+                },
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_validation_error_returns_json(self, fake_client: FakeGitHubClient) -> None:
+        tool = make_gh_proxy(
+            client=fake_client,  # type: ignore[arg-type]
+            allowlist=GhProxyAllowlist.default(),
+            task_id="t-123",
+        )
+        result = await tool("create_pr", {"repo": "owner/repo"})
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "missing required params" in parsed["error"]
+
+    @pytest.mark.asyncio
+    async def test_execution_error_returns_json(self, fake_client: FakeGitHubClient) -> None:
+        class BrokenClient:
+            async def create_pull_request(self, **kwargs: Any) -> Any:
+                raise RuntimeError("simulated failure")
+
+        tool = make_gh_proxy(
+            client=BrokenClient(),  # type: ignore[arg-type]
+            allowlist=GhProxyAllowlist.default(),
+            task_id="t-123",
+        )
+        result = await tool(
+            "create_pr",
+            {
+                "repo": "owner/repo",
+                "head": "feature",
+                "base": "main",
+                "title": "add feature",
+                "body": "details",
+            },
+        )
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        assert "simulated failure" in parsed["error"]


### PR DESCRIPTION
Implements the gh_proxy builtin tool that proxies GitHub operations through the daemon's authenticated GitHubClient instead of exposing raw tokens to agent subprocesses.`n`n- New module maxwell_daemon/tools/gh_proxy.py with structured validation, per-task allowlists, and audit logging`n- Extended GitHubClient with create_comment and set_issue_state`n- Wired gh_proxy into build_default_registry`n- Unit tests covering allowlist, validation, success, and error paths`n`nCloses #763