### PR TITLE
test: integration & benchmark scaffolding (phase 1 of #800)

### DIFF
--- a/docs/testing/integration-tests.md
+++ b/docs/testing/integration-tests.md
@@ -1,0 +1,84 @@
+# Integration & benchmark suites
+
+Phase 1 of [issue #800](https://github.com/D-sorganization/Maxwell-Daemon/issues/800).
+This document covers how to run the integration and benchmark scaffolds
+introduced under `tests/integration/` and `tests/benchmark/`. Subsequent
+phases will extend these suites with regression baselines, larger E2E
+matrices, and Locust-driven load profiles.
+
+## What lives where
+
+| Suite                | Path                                       | Purpose                                                                 |
+| -------------------- | ------------------------------------------ | ----------------------------------------------------------------------- |
+| API contract         | `tests/integration/test_api_contract.py`   | Pin the operator-facing `/api/health`, `/api/version`, `/api/status` and 404 error shapes against the Pydantic models in `maxwell_daemon/api/contract.py`. |
+| End-to-end           | `tests/integration/test_end_to_end.py`     | Drive a task through the in-process daemon via `TestClient` to assert it reaches a terminal state (plus existing cost/metrics round-trips). |
+| Benchmarks           | `tests/benchmark/test_benchmarks.py`       | Time `TaskStore.list_tasks` against a 500-row store. Skipped cleanly if `pytest-benchmark` is missing. |
+
+All of these tests are hermetic: they rely on the in-memory `RecordingBackend`
+fixture in `tests/conftest.py`, a temporary SQLite ledger, and a fresh
+`Daemon` instance per test. No outbound network, no GitHub, no LLM calls.
+
+## Running the suites
+
+### Integration
+
+```bash
+pytest tests/integration/ -v
+```
+
+Expect a single fixture pattern: each test gets a fresh `Daemon` started on
+its own event loop with `TestClient(create_app(daemon))` for HTTP traffic.
+This mirrors `tests/unit/test_api.py` so contract-style tests can flow
+freely between the unit and integration directories.
+
+### Benchmarks
+
+```bash
+# Requires the optional pytest-benchmark plugin.
+pip install 'pytest-benchmark>=4.0.0'
+
+pytest tests/benchmark/test_benchmarks.py -v
+```
+
+If `pytest-benchmark` is not installed, the file is skipped via
+`pytest.importorskip("pytest_benchmark")`, matching the optional-dependency
+guidance in `CLAUDE.md` §3.
+
+For comparing runs over time:
+
+```bash
+# Save a baseline
+pytest tests/benchmark/test_benchmarks.py --benchmark-save=baseline
+
+# Compare a new run against it
+pytest tests/benchmark/test_benchmarks.py --benchmark-compare=baseline
+```
+
+## Adding to the suites (phase 2 and beyond)
+
+When extending these scaffolds:
+
+1. Reuse the `daemon` / `client` fixtures from
+   `tests/integration/test_api_contract.py`. They already wire the
+   `RecordingBackend`, isolated SQLite ledger, and per-test event loop.
+2. Validate response shapes against the Pydantic models in
+   `maxwell_daemon/api/contract.py` — never against literal dictionaries.
+   This keeps the dashboard contract enforced in one place.
+3. Treat the HTTP contract as **append-only** (`CLAUDE.md` §1). Adding a
+   field is fine; renaming or removing one requires a `CONTRACT_VERSION`
+   bump and coordination with `runner-dashboard`.
+4. For new benchmarks, guard imports with
+   `pytest.importorskip("pytest_benchmark")` so CI environments without
+   the plugin still pass.
+
+## Known limitations
+
+- The benchmark suite is intentionally tiny in phase 1 — no budgets, no
+  regression gates. That arrives once we collect baseline numbers across
+  CI runners.
+- The end-to-end smoke test only asserts a terminal state. Richer
+  assertions (cost ledger entries, artifact creation, websocket events)
+  live in the existing `TestEndToEnd` class in the same module.
+- Locust load tests, multi-repo fleet integration, and websocket
+  reconnect storms are deliberately out of scope here. Track them under
+  follow-ups to issue #800.

--- a/tests/benchmark/test_benchmarks.py
+++ b/tests/benchmark/test_benchmarks.py
@@ -1,0 +1,53 @@
+"""Phase-1 benchmark scaffolding for issue #800.
+
+A single, self-contained ``pytest-benchmark`` test that times task list
+retrieval from the persistent ``TaskStore``.  Guarded by ``importorskip`` so
+the suite degrades cleanly when the plugin is unavailable (CLAUDE.md §3 —
+optional dependency hygiene).
+
+Follow-up phases will extend this file with API-roundtrip benchmarks,
+cost-ledger queries, and regression baselines.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pytest_benchmark")
+
+from maxwell_daemon.core.task_store import TaskStore
+from maxwell_daemon.daemon.runner import Task, TaskStatus
+
+
+@pytest.fixture
+def populated_task_store(tmp_path: Path) -> TaskStore:
+    """A task store pre-loaded with 500 tasks for a representative list query."""
+    store = TaskStore(tmp_path / "tasks.db")
+    now = datetime.now(timezone.utc)
+    for i in range(500):
+        store.save(
+            Task(
+                id=f"benchmark-task-{i:04d}",
+                prompt=f"benchmark prompt {i}",
+                status=TaskStatus.QUEUED,
+                created_at=now,
+            )
+        )
+    return store
+
+
+def test_task_list_retrieval(
+    benchmark: pytest.BenchmarkFixture, populated_task_store: TaskStore
+) -> None:
+    """Time a paginated ``list_tasks`` call against a 500-row store.
+
+    This is the foundation benchmark for issue #800 — future phases will pin
+    a budget (e.g. p95 < 50 ms) once we have baseline numbers across CI
+    environments.  For now we just want a deterministic, repeatable signal.
+    """
+    result = benchmark(populated_task_store.list_tasks, limit=100)
+    # Sanity check the benchmark actually exercised the code path.
+    assert len(result) == 100

--- a/tests/integration/test_api_contract.py
+++ b/tests/integration/test_api_contract.py
@@ -1,0 +1,172 @@
+"""Integration-level contract tests for the operator-facing /api surface.
+
+Phase 1 of issue #800. These tests pin the documented JSON shapes that
+``runner-dashboard`` consumes from a live FastAPI app wrapped in
+``TestClient``.  They reuse the fixture pattern from
+``tests/unit/test_api_contract.py`` (which itself mirrors
+``tests/unit/test_api.py``) so future contract checks have a single,
+familiar shape.
+
+Source of truth for the response models: ``maxwell_daemon/api/contract.py``.
+Per ``CLAUDE.md`` the HTTP contract is append-only — these tests will fail
+loudly if a field is renamed or removed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from maxwell_daemon.api import create_app
+from maxwell_daemon.api.contract import (
+    CONTRACT_VERSION,
+    HealthResponse,
+    StatusResponse,
+    VersionResponse,
+)
+from maxwell_daemon.config import MaxwellDaemonConfig
+from maxwell_daemon.daemon import Daemon
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrors tests/unit/test_api.py and tests/unit/test_api_contract.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def daemon(
+    minimal_config: MaxwellDaemonConfig,
+    isolated_ledger_path: Path,
+    tmp_path: Path,
+) -> Iterator[Daemon]:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    d = Daemon(
+        minimal_config,
+        ledger_path=isolated_ledger_path,
+        task_store_path=tmp_path / "tasks.db",
+        work_item_store_path=tmp_path / "work_items.db",
+        task_graph_store_path=tmp_path / "task_graphs.db",
+        artifact_store_path=tmp_path / "artifacts.db",
+        artifact_blob_root=tmp_path / "artifacts",
+        action_store_path=tmp_path / "actions.db",
+        delegate_lifecycle_store_path=tmp_path / "delegate_sessions.db",
+    )
+    loop.run_until_complete(d.start(worker_count=1))
+    try:
+        yield d
+    finally:
+        loop.run_until_complete(d.stop())
+        pending = asyncio.all_tasks(loop)
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+@pytest.fixture
+def client(daemon: Daemon) -> Iterator[TestClient]:
+    with TestClient(create_app(daemon)) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# GET /api/health
+# ---------------------------------------------------------------------------
+
+
+class TestApiHealthContract:
+    def test_returns_documented_schema(self, client: TestClient) -> None:
+        """Body must validate against ``HealthResponse`` and report ok status."""
+        response = client.get("/api/health")
+        assert response.status_code == 200
+
+        body = response.json()
+        # Pydantic validation guarantees the shape stays in lockstep with contract.py.
+        parsed = HealthResponse.model_validate(body)
+        assert parsed.status in {"ok", "degraded"}
+        assert parsed.uptime_seconds >= 0.0
+        assert parsed.gate in {"open", "closed"}
+
+    def test_response_keys_match_contract_model(self, client: TestClient) -> None:
+        body = client.get("/api/health").json()
+        # Model fields the dashboard relies on; extra fields are OK (append-only),
+        # but documented fields must always be present.
+        for required in ("status", "uptime_seconds", "gate"):
+            assert required in body, f"missing documented field {required!r}"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/version
+# ---------------------------------------------------------------------------
+
+
+class TestApiVersionContract:
+    def test_returns_semver_and_contract_version(self, client: TestClient) -> None:
+        response = client.get("/api/version")
+        assert response.status_code == 200
+
+        body = response.json()
+        parsed = VersionResponse.model_validate(body)
+
+        # contract version is pinned by CONTRACT_VERSION in contract.py
+        assert parsed.contract == CONTRACT_VERSION
+
+        # Daemon version should look like a semver-ish string ("X.Y.Z" or
+        # "X.Y.Z<suffix>" — we don't enforce strict PEP 440 here, but it must
+        # contain at least two dots so the dashboard can parse it.
+        assert parsed.daemon, "daemon version must be a non-empty string"
+        assert parsed.daemon.count(".") >= 2, (
+            f"daemon version {parsed.daemon!r} doesn't look like semver"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/status
+# ---------------------------------------------------------------------------
+
+
+class TestApiStatusContract:
+    def test_returns_documented_fields_only(self, client: TestClient) -> None:
+        """Status payload exposes exactly the contract.py StatusResponse shape.
+
+        The dashboard relies on the closed set ``{pipeline_state, active_task_id,
+        gate, sandbox}``.  This test fails loudly if a field is added without a
+        contract bump or removed without a major-version bump.
+        """
+        response = client.get("/api/status")
+        assert response.status_code == 200
+
+        body = response.json()
+        parsed = StatusResponse.model_validate(body)
+
+        assert set(body) == {"pipeline_state", "active_task_id", "gate", "sandbox"}
+        assert parsed.pipeline_state in {"idle", "running", "paused", "error"}
+        assert parsed.gate in {"open", "closed"}
+        assert parsed.sandbox in {"enabled", "disabled", "unknown"}
+
+
+# ---------------------------------------------------------------------------
+# Error response shape (404 on a nonexistent task)
+# ---------------------------------------------------------------------------
+
+
+class TestApiErrorContract:
+    def test_404_for_nonexistent_task_has_consistent_shape(self, client: TestClient) -> None:
+        """FastAPI default error envelope is ``{"detail": "<message>"}``.
+
+        The dashboard surfaces ``detail`` to operators; if we ever switch to a
+        custom error model this test will catch it before the dashboard does.
+        """
+        response = client.get("/api/v1/tasks/nonexistent-task-id-9d3f")
+
+        assert response.status_code == 404
+        body = response.json()
+        assert "detail" in body
+        assert isinstance(body["detail"], str)
+        assert body["detail"], "error detail must not be empty"

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -155,3 +155,28 @@ class TestEndToEnd:
         assert 'method="GET"' in metrics
         assert 'endpoint="/healthz"' in metrics
         assert "maxwell_daemon_http_request_duration_seconds" in metrics
+
+
+class TestPhase1Smoke:
+    """Phase-1 of #800 — minimum-viable smoke test for the integration suite.
+
+    Dispatches a trivial task through the in-process daemon (recording backend
+    from ``conftest.py``) and asserts the task reaches a terminal state.  Kept
+    deliberately small so the integration suite always has at least one fast,
+    deterministic happy-path check that fails loudly when wiring breaks.
+    """
+
+    def test_dispatched_task_reaches_terminal_state(
+        self,
+        live_system: tuple[Daemon, TestClient, asyncio.AbstractEventLoop],
+    ) -> None:
+        _, client, loop = live_system
+
+        response = client.post("/api/v1/tasks", json={"prompt": "smoke-test"})
+        assert response.status_code == 202, response.json()
+        task_id = response.json()["id"]
+
+        final = _wait_for_completion(client, loop, task_id)
+        assert final["status"] in {"completed", "failed"}, (
+            f"task {task_id} did not reach a terminal state: {final}"
+        )


### PR DESCRIPTION
## Summary

Phase 1 of #800 — a minimum-viable executable foundation for the integration test suite and performance benchmarks. Deliberately small so we can extend it in follow-up phases (regression baselines, locust load tests, the full E2E matrix from the issue) without re-litigating the scaffolding.

- `tests/integration/test_api_contract.py` — pins `/api/health`, `/api/version`, and `/api/status` against the Pydantic models in `maxwell_daemon/api/contract.py`; checks FastAPI's 404 `detail` envelope stays consistent.
- `tests/integration/test_end_to_end.py` — adds `TestPhase1Smoke` that dispatches a trivial task through the in-process daemon (recording backend) and asserts it reaches a terminal state. Reuses the existing `live_system` fixture so behavior matches the rest of the e2e suite.
- `tests/benchmark/test_benchmarks.py` — one `pytest-benchmark` test timing `TaskStore.list_tasks` over a 500-row store, guarded by `pytest.importorskip("pytest_benchmark")` per CLAUDE.md §3.
- `docs/testing/integration-tests.md` — short runbook for running and extending the new suites.

No production code changed. HTTP contract stays append-only.

## Test plan

- [x] `uv run ruff check tests/ docs/testing/` — clean
- [x] `uv run ruff format --check` on the three new/edited test files — clean
- [x] `uv run pytest tests/integration/ tests/benchmark/ --no-cov` — 22 passed (5 contract + 7 e2e + 3 issue-workflow + 7 benchmarks)
- [x] New contract tests fail loudly if a documented `/api/status` field is renamed or removed (closed-set assertion against the `StatusResponse` model)
- [ ] CI green on the PR

Partial #800.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSZE5Ybg5hstR6BBK5DCmD)_