### PR TITLE
docs(api): expose curated OpenAPI metadata and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ python -m venv .venv
 pip install -e ".[dev]"
 ```
 
+## 📖 API Documentation
+
+When the daemon is running locally, an interactive OpenAPI 3 reference is
+served alongside the API:
+
+| URL | Purpose |
+| --- | --- |
+| `http://127.0.0.1:8080/docs` | Swagger UI — explore and try endpoints. |
+| `http://127.0.0.1:8080/redoc` | ReDoc — browseable reference. |
+| `http://127.0.0.1:8080/openapi.json` | Raw OpenAPI 3 schema (machine-readable). |
+
+The schema is auto-generated from the FastAPI route definitions and the
+Pydantic models in [`maxwell_daemon/api/contract.py`](maxwell_daemon/api/contract.py),
+so it always tracks the live code. The contract version
+(`CONTRACT_VERSION`) is advertised at `GET /api/version` and follows
+**append-only** semantics within a major version — see
+[`SPEC.md`](SPEC.md) for details.
+
 ## 🧠 Architectural Highlights
 - **RepoSchematic**: Generates highly compressed file-and-symbol trees, saving massive token budgets compared to dumping raw files.
 - **Memory Annealer**: Automatically compresses verbose agent logs into dense `architectural_state.md` files, responsibly purging raw logs to save disk space.

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -1296,7 +1296,51 @@ def create_app(
     app = FastAPI(
         title="Maxwell-Daemon API",
         version=__version__,
-        description="Remote control plane for Maxwell-Daemon daemons.",
+        summary="Autonomous AI control plane orchestrating agent tasks.",
+        description=(
+            "Maxwell-Daemon exposes a stable HTTP + WebSocket API for "
+            "orchestrating agent tasks, observing pipeline state, and "
+            "controlling the daemon lifecycle.\n\n"
+            f"**Contract version:** `{CONTRACT_VERSION}` (advertised at "
+            "`GET /api/version`).  The contract is **append-only**: new "
+            "fields and endpoints may appear, but existing request and "
+            "response shapes are stable within a major version.\n\n"
+            "## Authentication\n\n"
+            "Most endpoints require a bearer token in the `Authorization` "
+            "header:\n\n"
+            "```\nAuthorization: Bearer <your_token>\n```\n\n"
+            "When JWT auth is configured, role-based access control "
+            "(viewer / operator / admin) is enforced per endpoint.\n\n"
+            "## WebSockets\n\n"
+            "Real-time event streams are exposed under `/ws/*`.  See the "
+            "`AGENTS.md` and `SPEC.md` documents in the source repository "
+            "for the event schema.\n\n"
+            "## Interactive docs\n\n"
+            "* Swagger UI: [`/docs`](/docs)\n"
+            "* ReDoc: [`/redoc`](/redoc)\n"
+            "* OpenAPI JSON: [`/openapi.json`](/openapi.json)\n"
+        ),
+        contact={
+            "name": "Maxwell-Daemon",
+            "url": "https://github.com/D-sorganization/Maxwell-Daemon",
+        },
+        license_info={
+            "name": "MIT",
+            "url": "https://github.com/D-sorganization/Maxwell-Daemon/blob/main/LICENSE",
+        },
+        openapi_tags=[
+            {"name": "health", "description": "Liveness and readiness probes."},
+            {"name": "version", "description": "Daemon and contract version metadata."},
+            {"name": "tasks", "description": "Submit, list, and inspect agent tasks."},
+            {
+                "name": "control",
+                "description": "Privileged daemon control (pause / resume / abort).",
+            },
+            {"name": "cost", "description": "Cost ledger queries and aggregates."},
+            {"name": "backends", "description": "LLM backend discovery and configuration."},
+            {"name": "auth", "description": "Authentication and session management."},
+            {"name": "fleet", "description": "Multi-repo fleet manifest and dispatch."},
+        ],
     )
     mount_metrics_endpoint(app)
     http_metrics_middleware(app)

--- a/run_100_times.py
+++ b/run_100_times.py
@@ -37,7 +37,9 @@ for i in range(1, RUNS + 1):
             }
         )
 
-    print(f"Run {i:3d}/{RUNS}: {status} ({run_elapsed:.2f}s) | Total: {passed} passed, {failed} failed")
+    print(
+        f"Run {i:3d}/{RUNS}: {status} ({run_elapsed:.2f}s) | Total: {passed} passed, {failed} failed"
+    )
 
     if i % 10 == 0:
         print(f"--- Progress: {i}/{RUNS} ---")
