### PR TITLE
refactor(daemon): extract RetryPolicy from runner (phase 1 of #798)

### DIFF
--- a/maxwell_daemon/daemon/retry_policy.py
+++ b/maxwell_daemon/daemon/retry_policy.py
@@ -19,10 +19,16 @@ from __future__ import annotations
 import secrets
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import Any
 
-if TYPE_CHECKING:
-    from maxwell_daemon.daemon.runner import Task
+# ``Task`` lives in ``maxwell_daemon.daemon.runner``, which imports
+# ``DEFAULT_RETRY_POLICY`` from this module at import time. Importing
+# ``Task`` here — even guarded by ``TYPE_CHECKING`` — is enough for static
+# analyzers (CodeQL) to flag a cyclic-import risk. ``should_retry`` only
+# touches duck-typed attributes, so the parameter is annotated as ``Any``
+# and the terminal-status check uses string values from ``TaskStatus``
+# (which subclasses ``str, Enum``) without importing the enum itself.
+_TERMINAL_STATUS_VALUES = frozenset({"completed", "cancelled"})
 
 
 # Default backoff parameters chosen to preserve the previously hard-coded
@@ -68,7 +74,7 @@ class RetryPolicy:
                 f"got max={self.max_delay_seconds} base={self.base_delay_seconds}",
             )
 
-    def should_retry(self, task: Task) -> bool:
+    def should_retry(self, task: Any) -> bool:
         """Return ``True`` while the task has retry budget remaining.
 
         Counts attempts via ``getattr(task, "retry_count", 0)`` so this is
@@ -76,11 +82,18 @@ class RetryPolicy:
         not yet carry an explicit retry counter — and against a future
         version that does. Tasks already terminal (``COMPLETED``,
         ``CANCELLED``) never qualify for retry.
-        """
-        from maxwell_daemon.daemon.runner import TaskStatus
 
+        ``task`` is annotated as ``Any`` to avoid an import cycle with
+        :mod:`maxwell_daemon.daemon.runner`; the terminal-status check
+        uses the underlying string values of ``TaskStatus`` (a
+        ``str, Enum``) and accepts either the enum member or its raw
+        string form.
+        """
         status = getattr(task, "status", None)
-        if status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED):
+        # ``TaskStatus`` is ``str, Enum``, so equality with a string works
+        # without importing the enum and breaking the cycle.
+        status_value = getattr(status, "value", status)
+        if isinstance(status_value, str) and status_value.lower() in _TERMINAL_STATUS_VALUES:
             return False
         attempts = int(getattr(task, "retry_count", 0))
         return attempts < self.max_retries
@@ -96,9 +109,14 @@ class RetryPolicy:
         """
         if retry_count < 0:
             raise ValueError(f"retry_count must be >= 0, got {retry_count}")
-        # Clamp the exponent so ``2 ** retry_count`` never overflows the
-        # cap calculation for absurd inputs.
-        capped_exp = min(retry_count, 30)
+        # Clamp the exponent so ``2 ** retry_count`` never builds a
+        # pathologically large int for absurd inputs. 64 is a generous
+        # ceiling: ``base_delay_seconds * 2 ** 64`` ~= 1.8e19 * base, which
+        # exceeds any realistic ``max_delay_seconds``, so the
+        # ``min(raw, max_delay_seconds)`` below still binds first and the
+        # documented "exponential then cap" behavior holds even for large
+        # retry counts.
+        capped_exp = min(retry_count, 64)
         raw = self.base_delay_seconds * (2**capped_exp)
         capped = min(raw, self.max_delay_seconds)
         # Multiplicative jitter in [1 - _JITTER_RATIO, 1 + _JITTER_RATIO].

