### PR TITLE
fix(lint): enforce ruff BLE rule with grandfathered baseline

### DIFF
--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -871,7 +871,7 @@ async def _websocket_auth_or_close(
 
     try:
         claims = jwt_config.decode_token(presented)
-    except Exception:  # nosec B110 - invalid WebSocket token, close below.
+    except Exception:  # nosec B110 - invalid WebSocket token, close below.  # noqa: BLE001
         if audit:
             audit.log_auth_decision(
                 subject="unknown",
@@ -1550,7 +1550,7 @@ def create_app(
                     "role": claims.role.value,
                     "exp": claims.exp.isoformat(),
                 }
-            except Exception:
+            except Exception:  # noqa: BLE001
                 # invalid/expired JWT, fall through to static token check
                 pass  # nosec B110
         if auth_token is not None and authorization:
@@ -1615,7 +1615,7 @@ def create_app(
     async def api_status() -> StatusResponse:
         try:
             state = daemon.state()
-        except Exception:
+        except Exception:  # noqa: BLE001
             return StatusResponse(
                 pipeline_state="error",
                 gate="closed",
@@ -1649,7 +1649,7 @@ def create_app(
         generated_at = datetime.now(timezone.utc)
         try:
             state = daemon.state()
-        except Exception:
+        except Exception:  # noqa: BLE001
             return StatusV2Response(
                 generated_at=generated_at.isoformat(),
                 counts=_status_v2_counts([]),
@@ -1788,7 +1788,7 @@ def create_app(
             state = daemon.state()
             running_tasks = [t for t in state.tasks.values() if t.status.value == "running"]
             previous_state = "running" if running_tasks else "idle"
-        except Exception:
+        except Exception:  # noqa: BLE001
             previous_state = "unknown"
 
         if action == "abort":
@@ -1799,7 +1799,7 @@ def create_app(
                     if task_obj.status.value in ("running", "queued"):
                         with contextlib.suppress(Exception):
                             daemon.cancel_task(task_obj.id)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("Error during abort: cancel tasks failed", exc_info=True)
 
         return ControlResponse(
@@ -1900,13 +1900,13 @@ def create_app(
                 raise HTTPException(status_code=404, detail=f"Backend '{name}' not configured")
             try:
                 backend = daemon._router._get_or_create(name, daemon._config.backends[name])
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 return BackendTestResponse(success=False, error=str(e))
 
         start = monotonic()
         try:
             is_healthy = await backend.health_check()
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             return BackendTestResponse(success=False, error=str(e))
 
         latency = (monotonic() - start) * 1000
@@ -1950,7 +1950,7 @@ def create_app(
                 max_tokens=10,
             )
             return {"status": "success", "response": resp.content}
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             return {"status": "error", "error": str(e)}
 
     @app.post(
@@ -2552,7 +2552,7 @@ def create_app(
                     priority=item.priority,
                 )
                 dispatched.append(TaskView.from_task(task))
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 failures.append({"repo": item.repo, "number": item.number, "error": str(e)})
         return {
             "dispatched": len(dispatched),
@@ -2675,7 +2675,7 @@ def create_app(
             fleet_client = RemoteDaemonClient(auth_token=daemon._config.api_auth_token)
             try:
                 probed = await fleet_client.refresh_all(initial)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 probed = initial  # fall back to config data on probe failure
 
             # Count tasks dispatched to each machine.
@@ -3010,7 +3010,7 @@ def create_app(
                                         pass_rate=1.0 if res.status.value == "passed" else 0.0,
                                     )
                                 )
-                except Exception:
+                except Exception:  # noqa: BLE001
                     log.warning(
                         "Failed to build leaderboard entry for %s/%s",
                         backend,
@@ -3298,7 +3298,7 @@ def create_app(
                 await ws.send_bytes(chunk)
         except WebSocketDisconnect:
             return
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             await ws.send_text(_json_mod.dumps({"error": str(exc)}))
             await ws.close(code=1011)
 
@@ -3325,7 +3325,7 @@ def create_app(
                 await ws.send_text(event.to_json())
         except WebSocketDisconnect:
             return
-        except Exception:
+        except Exception:  # noqa: BLE001
             await ws.close(code=1011)
 
     return app

--- a/maxwell_daemon/backends/agent_loop.py
+++ b/maxwell_daemon/backends/agent_loop.py
@@ -624,7 +624,7 @@ class AgentLoopBackend(ILLMBackend):
                 messages=[{"role": "user", "content": "."}],
             )
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/claude.py
+++ b/maxwell_daemon/backends/claude.py
@@ -136,14 +136,14 @@ class ClaudeBackend(ILLMBackend):
                 messages=[{"role": "user", "content": "."}],
             )
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
         try:
             page = await self._client.models.list()
             return [m.id for m in page.data]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/condensation.py
+++ b/maxwell_daemon/backends/condensation.py
@@ -87,7 +87,7 @@ class Condenser:
 
         try:
             summary_text = await self._summarize(list(middle))
-        except Exception:
+        except Exception:  # noqa: BLE001
             return messages
 
         summary_msg: dict[str, object] = {

--- a/maxwell_daemon/backends/deepseek.py
+++ b/maxwell_daemon/backends/deepseek.py
@@ -132,14 +132,14 @@ class DeepSeekBackend(ILLMBackend):
         try:
             await self._client.models.list()
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
         try:
             page = await self._client.models.list()
             return [m.id for m in page.data]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/external_adapter.py
+++ b/maxwell_daemon/backends/external_adapter.py
@@ -135,7 +135,7 @@ def _run_coroutine_sync(coroutine: Coroutine[Any, Any, _T]) -> _T:
     def runner() -> None:
         try:
             result.append(asyncio.run(coroutine))
-        except BaseException as exc:  # pragma: no cover - defensive thread handoff
+        except BaseException as exc:  # pragma: no cover - defensive thread handoff  # noqa: BLE001
             errors.append(exc)
 
     thread = threading.Thread(target=runner, daemon=True)

--- a/maxwell_daemon/backends/gemini.py
+++ b/maxwell_daemon/backends/gemini.py
@@ -137,13 +137,13 @@ class GeminiBackend(ILLMBackend):
             gmodel = self._genai.GenerativeModel(model_name="gemini-1.5-flash")
             await gmodel.generate_content_async("ping")
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
         try:
             return [m.name for m in self._genai.list_models()]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/groq.py
+++ b/maxwell_daemon/backends/groq.py
@@ -140,14 +140,14 @@ class GroqBackend(ILLMBackend):
         try:
             await self._client.models.list()
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
         try:
             page = await self._client.models.list()
             return [m.id for m in page.data]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/huggingface.py
+++ b/maxwell_daemon/backends/huggingface.py
@@ -125,14 +125,14 @@ class HuggingFaceBackend(ILLMBackend):
         try:
             await self._client.models.list()
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
         try:
             page = await self._client.models.list()
             return [m.id for m in page.data]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/mistral.py
+++ b/maxwell_daemon/backends/mistral.py
@@ -117,14 +117,14 @@ class MistralBackend(ILLMBackend):
         try:
             await self._client.models.list_async()
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
         try:
             result = await self._client.models.list_async()
             return [m.id for m in result.data]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/ollama.py
+++ b/maxwell_daemon/backends/ollama.py
@@ -123,7 +123,7 @@ class OllamaBackend(ILLMBackend):
         try:
             r = await self._client.get(f"{self._endpoint}/api/tags", timeout=5.0)
             return r.status_code == 200
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
@@ -132,7 +132,7 @@ class OllamaBackend(ILLMBackend):
             r.raise_for_status()
             data = r.json()
             return [m["name"] for m in data.get("models", [])]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/ollama_discovery.py
+++ b/maxwell_daemon/backends/ollama_discovery.py
@@ -141,7 +141,7 @@ def discover_ollama_models(endpoint: str | None = None) -> list[OllamaModelInfo]
             resp = client.get(f"{base}/api/tags")
             resp.raise_for_status()
             return _parse_models(resp.json())
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         log.debug("ollama_discovery: could not reach %s: %s", base, exc)
         return []
 
@@ -153,7 +153,7 @@ def is_ollama_available(endpoint: str | None = None) -> bool:
         with httpx.Client(timeout=_TIMEOUT) as client:
             resp = client.get(f"{base}/api/tags")
             return resp.status_code == 200
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False
 
 
@@ -177,7 +177,7 @@ async def adiscover_ollama_models(endpoint: str | None = None) -> list[OllamaMod
             resp = await client.get(f"{base}/api/tags")
             resp.raise_for_status()
             return _parse_models(resp.json())
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         log.debug("ollama_discovery: could not reach %s: %s", base, exc)
         return []
 
@@ -189,7 +189,7 @@ async def ais_ollama_available(endpoint: str | None = None) -> bool:
         async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
             resp = await client.get(f"{base}/api/tags")
             return resp.status_code == 200
-    except Exception:
+    except Exception:  # noqa: BLE001
         return False
 
 

--- a/maxwell_daemon/backends/openai.py
+++ b/maxwell_daemon/backends/openai.py
@@ -138,14 +138,14 @@ class OpenAIBackend(ILLMBackend):
         try:
             await self._client.models.list()
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
         try:
             page = await self._client.models.list()
             return [m.id for m in page.data]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/openrouter.py
+++ b/maxwell_daemon/backends/openrouter.py
@@ -130,14 +130,14 @@ class OpenRouterBackend(ILLMBackend):
         try:
             await self._client.models.list()
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
         try:
             page = await self._client.models.list()
             return [m.id for m in page.data]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/backends/together.py
+++ b/maxwell_daemon/backends/together.py
@@ -133,14 +133,14 @@ class TogetherBackend(ILLMBackend):
         try:
             await self._client.models.list()
             return True
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
 
     async def list_models(self) -> list[str]:
         try:
             page = await self._client.models.list()
             return [m.id for m in page.data]
-        except Exception:
+        except Exception:  # noqa: BLE001
             return []
 
     def capabilities(self, model: str) -> BackendCapabilities:

--- a/maxwell_daemon/cli/backup.py
+++ b/maxwell_daemon/cli/backup.py
@@ -48,7 +48,7 @@ def export_cmd(
     mgr = _make_manager(config, data_dir)
     try:
         archive = mgr.export(out)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         err_console.print(f"[red]Export failed:[/red] {exc}")
         raise typer.Exit(1) from None
 
@@ -88,7 +88,7 @@ def restore_cmd(
     except RestoreError as exc:
         err_console.print(f"[red]Restore failed:[/red] {exc}")
         raise typer.Exit(1) from None
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         err_console.print(f"[red]Unexpected error during restore:[/red] {exc}")
         raise typer.Exit(1) from None
 
@@ -136,7 +136,7 @@ def export_json_cmd(
     except ValueError as exc:
         err_console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(1) from None
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         err_console.print(f"[red]Unexpected error:[/red] {exc}")
         raise typer.Exit(1) from None
 
@@ -169,7 +169,7 @@ def info_cmd(
             if fh is None:
                 raise RuntimeError("Could not read manifest.json from archive")
             manifest_data = json.loads(fh.read().decode("utf-8"))
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         err_console.print(f"[red]Failed to read archive:[/red] {exc}")
         raise typer.Exit(1) from None
 

--- a/maxwell_daemon/cli/batch_dispatch.py
+++ b/maxwell_daemon/cli/batch_dispatch.py
@@ -129,7 +129,7 @@ class BatchDispatchPlanner:
     ) -> tuple[list[BatchItem], RepoBatchSummary]:
         try:
             issues = await self._list_issues(repo, state=state, limit=limit)
-        except Exception:
+        except Exception:  # noqa: BLE001
             return [], RepoBatchSummary(repo=repo, eligible=0, submitted=0, skipped=0)
 
         filtered = [i for i in issues if label is None or label in i.labels]

--- a/maxwell_daemon/cli/main.py
+++ b/maxwell_daemon/cli/main.py
@@ -184,7 +184,7 @@ def health(
                 table.add_row(name, "[green]healthy[/green]" if ok else "[red]unreachable[/red]")
                 if not ok:
                     failures += 1
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 table.add_row(name, f"[red]error: {e}[/red]")
                 failures += 1
         console.print(table)

--- a/maxwell_daemon/context/providers.py
+++ b/maxwell_daemon/context/providers.py
@@ -122,7 +122,7 @@ class RepoSchematicProvider:
         try:
             map_block = build_repo_schematic(self.workspace).to_prompt(max_chars=budget_chars)
             return ContextProviderResult(name=self.name, text=map_block, size_chars=len(map_block))
-        except Exception:
+        except Exception:  # noqa: BLE001
             return ContextProviderResult(name=self.name, text="", size_chars=0)
 
 

--- a/maxwell_daemon/core/action_service.py
+++ b/maxwell_daemon/core/action_service.py
@@ -114,7 +114,7 @@ class ActionService:
                         f"Action {action.id} exceeded {_ACTION_EXECUTOR_TIMEOUT_SECONDS:.0f}s timeout"
                     ) from None
             return self.mark_applied(running.id, result=result)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             return self.mark_failed(running.id, error=str(exc))
 
     def get(self, action_id: str) -> Action | None:

--- a/maxwell_daemon/core/backup.py
+++ b/maxwell_daemon/core/backup.py
@@ -566,7 +566,7 @@ class BackupManager:
             import yaml
 
             raw = yaml.safe_load(self._config_path.read_text(encoding="utf-8")) or {}
-        except Exception:
+        except Exception:  # noqa: BLE001
             return
 
         lines = [

--- a/maxwell_daemon/core/critics.py
+++ b/maxwell_daemon/core/critics.py
@@ -350,7 +350,7 @@ class CriticPanelRunner:
                 started_at=started_at,
                 finished_at=_utc_now(),
             )
-        except Exception as exc:  # pragma: no cover - exercised by failure-path tests
+        except Exception as exc:  # noqa: BLE001 — fail-closed wrapper; pragma: no cover
             return CriticPanelRun(
                 profile=profile,
                 status="error",

--- a/maxwell_daemon/core/cross_audit.py
+++ b/maxwell_daemon/core/cross_audit.py
@@ -181,7 +181,7 @@ class CrossAuditService:
             )
             response = await player.execute(Job(instructions=prompt))
             return self._success_result(target.role.name, decision.backend_name, response)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             return CrossAuditResult(
                 role_name=target.role.name,
                 backend_name=backend_label,

--- a/maxwell_daemon/core/doctor.py
+++ b/maxwell_daemon/core/doctor.py
@@ -53,7 +53,7 @@ def check_config_loadable(path: Path) -> CheckResult:
         return CheckResult("config", Severity.ERROR, f"config not found at {path}")
     try:
         load_config(path)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return CheckResult("config", Severity.ERROR, f"config invalid: {e}")
     return CheckResult("config", Severity.OK, f"loaded {path}")
 
@@ -66,7 +66,7 @@ def check_ledger_writable(path: Path) -> CheckResult:
         if parent.exists() and parent.stat().st_mode & 0o222 == 0:
             return CheckResult("ledger", Severity.ERROR, f"ledger parent is not writable: {parent}")
         CostLedger(path)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return CheckResult("ledger", Severity.ERROR, f"ledger not writable: {e}")
     return CheckResult("ledger", Severity.OK, f"writable at {path}")
 
@@ -135,7 +135,7 @@ async def check_backends_healthy(*, backends: Iterable[Any]) -> CheckResult:
     async def probe(b: Any) -> tuple[str, bool]:
         try:
             return b.name, await b.health_check()
-        except Exception:
+        except Exception:  # noqa: BLE001
             return b.name, False
 
     results = await asyncio.gather(*(probe(b) for b in backends))
@@ -174,7 +174,7 @@ async def run_all_checks(*, config_path: Path, ledger_path: Path) -> list[CheckR
         for name in router.available_backends():
             try:
                 backends.append(router.route(backend_override=name).backend)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 results.append(
                     CheckResult(
                         "backends",

--- a/maxwell_daemon/core/repo_overrides.py
+++ b/maxwell_daemon/core/repo_overrides.py
@@ -61,7 +61,7 @@ class RepoSchematic:
                     schematic += f"Dir: {item.name}\n"
                 elif item.is_file():
                     schematic += f"File: {item.name}\n"
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             schematic += f"Error: {e}\n"
 
         if os.environ.get("MAXWELL_AGGRESSIVE_COMPRESSION") == "1":

--- a/maxwell_daemon/core/template_store.py
+++ b/maxwell_daemon/core/template_store.py
@@ -348,7 +348,7 @@ class TemplateStore:
                 data = json.loads(child.read_text("utf-8"))
                 template = TaskTemplate.model_validate(data)
                 self._templates[template.id] = template
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("Failed to load template from %s", child.name, exc_info=True)
 
     def list_templates(self) -> list[TaskTemplate]:

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -649,7 +649,7 @@ class Daemon:
                     log.info("retention prune completed: %s", result)
             except asyncio.CancelledError:
                 raise
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("retention prune failed", exc_info=True)
             await asyncio.sleep(interval)
 
@@ -680,7 +680,7 @@ class Daemon:
                     log.debug("evicted %d stale tasks from live memory dict", evicted)
             except asyncio.CancelledError:
                 raise
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("live eviction loop failed", exc_info=True)
             await asyncio.sleep(60.0)
 
@@ -691,7 +691,7 @@ class Daemon:
                 await self._reconcile_stalled_runs()
             except asyncio.CancelledError:
                 raise
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("stall reconcile loop failed", exc_info=True)
             timeout = self._config.agent.stall_timeout_seconds
             interval = 1.0 if timeout <= 2 else min(timeout / 2.0, 30.0)
@@ -785,7 +785,7 @@ class Daemon:
                 log.info("memory dream cycle completed: %s", result)
             except asyncio.CancelledError:
                 raise
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("memory dream cycle failed", exc_info=True)
 
     async def run_memory_dream_cycle(self) -> str:
@@ -860,7 +860,7 @@ class Daemon:
                         "Task queue is full, please try again later", backoff_seconds=60
                     )
                 )
-            except BaseException as exc:  # pragma: no cover - surfaced via Future
+            except BaseException as exc:  # pragma: no cover - surfaced via Future  # noqa: BLE001
                 result.set_exception(exc)
             else:
                 result.set_result(None)
@@ -1642,7 +1642,7 @@ class Daemon:
                 log.info("dispatched task %s to machine %s", assigned_task.id, machine.name)
                 try:
                     self._task_store.save(assigned_task)
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001
                     log.warning(
                         "Failed to persist DISPATCHED state for task %s: %s",
                         assigned_task.id,
@@ -1745,7 +1745,7 @@ class Daemon:
                     self._task_store.update_status(
                         task.id, TaskStatus.RUNNING, started_at=task.started_at
                     )
-                except Exception as exc:
+                except Exception as exc:  # noqa: BLE001
                     log.error(
                         "failed to mark task %s RUNNING: %s; re-queuing",
                         task.id,
@@ -1938,12 +1938,12 @@ class Daemon:
                     hook_config = load_hooks_config(repo_path, global_config=snapshot.config)
                     if hook_config:
                         await execute_hooks("after_run", repo_path, config=hook_config, fatal=False)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     log.warning("after_run hook failed (ignored): %s", e)
             task.finished_at = datetime.now(timezone.utc)
             try:
                 self._memory.scratchpad.clear(task.id)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 log.warning(
                     "scratchpad clear failed for task %s: %s",
                     task.id,
@@ -2029,7 +2029,7 @@ class Daemon:
                     selection.model,
                     selection.factors,
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 # Selection is opportunistic — a failure here falls through
                 # to the default model so the task still proceeds.
                 log.warning("model-select failed for task=%s; using default", task.id)

--- a/maxwell_daemon/daemon/scheduler.py
+++ b/maxwell_daemon/daemon/scheduler.py
@@ -114,7 +114,7 @@ class DiscoveryScheduler:
         try:
             raw = json.loads(self._dedup_path.read_text())
             return {repo: set(nums) for repo, nums in raw.items() if isinstance(nums, list)}
-        except Exception:
+        except Exception:  # noqa: BLE001
             log.warning("discovery dedup file unreadable; starting fresh", exc_info=True)
             return {}
 
@@ -126,7 +126,7 @@ class DiscoveryScheduler:
             self._dedup_path.parent.mkdir(parents=True, exist_ok=True)
             payload = {repo: sorted(nums) for repo, nums in self._dispatched.items()}
             self._dedup_path.write_text(json.dumps(payload))
-        except Exception:
+        except Exception:  # noqa: BLE001
             log.warning("failed to persist discovery dedup", exc_info=True)
 
     async def run_once(self) -> DiscoveryTick:
@@ -143,7 +143,7 @@ class DiscoveryScheduler:
                 # — list_issues is cheap and the alternative would be
                 # threading a mutable out-param through discover_issues.
                 current_issues = await self._github.list_issues(spec.repo, state="open", limit=50)
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("discovery list failed for repo=%s", spec.repo, exc_info=True)
                 continue
 
@@ -156,7 +156,7 @@ class DiscoveryScheduler:
                     mode=spec.mode,
                     already_dispatched=seen,
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("discovery tick failed for repo=%s", spec.repo, exc_info=True)
                 continue
 
@@ -217,7 +217,7 @@ class DiscoveryScheduler:
         while not self._stop_event.is_set():
             try:
                 await self.run_once()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("discovery tick raised; continuing", exc_info=True)
             try:
                 await asyncio.wait_for(self._stop_event.wait(), timeout=self._interval)

--- a/maxwell_daemon/daemon/workspace_hooks.py
+++ b/maxwell_daemon/daemon/workspace_hooks.py
@@ -132,7 +132,7 @@ def load_hooks_config(
                 data = yaml.safe_load(f)
             if isinstance(data, dict):
                 return WorkspaceHooksConfig.from_dict(data)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning(f"Failed to load local workspace hooks from {local_file}: {e}")
 
     # Fallback to global config if available

--- a/maxwell_daemon/director/task_graph_runner.py
+++ b/maxwell_daemon/director/task_graph_runner.py
@@ -203,7 +203,7 @@ class GraphRunner:
                     cost_usd=output.cost_usd,
                     attempts=attempts,
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 last_error = str(exc) or repr(exc)
 
         finished_at = _now()

--- a/maxwell_daemon/evals/registry.py
+++ b/maxwell_daemon/evals/registry.py
@@ -120,7 +120,7 @@ def list_scenarios() -> list[EvalScenario]:
                         data.setdefault("fixture_repo_ref", "fixture://local")
                         data.setdefault("task_prompt", "Run benchmark")
                         scenarios.append(EvalScenario(**data))
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 import logging
 
                 logging.getLogger(__name__).warning(f"Failed to load suite {suite_file}: {e}")

--- a/maxwell_daemon/executor/pr_merge_daemon.py
+++ b/maxwell_daemon/executor/pr_merge_daemon.py
@@ -240,7 +240,7 @@ class PrMergeDaemon:
         for pr in prs:
             try:
                 results.append(await self.shepherd(pr, gh=gh))
-            except Exception:
+            except Exception:  # noqa: BLE001
                 log.warning("shepherd raised for pr=%s/%s", pr.repo, pr.number, exc_info=True)
                 results.append(
                     PrShepherdResult(

--- a/maxwell_daemon/fleet/client.py
+++ b/maxwell_daemon/fleet/client.py
@@ -145,7 +145,7 @@ class RemoteDaemonClient:
         url = f"{self._base_url(machine)}{_HEALTH_PATH}"
         try:
             response = await self._http.get(url, headers=self._headers())
-        except Exception:
+        except Exception:  # noqa: BLE001
             return False
         return response.status_code == 200
 
@@ -192,7 +192,7 @@ def _extract_error_detail(response: HTTPResponseProtocol) -> str:
                 if body.get(key):
                     return f"HTTP {status}: {body[key]}"
         return f"HTTP {status}: {body!r}"
-    except Exception:
+    except Exception:  # noqa: BLE001
         text = getattr(response, "text", "") or ""
         if text:
             return f"HTTP {status}: {text}"

--- a/maxwell_daemon/gh/client.py
+++ b/maxwell_daemon/gh/client.py
@@ -242,7 +242,7 @@ class GitHubClient:
             data = json.loads(out)
             reset = data.get("resources", {}).get("core", {}).get("reset")
             return float(reset) if reset is not None else None
-        except Exception:
+        except Exception:  # noqa: BLE001
             return None
 
     async def _request_with_retry(

--- a/maxwell_daemon/gh/context.py
+++ b/maxwell_daemon/gh/context.py
@@ -316,7 +316,7 @@ class ContextBuilder:
                 token_budget=1_000,
                 max_chars=4_000,
             )
-        except Exception:
+        except Exception:  # noqa: BLE001
             return ""
 
     @staticmethod

--- a/maxwell_daemon/gh/repo_schematic.py
+++ b/maxwell_daemon/gh/repo_schematic.py
@@ -135,7 +135,7 @@ def build_repo_schematic(workspace: Path) -> RepoSchematic:
             continue
         try:
             entry = parser(workspace, path)
-        except Exception:
+        except Exception:  # noqa: BLE001
             # Belt-and-suspenders: per-file parsing must never kill the sweep.
             entry = None
         if entry is not None:

--- a/maxwell_daemon/mcp/client.py
+++ b/maxwell_daemon/mcp/client.py
@@ -135,5 +135,5 @@ class McpClientManager:
             try:
                 registry.register(spec)
                 log.debug("Attached MCP tool %r", spec.name)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 log.warning("Failed to attach MCP tool %r: %s", spec.name, e)

--- a/maxwell_daemon/mcp/client/__init__.py
+++ b/maxwell_daemon/mcp/client/__init__.py
@@ -157,5 +157,5 @@ class McpClientManager:
             try:
                 registry.register(spec)
                 log.debug("Attached MCP tool %r", spec.name)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 log.warning("Failed to attach MCP tool %r: %s", spec.name, e)

--- a/maxwell_daemon/sandbox/gates.py
+++ b/maxwell_daemon/sandbox/gates.py
@@ -127,7 +127,7 @@ class SandboxGateAdapter:
                 network_enabled=network_enabled,
                 allow_gpu=allow_gpu,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             return self._failure(
                 "invalid sandbox policy",
                 (
@@ -152,7 +152,7 @@ class SandboxGateAdapter:
                 gate_name=gate.name,
                 policy_name=policy_name,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             return self._failure(
                 "sandbox command execution error",
                 (

--- a/maxwell_daemon/ssh/session.py
+++ b/maxwell_daemon/ssh/session.py
@@ -210,7 +210,7 @@ class SSHSessionPool:
                 try:
                     priv, _ = self._key_store.get_or_generate(host)
                     connect_kwargs["client_keys"] = [priv]
-                except Exception:
+                except Exception:  # noqa: BLE001
                     pass  # nosec B110 fall through to agent/default key resolution
 
             conn = await asyncssh.connect(**connect_kwargs)

--- a/maxwell_daemon/tools/gh_proxy.py
+++ b/maxwell_daemon/tools/gh_proxy.py
@@ -214,7 +214,7 @@ def make_gh_proxy(
 
         try:
             result = await _call_gh(client, operation, params)
-        except Exception as exc:  # pragma: no cover
+        except Exception as exc:  # pragma: no cover  # noqa: BLE001
             log.warning(
                 "gh_proxy execution failed",
                 task_id=task_id,
@@ -270,5 +270,5 @@ def _audit(
                 "summary": summary,
             },
         )
-    except Exception:
+    except Exception:  # noqa: BLE001
         log.warning("gh_proxy audit write failed", exc_info=True)

--- a/maxwell_daemon/tools/mcp.py
+++ b/maxwell_daemon/tools/mcp.py
@@ -427,7 +427,7 @@ class ToolRegistry:
         if self._hook_runner is not None:
             try:
                 pre = await self._hook_runner.run_pre_tool(name, arguments)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 self._record_invocation(
                     name,
                     arguments,
@@ -457,7 +457,7 @@ class ToolRegistry:
             if inspect.isawaitable(result):
                 result = await result
             content = _stringify(result)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             self._record_invocation(
                 name,
                 arguments,
@@ -506,7 +506,7 @@ class ToolRegistry:
                 result_summary=result_summary,
                 error=error,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             import structlog
 
             log = structlog.get_logger(__name__)

--- a/maxwell_daemon/triggers/cron.py
+++ b/maxwell_daemon/triggers/cron.py
@@ -94,7 +94,7 @@ def _matches(dt: datetime, cron: str) -> bool:
     """Return True if *dt* (minute-precision) matches *cron*."""
     try:
         minutes, hours, mdays, months, wdays = _parse_cron(cron)
-    except (ValueError, Exception):
+    except (ValueError, Exception):  # noqa: BLE001
         log.warning("invalid cron expression %r; skipping", cron)
         return False
     return (
@@ -219,7 +219,7 @@ try:
         try:
             # croniter.match checks whether *dt* falls on the given cron tick
             return bool(_croniter.match(cron, dt.replace(second=0, microsecond=0)))
-        except Exception:
+        except Exception:  # noqa: BLE001
             log.warning("croniter could not parse cron=%r; skipping", cron)
             return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,12 @@ target-version = "py310"
 line-ending = "lf"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "N", "UP", "B", "C4", "SIM", "RUF", "C90"]
+select = ["E", "F", "W", "I", "N", "UP", "B", "C4", "SIM", "RUF", "C90", "BLE"]
 ignore = ["E501"]
+# `BLE` (flake8-blind-except) is now enforced. Existing bare
+# `except Exception:` handlers (~94 sites, see #795) are grandfathered
+# with inline `# noqa: BLE001` directives so any new code is held to
+# the stricter standard. Per-module remediation tracked under #795.
 
 [tool.ruff.lint.mccabe]
 max-complexity = 270

--- a/run_100_times.py
+++ b/run_100_times.py
@@ -37,7 +37,9 @@ for i in range(1, RUNS + 1):
             }
         )
 
-    print(f"Run {i:3d}/{RUNS}: {status} ({run_elapsed:.2f}s) | Total: {passed} passed, {failed} failed")
+    print(
+        f"Run {i:3d}/{RUNS}: {status} ({run_elapsed:.2f}s) | Total: {passed} passed, {failed} failed"
+    )
 
     if i % 10 == 0:
         print(f"--- Progress: {i}/{RUNS} ---")
@@ -46,7 +48,7 @@ total_elapsed = time.monotonic() - start
 
 print("\n" + "=" * 60)
 print(f"SUMMARY: {passed} passed, {failed} failed out of {RUNS} runs")
-print(f"Total time: {total_elapsed:.1f}s  Avg per run: {total_elapsed/RUNS:.2f}s")
+print(f"Total time: {total_elapsed:.1f}s  Avg per run: {total_elapsed / RUNS:.2f}s")
 print("=" * 60)
 
 if failures:

--- a/run_100_times.py
+++ b/run_100_times.py
@@ -50,7 +50,7 @@ print(f"Total time: {total_elapsed:.1f}s  Avg per run: {total_elapsed/RUNS:.2f}s
 print("=" * 60)
 
 if failures:
-    print(f"\n--- First failure details ---\n")
+    print("\n--- First failure details ---\n")
     f = failures[0]
     print(f"Run #{f['run']} ({f['elapsed']:.2f}s):")
     print("STDOUT:", f["stdout"][:2000])

--- a/run_100_times_v2.py
+++ b/run_100_times_v2.py
@@ -85,7 +85,9 @@ def main() -> int:
         }
         save_progress(progress)
 
-        print(f"Run {i:3d}/{RUNS}: {status} ({run_elapsed:.2f}s) | Total: {passed} passed, {failed} failed")
+        print(
+            f"Run {i:3d}/{RUNS}: {status} ({run_elapsed:.2f}s) | Total: {passed} passed, {failed} failed"
+        )
 
         if i % 10 == 0:
             print(f"--- Progress: {i}/{RUNS} ---")

--- a/run_100_times_v2.py
+++ b/run_100_times_v2.py
@@ -110,7 +110,7 @@ def main() -> int:
     print("=" * 60)
 
     if failures:
-        print(f"\n--- First failure details ---\n")
+        print("\n--- First failure details ---\n")
         f = failures[0]
         print(f"Run #{f['run']} ({f['elapsed']:.2f}s):")
         print("STDOUT:", f["stdout"])

--- a/tests/unit/test_config_hot_reload.py
+++ b/tests/unit/test_config_hot_reload.py
@@ -141,7 +141,7 @@ class TestReloadConfig:
         def _reload() -> None:
             try:
                 file_daemon.reload_config()
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
 
         threads = [threading.Thread(target=_reload) for _ in range(8)]

--- a/tests/unit/test_daemon_thread_safety.py
+++ b/tests/unit/test_daemon_thread_safety.py
@@ -196,7 +196,7 @@ class TestTasksDictThreadSafety:
                 d.submit("hi")
             except QueueSaturationError:
                 pass
-            except BaseException as e:
+            except BaseException as e:  # noqa: BLE001
                 errors.append(e)
 
         def _read(_: int) -> None:
@@ -204,7 +204,7 @@ class TestTasksDictThreadSafety:
                 # state() copies self._tasks — the bug surfaces here when a
                 # concurrent submit() mutates the dict mid-copy.
                 d.state()
-            except BaseException as e:
+            except BaseException as e:  # noqa: BLE001
                 errors.append(e)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=10) as pool:
@@ -241,7 +241,7 @@ class TestTasksDictThreadSafety:
                 while not stop:
                     with contextlib.suppress(QueueSaturationError):
                         d.submit("hi")
-            except BaseException as e:
+            except BaseException as e:  # noqa: BLE001
                 errors.append(e)
 
         def _reader() -> None:
@@ -251,7 +251,7 @@ class TestTasksDictThreadSafety:
                     # Force full iteration — catches torn snapshots.
                     for _tid, _task in snap.tasks.items():
                         pass
-            except BaseException as e:
+            except BaseException as e:  # noqa: BLE001
                 errors.append(e)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -94,7 +94,7 @@ class TestTracingImportError:
         with patch.dict("sys.modules", dict.fromkeys(otel_modules)):
             try:
                 configure_tracing(endpoint="http://localhost:4317", service_name="test")
-            except Exception:
+            except Exception:  # noqa: BLE001
                 pass  # either succeeds silently or raises; both are acceptable
             finally:
                 configure_tracing(endpoint=None)


### PR DESCRIPTION
## Summary
- Adds `BLE` (flake8-blind-except) to the ruff `select` list in `pyproject.toml` so any **new** bare `except:` or `except Exception:` handler fails CI.
- Grandfathers the 94 existing sites identified by ruff with inline `# noqa: BLE001` directives (auto-generated via `ruff check --add-noqa`) so they remain visible as tech debt without breaking CI.
- One blob-style `except (\n    Exception\n)` in `core/critics.py` was collapsed by the formatter and re-inlined manually so the noqa attaches to the right line.

This is the exact "Phase 1" from the issue body: enable the rule, baseline the violations, and let per-module remediation continue under #795.

Fixes #795

## Test plan
- [x] `ruff check maxwell_daemon` clean
- [x] `ruff format` clean on touched files
- [x] Smoke import of representative modules succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)