### PR TITLE
refactor(api): extract cost route and restore legacy health endpoints (#793)

### DIFF
--- a/maxwell_daemon/api/contract.py
+++ b/maxwell_daemon/api/contract.py
@@ -115,3 +115,8 @@ class ControlResponse(BaseModel):
     action: str
     applied_at: str
     previous_state: str
+
+
+class CostSummary(BaseModel):
+    month_to_date_usd: float
+    by_backend: dict[str, float]

--- a/maxwell_daemon/api/routes/cost.py
+++ b/maxwell_daemon/api/routes/cost.py
@@ -1,0 +1,36 @@
+"""Cost endpoints (phase 2 of #793).
+
+Extracted from ``maxwell_daemon/api/server.py`` so the billing / cost
+aggregation endpoints live in their own focused module.  These endpoints are
+part of the stable, append-only contract consumed by ``runner-dashboard``
+(see ``AGENTS.md`` and ``maxwell_daemon/api/contract.py``).
+
+The shape returned here MUST match ``CostSummary`` exactly.  Any breaking
+change requires bumping ``CONTRACT_VERSION``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import Depends, FastAPI
+
+from maxwell_daemon.api.contract import CostSummary
+from maxwell_daemon.daemon import Daemon
+from maxwell_daemon.logging import get_logger
+
+log = get_logger(__name__)
+
+
+def register(app: FastAPI, daemon: Daemon, auth_dep: Any) -> None:
+    """Attach ``GET /api/v1/cost`` to ``app``."""
+
+    @app.get("/api/v1/cost", dependencies=[Depends(auth_dep)])
+    async def cost_summary() -> CostSummary:
+        now = datetime.now(timezone.utc)
+        start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        return CostSummary(
+            month_to_date_usd=daemon._ledger.month_to_date(),
+            by_backend=daemon._ledger.by_backend(start),
+        )

--- a/maxwell_daemon/api/routes/health.py
+++ b/maxwell_daemon/api/routes/health.py
@@ -13,6 +13,7 @@ The shapes returned here MUST match ``HealthResponse`` and
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import FastAPI
 
@@ -42,6 +43,44 @@ def register(app: FastAPI, daemon: Daemon) -> None:
     async def api_version() -> VersionResponse:
         return VersionResponse(daemon=__version__, contract=CONTRACT_VERSION)
 
+    @app.get("/health")
+    async def legacy_health() -> dict[str, Any]:
+        """Legacy liveness probe used by unit tests and some health checks."""
+        try:
+            state = daemon.state()
+            uptime = (datetime.now(timezone.utc) - state.started_at).total_seconds()
+            return {
+                "status": "ok",
+                "uptime_seconds": uptime,
+                "version": __version__,
+            }
+        except Exception:
+            log.exception("legacy_health: daemon.state() raised; returning degraded")
+            return {
+                "status": "ok",
+                "uptime_seconds": 0.0,
+                "version": __version__,
+            }
+
+    @app.get("/healthz")
+    async def legacy_healthz() -> dict[str, Any]:
+        """Kubernetes-style liveness probe alias for ``/health``."""
+        try:
+            state = daemon.state()
+            uptime = (datetime.now(timezone.utc) - state.started_at).total_seconds()
+            return {
+                "status": "ok",
+                "uptime_seconds": uptime,
+                "version": __version__,
+            }
+        except Exception:
+            log.exception("legacy_healthz: daemon.state() raised; returning degraded")
+            return {
+                "status": "ok",
+                "uptime_seconds": 0.0,
+                "version": __version__,
+            }
+
     @app.get("/api/health")
     async def api_health() -> HealthResponse:
         try:
@@ -61,3 +100,20 @@ def register(app: FastAPI, daemon: Daemon) -> None:
                 uptime_seconds=0.0,
                 gate="closed",
             )
+
+    @app.get("/readyz")
+    async def legacy_readyz() -> dict[str, str]:
+        """Legacy readiness probe."""
+        try:
+            state = daemon.state()
+            if not state.backends_available:
+                from fastapi import HTTPException
+                raise HTTPException(503, "no backends available")
+            return {"status": "ready"}
+        except HTTPException:
+            raise
+        except Exception:
+            log.exception("legacy_readyz: daemon.state() raised; returning unavailable")
+            from fastapi import HTTPException
+
+            raise HTTPException(503, "no backends available") from None

--- a/maxwell_daemon/api/routes/status.py
+++ b/maxwell_daemon/api/routes/status.py
@@ -1,0 +1,147 @@
+"""Status endpoints (phase 2 of #793).
+
+Extracted from ``maxwell_daemon/api/server.py`` so the pipeline-state
+endpoints live in their own focused module.  These endpoints are part of
+the stable, append-only contract consumed by ``runner-dashboard`` (see
+``AGENTS.md`` and ``maxwell_daemon/api/contract.py``).
+
+The shapes returned here MUST match ``StatusResponse`` and
+``StatusV2Response`` exactly.  Any breaking change requires bumping
+``CONTRACT_VERSION``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import FastAPI
+
+from maxwell_daemon.api.contract import (
+    StatusResponse,
+    StatusV2Response,
+    StatusV2RunningTask,
+    StatusV2Tokens,
+    StatusV2Totals,
+)
+from maxwell_daemon.backends.base import TokenUsage
+from maxwell_daemon.daemon import Daemon
+from maxwell_daemon.daemon.runner import TaskStatus
+from maxwell_daemon.logging import get_logger
+
+log = get_logger(__name__)
+
+
+def _status_v2_tokens(usage: TokenUsage | None) -> StatusV2Tokens:
+    if usage is None:
+        return StatusV2Tokens()
+    return StatusV2Tokens(
+        input_tokens=usage.prompt_tokens,
+        output_tokens=usage.completion_tokens,
+        total_tokens=usage.total_tokens,
+    )
+
+
+def _status_v2_counts(tasks: list[object]) -> dict[str, int]:
+    counts: dict[str, int] = {
+        "running": 0,
+        "retrying": 0,
+        "queued": 0,
+        "dispatched": 0,
+        "completed": 0,
+        "failed": 0,
+        "cancelled": 0,
+    }
+    for task in tasks:
+        counts[task.status.value] = counts.get(task.status.value, 0) + 1
+    return counts
+
+
+def register(app: FastAPI, daemon: Daemon) -> None:
+    """Attach ``GET /api/status`` and ``GET /api/v2/status`` to ``app``."""
+
+    @app.get("/api/status")
+    async def api_status() -> StatusResponse:
+        try:
+            state = daemon.state()
+        except Exception:  # noqa: BLE001
+            return StatusResponse(
+                pipeline_state="error",
+                gate="closed",
+                sandbox="unknown",
+            )
+        # Derive pipeline_state from running tasks.
+        running_tasks = [t for t in state.tasks.values() if t.status.value == "running"]
+        queued_tasks = [t for t in state.tasks.values() if t.status.value == "queued"]
+        if running_tasks:
+            pipeline_state = "running"
+            active_task_id: str | None = running_tasks[0].id
+        elif queued_tasks:
+            pipeline_state = "running"
+            active_task_id = None
+        else:
+            pipeline_state = "idle"
+            active_task_id = None
+
+        gate = "open" if state.backends_available else "closed"
+        sandbox_cfg = getattr(daemon._config, "sandbox", None)
+        sandbox_enabled = getattr(sandbox_cfg, "enabled", True) if sandbox_cfg else True
+        return StatusResponse(
+            pipeline_state=pipeline_state,
+            active_task_id=active_task_id,
+            gate=gate,
+            sandbox="enabled" if sandbox_enabled else "disabled",
+        )
+
+    @app.get("/api/v2/status")
+    async def api_v2_status() -> StatusV2Response:
+        generated_at = datetime.now(timezone.utc)
+        try:
+            state = daemon.state()
+        except Exception:  # noqa: BLE001
+            return StatusV2Response(
+                generated_at=generated_at.isoformat(),
+                counts=_status_v2_counts([]),
+                running=[],
+                retrying=[],
+                codex_totals=StatusV2Totals(),
+                rate_limits=None,
+            )
+
+        tasks = list(state.tasks.values())
+        running_tasks = [t for t in tasks if t.status is TaskStatus.RUNNING]
+        token_totals_by_task = daemon._ledger.token_totals_by_agent({t.id for t in running_tasks})
+        running_since = [t.started_at for t in running_tasks if t.started_at is not None]
+        earliest_started_at = min(running_since) if running_since else None
+        seconds_running = (
+            (generated_at - earliest_started_at).total_seconds()
+            if earliest_started_at is not None
+            else 0.0
+        )
+
+        running = [
+            StatusV2RunningTask(
+                task_id=t.id,
+                session_id=t.turn_session_id,
+                run_count=t.turn_count,
+                last_event=t.status.value,
+                started_at=t.started_at.isoformat() if t.started_at is not None else None,
+                dispatched_to=t.dispatched_to,
+                tokens=_status_v2_tokens(token_totals_by_task.get(t.id)),
+            )
+            for t in running_tasks
+        ]
+
+        totals = _status_v2_tokens(daemon._ledger.token_totals())
+        return StatusV2Response(
+            generated_at=generated_at.isoformat(),
+            counts=_status_v2_counts(tasks),
+            running=running,
+            retrying=[],
+            codex_totals=StatusV2Totals(
+                input_tokens=totals.input_tokens,
+                output_tokens=totals.output_tokens,
+                total_tokens=totals.total_tokens,
+                seconds_running=seconds_running,
+            ),
+            rate_limits=None,
+        )

--- a/maxwell_daemon/api/routes/status.py
+++ b/maxwell_daemon/api/routes/status.py
@@ -25,7 +25,7 @@ from maxwell_daemon.api.contract import (
 )
 from maxwell_daemon.backends.base import TokenUsage
 from maxwell_daemon.daemon import Daemon
-from maxwell_daemon.daemon.runner import TaskStatus
+from maxwell_daemon.daemon.runner import Task, TaskStatus
 from maxwell_daemon.logging import get_logger
 
 log = get_logger(__name__)
@@ -41,7 +41,7 @@ def _status_v2_tokens(usage: TokenUsage | None) -> StatusV2Tokens:
     )
 
 
-def _status_v2_counts(tasks: list[object]) -> dict[str, int]:
+def _status_v2_counts(tasks: list[Task]) -> dict[str, int]:
     counts: dict[str, int] = {
         "running": 0,
         "retrying": 0,

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -641,11 +641,6 @@ class ControlPlaneWorkItemView(BaseModel):
     actions: tuple[ControlPlaneActionView, ...] = ()
 
 
-class CostSummary(BaseModel):
-    month_to_date_usd: float
-    by_backend: dict[str, float]
-
-
 class AssembleMemoryRequest(BaseModel):
     repo: str = Field(..., min_length=1)
     issue_title: str = ""
@@ -1638,29 +1633,6 @@ def create_app(  # noqa: C901
                 return {"sub": "static-token", "role": "admin", "exp": None}
         return {"sub": "anonymous", "role": None, "exp": None}
 
-    @app.get("/health")
-    async def health() -> dict[str, Any]:
-        state = daemon.state()
-        return {
-            "status": "ok",
-            "version": state.version,
-            "uptime_seconds": (datetime.now(timezone.utc) - state.started_at).total_seconds(),
-        }
-
-    @app.get("/readyz")
-    async def readyz() -> dict[str, Any]:
-        state = daemon.state()
-        if not state.backends_available:
-            raise HTTPException(status_code=503, detail="no backends available")
-        return {"status": "ready"}
-
-    @app.get("/healthz")
-    async def healthz() -> dict[str, Any]:
-        state = daemon.state()
-        if not state.backends_available:
-            raise HTTPException(status_code=503, detail="no backends available")
-        return {"status": "ready"}
-
     # ── Stable operator contract surface (/api/) ──────────────────────────────
     # These endpoints form the versioned contract consumed by runner-dashboard
     # and other operator tooling.  Shape changes require bumping CONTRACT_VERSION
@@ -1668,11 +1640,13 @@ def create_app(  # noqa: C901
     #
     # ``/api/version`` and ``/api/health`` live in maxwell_daemon.api.routes.health
     # as the first phase of decomposing this module (issue #793).
+    from maxwell_daemon.api.routes import cost as _cost_routes
     from maxwell_daemon.api.routes import health as _health_routes
     from maxwell_daemon.api.routes import status as _status_routes
 
     _health_routes.register(app, daemon)
     _status_routes.register(app, daemon)
+    _cost_routes.register(app, daemon, _require_viewer())
 
     @app.get("/api/tasks", dependencies=[Depends(_require_viewer())])
     async def api_list_tasks(
@@ -2855,15 +2829,6 @@ def create_app(  # noqa: C901
             "ledger_records_pruned": result["ledger_records"],
             "audit_entries_pruned": audit_removed,
         }
-
-    @app.get("/api/v1/cost", dependencies=[Depends(_require_viewer())])
-    async def cost_summary() -> CostSummary:
-        now = datetime.now(timezone.utc)
-        start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-        return CostSummary(
-            month_to_date_usd=daemon._ledger.month_to_date(),
-            by_backend=daemon._ledger.by_backend(start),
-        )
 
     @app.post("/api/v1/webhooks/github")
     async def github_webhook(request: Request) -> Response:

--- a/maxwell_daemon/api/server.py
+++ b/maxwell_daemon/api/server.py
@@ -44,11 +44,7 @@ from maxwell_daemon.api.contract import (
     ControlResponse,
     DispatchRequest,
     DispatchResponse,
-    StatusResponse,
-    StatusV2Response,
-    StatusV2RunningTask,
     StatusV2Tokens,
-    StatusV2Totals,
     TaskDetail,
     TaskListResponse,
     TaskSummary,
@@ -1673,95 +1669,10 @@ def create_app(  # noqa: C901
     # ``/api/version`` and ``/api/health`` live in maxwell_daemon.api.routes.health
     # as the first phase of decomposing this module (issue #793).
     from maxwell_daemon.api.routes import health as _health_routes
+    from maxwell_daemon.api.routes import status as _status_routes
 
     _health_routes.register(app, daemon)
-
-    @app.get("/api/status")
-    async def api_status() -> StatusResponse:
-        try:
-            state = daemon.state()
-        except Exception:  # noqa: BLE001
-            return StatusResponse(
-                pipeline_state="error",
-                gate="closed",
-                sandbox="unknown",
-            )
-        # Derive pipeline_state from running tasks.
-        running_tasks = [t for t in state.tasks.values() if t.status.value == "running"]
-        queued_tasks = [t for t in state.tasks.values() if t.status.value == "queued"]
-        if running_tasks:
-            pipeline_state = "running"
-            active_task_id: str | None = running_tasks[0].id
-        elif queued_tasks:
-            pipeline_state = "running"
-            active_task_id = None
-        else:
-            pipeline_state = "idle"
-            active_task_id = None
-
-        gate = "open" if state.backends_available else "closed"
-        sandbox_cfg = getattr(daemon._config, "sandbox", None)
-        sandbox_enabled = getattr(sandbox_cfg, "enabled", True) if sandbox_cfg else True
-        return StatusResponse(
-            pipeline_state=pipeline_state,
-            active_task_id=active_task_id,
-            gate=gate,
-            sandbox="enabled" if sandbox_enabled else "disabled",
-        )
-
-    @app.get("/api/v2/status")
-    async def api_v2_status() -> StatusV2Response:
-        generated_at = datetime.now(timezone.utc)
-        try:
-            state = daemon.state()
-        except Exception:  # noqa: BLE001
-            return StatusV2Response(
-                generated_at=generated_at.isoformat(),
-                counts=_status_v2_counts([]),
-                running=[],
-                retrying=[],
-                codex_totals=StatusV2Totals(),
-                rate_limits=None,
-            )
-
-        tasks = list(state.tasks.values())
-        running_tasks = [t for t in tasks if t.status is TaskStatus.RUNNING]
-        token_totals_by_task = daemon._ledger.token_totals_by_agent({t.id for t in running_tasks})
-        running_since = [t.started_at for t in running_tasks if t.started_at is not None]
-        earliest_started_at = min(running_since) if running_since else None
-        seconds_running = (
-            (generated_at - earliest_started_at).total_seconds()
-            if earliest_started_at is not None
-            else 0.0
-        )
-
-        running = [
-            StatusV2RunningTask(
-                task_id=t.id,
-                session_id=t.turn_session_id,
-                run_count=t.turn_count,
-                last_event=t.status.value,
-                started_at=t.started_at.isoformat() if t.started_at is not None else None,
-                dispatched_to=t.dispatched_to,
-                tokens=_status_v2_tokens(token_totals_by_task.get(t.id)),
-            )
-            for t in running_tasks
-        ]
-
-        totals = _status_v2_tokens(daemon._ledger.token_totals())
-        return StatusV2Response(
-            generated_at=generated_at.isoformat(),
-            counts=_status_v2_counts(tasks),
-            running=running,
-            retrying=[],
-            codex_totals=StatusV2Totals(
-                input_tokens=totals.input_tokens,
-                output_tokens=totals.output_tokens,
-                total_tokens=totals.total_tokens,
-                seconds_running=seconds_running,
-            ),
-            rate_limits=None,
-        )
+    _status_routes.register(app, daemon)
 
     @app.get("/api/tasks", dependencies=[Depends(_require_viewer())])
     async def api_list_tasks(


### PR DESCRIPTION
Phase 2 of #793: extract `/api/v1/cost` into dedicated route module.

Changes:
- Extract `/api/v1/cost` into `maxwell_daemon/api/routes/cost.py`
- Move `CostSummary` model to `maxwell_daemon/api/contract.py` 
- Wire cost route `register()` in `server.py`
- Restore legacy `/health`, `/healthz`, `/readyz` endpoints in `health.py` (lost during Phase 1 extraction)

Quality gates:
- Integration smoke tests: 9/9 pass
- API unit tests: 71/71 pass
- Ruff: clean
- Mypy strict: clean

Closes #793