--- a/maxwell_daemon/daemon/retry_policy.py
+++ b/maxwell_daemon/daemon/retry_policy.py
@@ -1,0 +1,125 @@
+"""Pure retry/backoff policy used by the daemon's task lifecycle.
+
+Phase 1 of the runner.py decomposition (issue #798). This module deliberately
+contains no I/O, no async, and no logging — only the math required to decide
+*whether* to retry a task and *how long* to wait before the next attempt.
+That makes it trivially unit-testable and lets follow-up phases route every
+retry/backoff site through one collaborator without behavior drift.
+
+The current daemon does not yet thread a ``retry_count`` through the
+``Task`` model; ``next_retry_delay`` is therefore introduced as a pure
+helper in anticipation of the wider extraction. The existing call sites
+(``QueueSaturationError`` raise points) consume the retry delay only at
+``retry_count == 0`` via :meth:`RetryPolicy.queue_saturation_backoff`,
+which preserves the previously hard-coded 60-second value.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from maxwell_daemon.daemon.runner import Task
+
+
+# Default backoff parameters chosen to preserve the previously hard-coded
+# 60-second queue-saturation backoff: ``base_delay`` * 2 ** 0 == 60.
+_DEFAULT_MAX_RETRIES = 3
+_DEFAULT_BASE_DELAY_SECONDS = 60.0
+_DEFAULT_MAX_DELAY_SECONDS = 600.0
+# Bounded multiplicative jitter in [1 - JITTER_RATIO, 1 + JITTER_RATIO].
+_JITTER_RATIO = 0.1
+
+
+@dataclass(frozen=True, slots=True)
+class RetryPolicy:
+    """Pure configuration + math for task retry decisions.
+
+    Attributes:
+        max_retries: Inclusive cap on the number of retry attempts.
+            ``should_retry`` returns ``False`` once a task's recorded
+            attempt count reaches this value.
+        base_delay_seconds: Backoff at ``retry_count == 0`` (before jitter).
+            Doubled for each subsequent retry.
+        max_delay_seconds: Hard cap on the post-exponential delay
+            *before* jitter is applied. The final returned delay may
+            therefore be at most ``max_delay_seconds * (1 + JITTER_RATIO)``.
+    """
+
+    max_retries: int = _DEFAULT_MAX_RETRIES
+    base_delay_seconds: float = _DEFAULT_BASE_DELAY_SECONDS
+    max_delay_seconds: float = _DEFAULT_MAX_DELAY_SECONDS
+
+    def __post_init__(self) -> None:
+        if self.max_retries < 0:
+            raise ValueError(
+                f"max_retries must be >= 0, got {self.max_retries}",
+            )
+        if self.base_delay_seconds < 0:
+            raise ValueError(
+                f"base_delay_seconds must be >= 0, got {self.base_delay_seconds}",
+            )
+        if self.max_delay_seconds < self.base_delay_seconds:
+            raise ValueError(
+                "max_delay_seconds must be >= base_delay_seconds; "
+                f"got max={self.max_delay_seconds} base={self.base_delay_seconds}",
+            )
+
+    def should_retry(self, task: Task) -> bool:
+        """Return ``True`` while the task has retry budget remaining.
+
+        Counts attempts via ``getattr(task, "retry_count", 0)`` so this is
+        safe to call against the current ``Task`` dataclass — which does
+        not yet carry an explicit retry counter — and against a future
+        version that does. Tasks already terminal (``COMPLETED``,
+        ``CANCELLED``) never qualify for retry.
+        """
+        from maxwell_daemon.daemon.runner import TaskStatus
+
+        status = getattr(task, "status", None)
+        if status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED):
+            return False
+        attempts = int(getattr(task, "retry_count", 0))
+        return attempts < self.max_retries
+
+    def next_retry_delay(self, retry_count: int) -> timedelta:
+        """Compute the wait before the next attempt with bounded jitter.
+
+        The schedule is exponential — ``base_delay_seconds * 2 ** retry_count`` —
+        capped at ``max_delay_seconds`` *before* a small symmetric jitter is
+        applied to avoid retry storms. Jitter draws from
+        ``secrets.randbelow`` so the policy is deterministic-modulo-randomness
+        and uses a CSPRNG (no extra dependency).
+        """
+        if retry_count < 0:
+            raise ValueError(f"retry_count must be >= 0, got {retry_count}")
+        # Clamp the exponent so ``2 ** retry_count`` never overflows the
+        # cap calculation for absurd inputs.
+        capped_exp = min(retry_count, 30)
+        raw = self.base_delay_seconds * (2**capped_exp)
+        capped = min(raw, self.max_delay_seconds)
+        # Multiplicative jitter in [1 - _JITTER_RATIO, 1 + _JITTER_RATIO].
+        jitter_unit = secrets.randbelow(1_000_001) / 1_000_000  # [0.0, 1.0]
+        jitter_multiplier = 1.0 + (jitter_unit * 2.0 - 1.0) * _JITTER_RATIO
+        delayed = capped * jitter_multiplier
+        # Always non-negative; the policy never returns a negative timedelta.
+        return timedelta(seconds=max(delayed, 0.0))
+
+    def queue_saturation_backoff(self) -> int:
+        """Backoff (in seconds) advertised when the priority queue is full.
+
+        Returned as ``int`` because :class:`QueueSaturationError` exposes the
+        value as ``backoff_seconds: int`` over the HTTP contract. Computed
+        from ``base_delay_seconds`` to keep one source of truth, and rounded
+        deterministically (no jitter) so the public retry hint is stable.
+        """
+        return round(self.base_delay_seconds)
+
+
+# Module-level default used at the existing call sites. Wrapping the dataclass
+# in a constant keeps the runner's import surface tiny (one symbol) without
+# forcing every caller to repeat the construction.
+DEFAULT_RETRY_POLICY = RetryPolicy()

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -49,6 +49,7 @@ from maxwell_daemon.core.delegate_lifecycle import (
 from maxwell_daemon.core.task_store import TaskStore
 from maxwell_daemon.core.work_item_store import WorkItemStore
 from maxwell_daemon.core.work_items import WorkItem, WorkItemStatus
+from maxwell_daemon.daemon.retry_policy import DEFAULT_RETRY_POLICY
 from maxwell_daemon.director import (
     GraphNodeExecutor,
     GraphStatus,
@@ -817,7 +818,8 @@ class Daemon:
         if self._queue.full():
             log.warning("queue is saturated (max_depth=%d)", self._config.agent.max_queue_depth)
             raise QueueSaturationError(
-                "Task queue is full, please try again later", backoff_seconds=60
+                "Task queue is full, please try again later",
+                backoff_seconds=DEFAULT_RETRY_POLICY.queue_saturation_backoff(),
             )
 
         if self._loop is None or not self._loop.is_running():
@@ -825,7 +827,8 @@ class Daemon:
                 self._queue.put_nowait(item)
             except asyncio.QueueFull as exc:
                 raise QueueSaturationError(
-                    "Task queue is full, please try again later", backoff_seconds=60
+                    "Task queue is full, please try again later",
+                    backoff_seconds=DEFAULT_RETRY_POLICY.queue_saturation_backoff(),
                 ) from exc
             return
         try:
@@ -857,7 +860,8 @@ class Daemon:
             except asyncio.QueueFull:
                 result.set_exception(
                     QueueSaturationError(
-                        "Task queue is full, please try again later", backoff_seconds=60
+                        "Task queue is full, please try again later",
+                        backoff_seconds=DEFAULT_RETRY_POLICY.queue_saturation_backoff(),
                     )
                 )
             except BaseException as exc:  # pragma: no cover - surfaced via Future

--- a/tests/unit/daemon/test_retry_policy.py
+++ b/tests/unit/daemon/test_retry_policy.py
@@ -1,0 +1,133 @@
+"""Unit tests for the pure-logic ``RetryPolicy`` helper (issue #798, phase 1)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from maxwell_daemon.daemon.retry_policy import (
+    DEFAULT_RETRY_POLICY,
+    RetryPolicy,
+)
+from maxwell_daemon.daemon.runner import TaskStatus
+
+
+def _task(*, status: TaskStatus = TaskStatus.FAILED, retry_count: int = 0) -> SimpleNamespace:
+    """Build a task-shaped object with just the attributes the policy reads."""
+    return SimpleNamespace(status=status, retry_count=retry_count)
+
+
+class TestShouldRetry:
+    def test_returns_true_until_max_retries_reached(self) -> None:
+        policy = RetryPolicy(max_retries=3, base_delay_seconds=1.0, max_delay_seconds=10.0)
+        assert policy.should_retry(_task(retry_count=0)) is True
+        assert policy.should_retry(_task(retry_count=1)) is True
+        assert policy.should_retry(_task(retry_count=2)) is True
+        assert policy.should_retry(_task(retry_count=3)) is False
+        assert policy.should_retry(_task(retry_count=4)) is False
+
+    def test_zero_max_retries_never_retries(self) -> None:
+        policy = RetryPolicy(max_retries=0, base_delay_seconds=1.0, max_delay_seconds=10.0)
+        assert policy.should_retry(_task(retry_count=0)) is False
+
+    def test_terminal_statuses_never_retry(self) -> None:
+        policy = RetryPolicy(max_retries=5, base_delay_seconds=1.0, max_delay_seconds=10.0)
+        assert policy.should_retry(_task(status=TaskStatus.COMPLETED)) is False
+        assert policy.should_retry(_task(status=TaskStatus.CANCELLED)) is False
+        assert policy.should_retry(_task(status=TaskStatus.FAILED)) is True
+
+    def test_missing_retry_count_attribute_treated_as_zero(self) -> None:
+        policy = RetryPolicy(max_retries=2, base_delay_seconds=1.0, max_delay_seconds=10.0)
+        bare = SimpleNamespace(status=TaskStatus.FAILED)
+        assert policy.should_retry(bare) is True
+
+
+class TestNextRetryDelay:
+    def test_grows_with_retry_count(self) -> None:
+        policy = RetryPolicy(max_retries=10, base_delay_seconds=1.0, max_delay_seconds=10_000.0)
+        # Run several samples per step so a single jitter draw can't fool us.
+        samples_per_step = 25
+        prev_max = 0.0
+        for retry_count in range(0, 6):
+            seen = [
+                policy.next_retry_delay(retry_count).total_seconds()
+                for _ in range(samples_per_step)
+            ]
+            current_min = min(seen)
+            assert current_min >= prev_max * 0.95, (
+                f"retry_count={retry_count} produced {current_min}s, "
+                f"which is not greater than the previous step's max {prev_max}s"
+            )
+            prev_max = max(seen)
+
+    def test_delay_is_capped_at_max_delay_seconds(self) -> None:
+        max_delay = 30.0
+        jitter_ceiling = max_delay * 1.1  # 10% jitter ratio
+        policy = RetryPolicy(
+            max_retries=99,
+            base_delay_seconds=1.0,
+            max_delay_seconds=max_delay,
+        )
+        # A high retry_count would produce 2 ** 20 seconds without the cap;
+        # the cap must hold even after jitter is applied.
+        for _ in range(200):
+            delay = policy.next_retry_delay(20).total_seconds()
+            assert delay <= jitter_ceiling, (
+                f"delay {delay}s exceeded the cap+jitter ceiling {jitter_ceiling}s"
+            )
+
+    def test_jitter_stays_bounded(self) -> None:
+        # With base_delay=100 and retry_count=0, raw=100 and post-jitter must
+        # land in [90, 110] for every draw.
+        policy = RetryPolicy(
+            max_retries=99,
+            base_delay_seconds=100.0,
+            max_delay_seconds=100.0,
+        )
+        observed_min = float("inf")
+        observed_max = 0.0
+        for _ in range(500):
+            delay = policy.next_retry_delay(0).total_seconds()
+            assert 90.0 <= delay <= 110.0, f"jitter out of bounds: {delay}s"
+            observed_min = min(observed_min, delay)
+            observed_max = max(observed_max, delay)
+        # Sanity: the jitter actually moved the value (not stuck at the mean).
+        # The probability of 500 draws all being identical is vanishingly small.
+        assert observed_min < observed_max
+
+    def test_returns_timedelta(self) -> None:
+        policy = RetryPolicy(max_retries=3, base_delay_seconds=1.0, max_delay_seconds=10.0)
+        assert isinstance(policy.next_retry_delay(0), timedelta)
+
+    def test_negative_retry_count_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            DEFAULT_RETRY_POLICY.next_retry_delay(-1)
+
+
+class TestQueueSaturationBackoff:
+    def test_default_policy_matches_legacy_value(self) -> None:
+        # The pre-extraction code hard-coded 60 seconds at three call sites;
+        # the default policy must preserve that exact value to keep behavior
+        # identical for clients depending on the QueueSaturationError contract.
+        assert DEFAULT_RETRY_POLICY.queue_saturation_backoff() == 60
+
+    def test_custom_base_delay_round_trips(self) -> None:
+        assert RetryPolicy(base_delay_seconds=15.0).queue_saturation_backoff() == 15
+        assert RetryPolicy(base_delay_seconds=15.4).queue_saturation_backoff() == 15
+        assert RetryPolicy(base_delay_seconds=15.6).queue_saturation_backoff() == 16
+
+
+class TestConfigValidation:
+    def test_max_retries_must_be_non_negative(self) -> None:
+        with pytest.raises(ValueError):
+            RetryPolicy(max_retries=-1)
+
+    def test_base_delay_must_be_non_negative(self) -> None:
+        with pytest.raises(ValueError):
+            RetryPolicy(base_delay_seconds=-1.0)
+
+    def test_max_delay_must_be_at_least_base_delay(self) -> None:
+        with pytest.raises(ValueError):
+            RetryPolicy(base_delay_seconds=10.0, max_delay_seconds=5.0)


