### PR TITLE
refactor(api): extract health/version routes (phase 1 of #793)

### DIFF
--- a/maxwell_daemon/api/routes/__init__.py
+++ b/maxwell_daemon/api/routes/__init__.py
@@ -1,0 +1,9 @@
+"""Modular HTTP route registrations for the Maxwell-Daemon API.
+
+Each submodule exposes a ``register(app, daemon, ...)`` callable that
+attaches a cohesive group of endpoints to the FastAPI app.  This package
+exists to incrementally decompose ``maxwell_daemon/api/server.py`` (see
+issue #793) without breaking the append-only HTTP contract.
+"""
+
+from __future__ import annotations

--- a/maxwell_daemon/api/routes/health.py
+++ b/maxwell_daemon/api/routes/health.py
@@ -1,0 +1,63 @@
+"""Health and version endpoints (phase 1 of #793).
+
+Extracted from ``maxwell_daemon/api/server.py`` so the operator-facing
+liveness probes live in their own focused module.  These endpoints are
+part of the stable, append-only contract consumed by ``runner-dashboard``
+(see ``AGENTS.md`` and ``maxwell_daemon/api/contract.py``).
+
+The shapes returned here MUST match ``HealthResponse`` and
+``VersionResponse`` exactly.  Any breaking change requires bumping
+``CONTRACT_VERSION``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import FastAPI
+
+from maxwell_daemon import __version__
+from maxwell_daemon.api.contract import (
+    CONTRACT_VERSION,
+    HealthResponse,
+    VersionResponse,
+)
+from maxwell_daemon.daemon import Daemon
+from maxwell_daemon.logging import get_logger
+
+log = get_logger(__name__)
+
+
+def register(app: FastAPI, daemon: Daemon) -> None:
+    """Attach ``GET /api/version`` and ``GET /api/health`` to ``app``.
+
+    These endpoints are intentionally orthogonal to the rest of the
+    daemon's state: ``/api/version`` returns static build metadata, and
+    ``/api/health`` degrades gracefully if ``daemon.state()`` raises so
+    that liveness probes never observe a 5xx from a partially-initialised
+    daemon.
+    """
+
+    @app.get("/api/version")
+    async def api_version() -> VersionResponse:
+        return VersionResponse(daemon=__version__, contract=CONTRACT_VERSION)
+
+    @app.get("/api/health")
+    async def api_health() -> HealthResponse:
+        try:
+            state = daemon.state()
+            uptime = (datetime.now(timezone.utc) - state.started_at).total_seconds()
+            # "gate" concept: open when backends are available, closed otherwise.
+            gate = "open" if state.backends_available else "closed"
+            return HealthResponse(
+                status="ok",
+                uptime_seconds=uptime,
+                gate=gate,
+            )
+        except Exception:
+            log.exception("api_health: daemon.state() raised; returning degraded")
+            return HealthResponse(
+                status="degraded",
+                uptime_seconds=0.0,
+                gate="closed",
+            )

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -44,7 +44,6 @@ from maxwell_daemon.api.contract import (
     ControlResponse,
     DispatchRequest,
     DispatchResponse,
-    HealthResponse,
     StatusResponse,
     StatusV2Response,
     StatusV2RunningTask,
@@ -53,7 +52,6 @@ from maxwell_daemon.api.contract import (
     TaskDetail,
     TaskListResponse,
     TaskSummary,
-    VersionResponse,
 )
 from maxwell_daemon.api.validation import (
     PriorityField,
@@ -1630,30 +1628,12 @@ def create_app(
     # These endpoints form the versioned contract consumed by runner-dashboard
     # and other operator tooling.  Shape changes require bumping CONTRACT_VERSION
     # in maxwell_daemon/api/contract.py.
+    #
+    # ``/api/version`` and ``/api/health`` live in maxwell_daemon.api.routes.health
+    # as the first phase of decomposing this module (issue #793).
+    from maxwell_daemon.api.routes import health as _health_routes
 
-    @app.get("/api/version")
-    async def api_version() -> VersionResponse:
-        return VersionResponse(daemon=__version__, contract=CONTRACT_VERSION)
-
-    @app.get("/api/health")
-    async def api_health() -> HealthResponse:
-        try:
-            state = daemon.state()
-            uptime = (datetime.now(timezone.utc) - state.started_at).total_seconds()
-            # "gate" concept: open when backends are available, closed otherwise.
-            gate = "open" if state.backends_available else "closed"
-            return HealthResponse(
-                status="ok",
-                uptime_seconds=uptime,
-                gate=gate,
-            )
-        except Exception:
-            log.exception("api_health: daemon.state() raised; returning degraded")
-            return HealthResponse(
-                status="degraded",
-                uptime_seconds=0.0,
-                gate="closed",
-            )
+    _health_routes.register(app, daemon)
 
     @app.get("/api/status")
     async def api_status() -> StatusResponse:


### PR DESCRIPTION
Partial #793

## Summary

First phase of decomposing the 3,300+ line `maxwell_daemon/api/server.py` god object. This PR proves out the extraction pattern with the smallest, most self-contained slice and keeps subsequent phases unblocked.

### What moved

Two endpoints were lifted out of the `create_app()` closure into a new `maxwell_daemon/api/routes/health.py` module exposing `register(app: FastAPI, daemon: Daemon) -> None`:

- `GET /api/version`
- `GET /api/health`

`server.py`'s `create_app()` now calls `_health_routes.register(app, daemon)` in place of the inline definitions.

### Contract preservation

- Response models (`HealthResponse`, `VersionResponse`) are unchanged.
- Paths are unchanged.
- Append-only HTTP contract preserved per `AGENTS.md` and `CLAUDE.md`.
- `CONTRACT_VERSION` is **not** bumped (no breaking change).

### Size impact

`maxwell_daemon/api/server.py`: 3,375 -> 3,355 lines (**-20 lines** net; the inline endpoints plus two now-unused contract imports were removed). The new module adds 63 lines including a docstring; this is intentional overhead that pays off once the next 5+ groups are extracted.

### Deferred phases (out of scope; next-up under #793)

- `/api/status` and `/api/v2/status`
- Tasks (`/api/tasks*`, `/api/v1/tasks*`)
- Dispatch (`POST /api/dispatch`)
- Control (`POST /api/control/{pause,resume,abort}`)
- Fleet (`/api/v1/fleet*`)
- WebSocket / SSE event streams
- Middleware (HTTP metrics, queue-saturation handler, exception handlers)
- Auth endpoints (`/api/v1/auth/*`)

These were deliberately skipped because they share local helpers, dependencies (`auth`, `_require_*`), and closures with the rest of `create_app`. Extracting them safely needs the small dependency-injection scaffolding that this phase establishes.

## Test plan

- [x] `ruff check maxwell_daemon` — clean
- [x] `ruff format` — no changes needed
- [x] `pytest tests/unit/test_api.py tests/unit/test_api_contract.py` — 115 passed
- [x] Adjacent suites (`test_api_validation.py`, `test_api_events.py`, `test_api_cancel.py`, `test_api_websocket_auth.py`) — 29 passed
- [x] Verified `TestApiVersion` and `TestApiHealth` classes (10 cases) still green, including the `degraded` path that monkeypatches `Daemon.state` to raise


---
_Generated by [Claude Code](https://claude.ai/code/session_01GSZE5Ybg5hstR6BBK5DCmD)_