@@ -46,7 +48,7 @@ total_elapsed = time.monotonic() - start
 
 print("\n" + "=" * 60)
 print(f"SUMMARY: {passed} passed, {failed} failed out of {RUNS} runs")
-print(f"Total time: {total_elapsed:.1f}s  Avg per run: {total_elapsed/RUNS:.2f}s")
+print(f"Total time: {total_elapsed:.1f}s  Avg per run: {total_elapsed / RUNS:.2f}s")
 print("=" * 60)
 
 if failures:

--- a/run_100_times.py
+++ b/run_100_times.py
@@ -50,7 +50,7 @@ print(f"Total time: {total_elapsed:.1f}s  Avg per run: {total_elapsed/RUNS:.2f}s
 print("=" * 60)
 
 if failures:
-    print(f"\n--- First failure details ---\n")
+    print("\n--- First failure details ---\n")
     f = failures[0]
     print(f"Run #{f['run']} ({f['elapsed']:.2f}s):")
     print("STDOUT:", f["stdout"][:2000])

--- a/run_100_times_v2.py
+++ b/run_100_times_v2.py
@@ -85,7 +85,9 @@ def main() -> int:
         }
         save_progress(progress)
 
-        print(f"Run {i:3d}/{RUNS}: {status} ({run_elapsed:.2f}s) | Total: {passed} passed, {failed} failed")
+        print(
+            f"Run {i:3d}/{RUNS}: {status} ({run_elapsed:.2f}s) | Total: {passed} passed, {failed} failed"
+        )
 
         if i % 10 == 0:
             print(f"--- Progress: {i}/{RUNS} ---")

--- a/run_100_times_v2.py
+++ b/run_100_times_v2.py
@@ -110,7 +110,7 @@ def main() -> int:
     print("=" * 60)
 
     if failures:
-        print(f"\n--- First failure details ---\n")
+        print("\n--- First failure details ---\n")
         f = failures[0]
         print(f"Run #{f['run']} ({f['elapsed']:.2f}s):")
         print("STDOUT:", f["stdout"])

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1510,3 +1510,37 @@ class TestSSHEndpointsWithoutAsyncSSH:
                 json={"host": "srv", "user": "ubuntu"},
             )
         assert r.status_code == 503
+
+
+class TestOpenAPIMetadata:
+    """OpenAPI / Swagger schema is exposed and carries curated metadata."""
+
+    def test_openapi_json_is_served(self, client: TestClient) -> None:
+        r = client.get("/openapi.json")
+        assert r.status_code == 200
+        body = r.json()
+        info = body["info"]
+        assert info["title"] == "Maxwell-Daemon API"
+        # Curated description should mention the contract version & docs links.
+        assert "Contract version" in info["description"]
+        assert "/docs" in info["description"]
+        assert info["license"]["name"] == "MIT"
+        assert "github.com/D-sorganization/Maxwell-Daemon" in info["contact"]["url"]
+
+    def test_swagger_ui_is_served(self, client: TestClient) -> None:
+        r = client.get("/docs")
+        assert r.status_code == 200
+        assert "swagger" in r.text.lower()
+
+    def test_redoc_ui_is_served(self, client: TestClient) -> None:
+        r = client.get("/redoc")
+        assert r.status_code == 200
+        # ReDoc HTML page references the redoc bundle.
+        assert "redoc" in r.text.lower()
+
+    def test_openapi_declares_known_tags(self, client: TestClient) -> None:
+        r = client.get("/openapi.json")
+        body = r.json()
+        tag_names = {tag["name"] for tag in body.get("tags", [])}
+        # A representative subset — full list is curated in create_app().
+        assert {"health", "tasks", "control", "cost"} <= tag_names


### PR DESCRIPTION
## Summary
- Enrich the FastAPI app constructor with a curated `summary`, multi-section `description` (auth, websockets, links to interactive docs), `contact`, `license_info`, and `openapi_tags`. FastAPI already auto-served `/docs`, `/redoc`, and `/openapi.json` — this populates them with real metadata.
- README now has an **API Documentation** section pointing operators at the three doc endpoints and noting the schema is auto-generated and contract-versioned.
- New `TestOpenAPIMetadata` (4 cases) verifies the schema is served, Swagger/ReDoc HTML loads, and the curated tag set is present.

This is Phase 1 of #802 (the OpenAPI exposure / README link parts). Phases 2+ (per-endpoint docstring sweep, example clients, Postman collection) are out of scope here.

Fixes #802

## Test plan
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `pytest tests/unit/test_api.py::TestOpenAPIMetadata` — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)