### PR DESCRIPTION
## Summary

Partial #798 — first, smallest extraction in the multi-PR runner.py decomposition.

- Adds `maxwell_daemon/daemon/retry_policy.py`: pure-logic `RetryPolicy` dataclass with `should_retry(task)`, `next_retry_delay(retry_count) -> timedelta` (exponential backoff + bounded jitter, capped at `max_delay_seconds`), and `queue_saturation_backoff()`. No I/O, no async, no logging — trivially unit-testable.
- Routes the three `QueueSaturationError` raise sites in `runner.py` through `DEFAULT_RETRY_POLICY.queue_saturation_backoff()` so the previously hard-coded 60-second backoff lives in one place. Default `RetryPolicy()` returns 60, preserving behavior exactly.
- Adds `tests/unit/daemon/test_retry_policy.py` (14 tests): `should_retry` budget enforcement, terminal-status guard, exponential growth, max-delay cap, jitter bounds, config validation, and a regression test pinning `queue_saturation_backoff() == 60`.

### Why this scope

Inspection of `runner.py` showed there is **no existing exponential backoff or `retry_count` math** — `retry_task` simply re-queues, and the only retry-adjacent values are three identical hard-coded `backoff_seconds=60` literals on `QueueSaturationError`. Per the issue's fallback path in the spec for this phase, this PR (a) introduces the pure helper now so future phases have a single collaborator to call into, and (b) demonstrates one real call site (the queue-saturation backoff) without changing observable behavior.

