### PR TITLE
feat(ui): a11y pass + dark-mode toggle (phase 1 of #799)

### DIFF
--- a/maxwell_daemon/api/ui/app.js
+++ b/maxwell_daemon/api/ui/app.js
@@ -1684,8 +1684,46 @@ async function submitNewTask(ev) {
   await fetchTasks();
 }
 
+// ---- theme toggle --------------------------------------------------------
+
+// The data-theme attribute is set pre-paint by the inline bootstrap in
+// index.html. This function only handles the runtime toggle + persistence.
+function applyTheme(theme) {
+  const next = theme === "dark" ? "dark" : "light";
+  document.documentElement.setAttribute("data-theme", next);
+  const btn = document.getElementById("theme-toggle");
+  if (btn) {
+    btn.textContent = next === "dark" ? "☀️" : "🌙";
+    btn.setAttribute("aria-pressed", next === "dark" ? "true" : "false");
+    btn.setAttribute(
+      "aria-label",
+      next === "dark" ? "Switch to light mode" : "Switch to dark mode",
+    );
+  }
+}
+
+function initThemeToggle() {
+  const btn = document.getElementById("theme-toggle");
+  if (!btn) return;
+  // Sync icon + aria state with whatever the pre-paint bootstrap chose.
+  const current = document.documentElement.getAttribute("data-theme") || "light";
+  applyTheme(current);
+  btn.addEventListener("click", () => {
+    const now = document.documentElement.getAttribute("data-theme") === "dark"
+      ? "light"
+      : "dark";
+    applyTheme(now);
+    try {
+      localStorage.setItem("maxwell-theme", now);
+    } catch (_) {
+      // localStorage may be unavailable (private browsing); toggle still works.
+    }
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   wireKindSwitch();
+  initThemeToggle();
   document.getElementById("new-task-btn").addEventListener("click", openNewTaskDialog);
   document.getElementById("new-task-cancel").addEventListener("click", closeNewTaskDialog);
   document.getElementById("new-task-form").addEventListener("submit", submitNewTask);
@@ -1693,14 +1731,27 @@ document.addEventListener("DOMContentLoaded", () => {
   // N opens the dialog when it's closed and no input is focused.
   document.addEventListener("keydown", (ev) => {
     if (ev.key === "Escape") {
-      const dialogs = document.querySelectorAll("dialog");
-      const isDialogOpen = Array.from(dialogs).some(d => d.open);
-      if (!isDialogOpen) {
-        const detailCard = document.getElementById("detail-card");
-        if (detailCard && !detailCard.hidden) {
-          detailCard.hidden = true;
-          state.selected = null;
-        }
+      // Global Escape handler: close any open <dialog> (modal/non-modal) or
+      // any open .modal[open] / dialog[open] element. Falls through to the
+      // detail-card close behaviour when nothing modal is open.
+      const openModals = document.querySelectorAll(
+        "dialog[open], .modal[open]"
+      );
+      if (openModals.length > 0) {
+        ev.preventDefault();
+        openModals.forEach((el) => {
+          if (typeof el.close === "function") {
+            try { el.close(); } catch (_) { el.removeAttribute("open"); }
+          } else {
+            el.removeAttribute("open");
+          }
+        });
+        return;
+      }
+      const detailCard = document.getElementById("detail-card");
+      if (detailCard && !detailCard.hidden) {
+        detailCard.hidden = true;
+        state.selected = null;
       }
       return;
     }

--- a/maxwell_daemon/api/ui/index.html
+++ b/maxwell_daemon/api/ui/index.html
@@ -27,7 +27,15 @@
           : (prefersDark ? "dark" : "light");
         document.documentElement.setAttribute("data-theme", theme);
       } catch (e) {
-        document.documentElement.setAttribute("data-theme", "light");
+        var prefersDarkFallback = false;
+        try {
+          prefersDarkFallback = !!(window.matchMedia
+            && window.matchMedia("(prefers-color-scheme: dark)").matches);
+        } catch (e2) { /* matchMedia also unavailable; default to light */ }
+        document.documentElement.setAttribute(
+          "data-theme",
+          prefersDarkFallback ? "dark" : "light"
+        );
       }
     })();
   </script>

--- a/maxwell_daemon/api/ui/index.html
+++ b/maxwell_daemon/api/ui/index.html
@@ -13,6 +13,24 @@
   <link rel="icon" href="/ui/icon-192.svg" type="image/svg+xml">
   <link rel="manifest" href="/ui/manifest.json">
   <link rel="stylesheet" href="/ui/style.css">
+  <script>
+    // Pre-paint theme bootstrap. Reads localStorage["maxwell-theme"] and
+    // falls back to prefers-color-scheme. Runs before <body> paints to
+    // avoid a flash of the wrong theme.
+    (function () {
+      try {
+        var stored = localStorage.getItem("maxwell-theme");
+        var prefersDark = window.matchMedia
+          && window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var theme = (stored === "dark" || stored === "light")
+          ? stored
+          : (prefersDark ? "dark" : "light");
+        document.documentElement.setAttribute("data-theme", theme);
+      } catch (e) {
+        document.documentElement.setAttribute("data-theme", "light");
+      }
+    })();
+  </script>
 </head>
 <body>
   <header>
@@ -21,8 +39,9 @@
       <button id="new-task-btn" title="Dispatch a task (shortcut: N)">+ New</button>
       <button id="command-palette-btn" title="Open command palette (shortcut: Ctrl+K)">Command</button>
       <button id="enable-notifications-btn" title="Enable push notifications" hidden>🔔 Notifications</button>
-      <span id="connection" class="pill">connecting…</span>
-      <span id="cost-summary" class="pill"></span>
+      <button id="theme-toggle" type="button" aria-label="Toggle dark mode" title="Toggle dark mode" aria-pressed="false">🌙</button>
+      <span id="connection" class="pill" role="status" aria-live="polite">connecting…</span>
+      <span id="cost-summary" class="pill" aria-live="polite"></span>
     </div>
   </header>
 
@@ -458,7 +477,7 @@
 
   <footer class="status-bar" aria-label="Status Bar">
     <span id="status-operation" role="status" aria-live="polite">Ready</span>
-    <span id="status-resources">Tasks 0 | Cost $0.00</span>
+    <span id="status-resources" aria-live="polite">Tasks 0 | Cost $0.00</span>
     <span class="hint">Press <kbd>N</kbd> to dispatch, <kbd>Ctrl</kbd>+<kbd>K</kbd> for commands.</span>
   </footer>
 

--- a/maxwell_daemon/api/ui/style.css
+++ b/maxwell_daemon/api/ui/style.css
@@ -1,7 +1,45 @@
 /* Maxwell-Daemon web UI — vanilla CSS, no framework. */
 
+/*
+ * Theme is controlled exclusively by `data-theme` on <html>. The JS bootstrap
+ * sets it from localStorage["maxwell-theme"], falling back to
+ * prefers-color-scheme. We intentionally do NOT use a `prefers-color-scheme`
+ * media query here because that would override the user's explicit choice.
+ */
+
 :root {
   color-scheme: dark light;
+  /* Light theme defaults — applied if no data-theme is ever set. */
+  --bg: #f8f9fc;
+  --panel: #ffffff;
+  --panel-alt: #eef1f7;
+  --text: #20232b;
+  --muted: #5b6577;
+  --border: #d9dde5;
+  --accent: #2e5fd6;
+  --ok: #2f8f3f;
+  --warn: #b57a00;
+  --err: #c13f4a;
+  --pill-bg: #e4e8f1;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f8f9fc;
+  --panel: #ffffff;
+  --panel-alt: #eef1f7;
+  --text: #20232b;
+  --muted: #5b6577;
+  --border: #d9dde5;
+  --accent: #2e5fd6;
+  --ok: #2f8f3f;
+  --warn: #b57a00;
+  --err: #c13f4a;
+  --pill-bg: #e4e8f1;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
   --bg: #0f1115;
   --panel: #171a21;
   --panel-alt: #1e2230;
@@ -13,22 +51,6 @@
   --warn: #e0af68;
   --err: #f7768e;
   --pill-bg: #232834;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    --bg: #f8f9fc;
-    --panel: #ffffff;
-    --panel-alt: #eef1f7;
-    --text: #20232b;
-    --muted: #5b6577;
-    --border: #d9dde5;
-    --accent: #2e5fd6;
-    --ok: #2f8f3f;
-    --warn: #b57a00;
-    --err: #c13f4a;
-    --pill-bg: #e4e8f1;
-  }
 }
 
 * { box-sizing: border-box; }
@@ -70,6 +92,19 @@ header h1 {
   color: var(--muted);
   font-size: 12px;
 }
+
+/* Theme toggle button (icon-only). Icon flips via JS textContent. */
+#theme-toggle {
+  background: var(--panel-alt);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 10px;
+  font: inherit;
+  cursor: pointer;
+  line-height: 1;
+}
+#theme-toggle:hover { background: var(--border); }
 .pill.ok    { color: var(--ok); }
 .pill.warn  { color: var(--warn); }
 .pill.err   { color: var(--err); }


### PR DESCRIPTION
Partial #799 — Phase 1 of the UI/UX enhancement work. Two focused, mergeable improvements to `maxwell_daemon/api/ui/`.

## Summary

### 1. Accessibility pass (`index.html`, `app.js`)
- Added `aria-live="polite"` to the dynamic toolbar pills `#connection` and `#cost-summary`, plus the status-bar `#status-resources` span, so screen readers announce updates.
- Generalised the global `Escape`-key handler in `app.js`: now closes **any** open `<dialog>` or `.modal[open]` element (previously only closed the `#detail-card` when no dialog was open). Falls back to the existing detail-card close behaviour when nothing modal is open.
- Audited every `<button>` for icon-only contents missing `aria-label` — none remain. All `<select>` / `<input>` already have associated `<label>` wrappers or `aria-label`.

### 2. Dark-mode toggle (`index.html`, `style.css`, `app.js`)
- Refactored color custom properties out of the `prefers-color-scheme` media query and scoped them to `:root[data-theme="light"]` and `:root[data-theme="dark"]`. The media query is **removed** so it no longer overrides the user's explicit choice.
- Added a header toggle button (`#theme-toggle`) with `aria-label`, `aria-pressed`, and an icon that flips between moon and sun. Persists to `localStorage["maxwell-theme"]`; falls back to `prefers-color-scheme` on first visit.
- Pre-paint inline bootstrap script in `<head>` sets `data-theme` before `<body>` paints, avoiding a flash of the wrong theme.

## Files changed
- `maxwell_daemon/api/ui/index.html` — pre-paint theme bootstrap, theme toggle button, aria-live regions
- `maxwell_daemon/api/ui/style.css` — `:root[data-theme="…"]` blocks, `#theme-toggle` styling, removed `prefers-color-scheme` media query
- `maxwell_daemon/api/ui/app.js` — `applyTheme()` + `initThemeToggle()`, generalised Escape handler

## Toggle behaviour
1. First page load with no localStorage entry: theme follows `prefers-color-scheme` (system).
2. Click `#theme-toggle`: `data-theme` flips, all CSS vars cascade, button icon swaps moon ↔ sun, `aria-pressed` updates.
3. Choice is saved to `localStorage["maxwell-theme"]` and survives reload (no theme flash because the inline `<head>` script runs before paint).

## Deferred to follow-up PRs (per phase-1 scope)
- `app.js` modularization (split 65 KB monolith into `state.js`, `views.js`, `api.js`, `keyboard.js`).
- Tablet breakpoint (900–1200 px).
- Service-worker offline cache overhaul (network-first for `/api`, cache-first for static).
- Scroll-position and filter-state persistence per view.

## Test plan
- [ ] Open `/ui/` in a fresh browser profile, verify initial theme matches OS preference.
- [ ] Click the moon/sun button, verify all panels (header, sidebar, tables, dialogs) re-color and the icon flips.
- [ ] Reload, verify chosen theme persists (no flash of wrong colors during load).
- [ ] Open the "+ New" dialog, press `Escape`, verify it closes. Repeat for the command palette (`Ctrl+K`).
- [ ] Tab through the toolbar with keyboard only, verify the theme toggle is reachable and announces "Switch to dark/light mode".
- [ ] Run a screen reader (NVDA / VoiceOver) over the tasks list and confirm `#connection` and `#status-resources` updates are announced.

https://claude.ai/code/session_01GSZE5Ybg5hstR6BBK5DCmD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSZE5Ybg5hstR6BBK5DCmD)_