### Line-count delta on `runner.py`

| | lines |
|---|---|
| origin/main | 2,137 |
| this branch | 2,141 |
| delta | **+4** (one import + one re-flowed argument list per call site) |

This phase establishes the seam; size reduction lands in subsequent phases.

### Deferred to follow-up PRs

- `task_queue` — `_enqueue_task_entry`, priority-queue mechanics
- `state_machine` — `TaskStatus` transitions, `retry_task`/`cancel_task`/`waive_task`
- `side_effects` — `mark_task_side_effects_started`, stale-dispatch handling
- `cost_tracker` — budget + cost-record emission inside `_execute`
- `session_manager` — workspace hooks, scratchpad cleanup, stream-event tracking

Once `Task` grows a `retry_count` field (or an external retry counter is threaded through the FAILED → QUEUED transition), the existing `should_retry` / `next_retry_delay` will be wired into the `_handle_stalled_task` path.

## Test plan

- [x] `ruff check maxwell_daemon/daemon/retry_policy.py maxwell_daemon/daemon/runner.py tests/unit/daemon/` — clean
- [x] `ruff format --check` — clean (4 files already formatted)
- [x] `pytest tests/unit/daemon/` — 14 new tests pass
- [x] `pytest tests/unit/test_daemon*.py` — 73 existing tests still pass (87 total)
- [ ] CI: full lint + mypy --strict + bandit + pytest matrix

https://claude.ai/code/session_01GSZE5Ybg5hstR6BBK5DCmD

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSZE5Ybg5hstR6BBK5DCmD)_