### PR TITLE
refactor(daemon): extract FleetCoordinator from runner.py (#798)

### DIFF
--- a/maxwell_daemon/daemon/fleet_coordinator.py
+++ b/maxwell_daemon/daemon/fleet_coordinator.py
@@ -1,0 +1,268 @@
+"""Fleet coordinator logic extracted from runner.py (phase 2 of #798).
+
+Handles the coordinator role: probing remote workers, dispatching queued tasks
+to healthy machines via :class:`FleetDispatcher`, and requeueing tasks whose
+assigned machine has gone offline.
+
+This module is imported by :class:`~maxwell_daemon.daemon.runner.Daemon` when
+the daemon starts in ``coordinator`` role.  No business logic lives here —
+only fleet topology management and remote dispatch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from maxwell_daemon.logging import get_logger
+
+if TYPE_CHECKING:
+    from maxwell_daemon.config import MaxwellDaemonConfig
+    from maxwell_daemon.core.task_store import TaskStore
+    from maxwell_daemon.daemon.task_models import Task
+
+log = get_logger("maxwell_daemon.daemon.fleet_coordinator")
+
+__all__ = ["FleetCoordinator"]
+
+
+class FleetCoordinator:
+    """Encapsulates coordinator-role fleet dispatch logic.
+
+    A :class:`~maxwell_daemon.daemon.runner.Daemon` running as ``coordinator``
+    creates one :class:`FleetCoordinator` and drives it via
+    :meth:`run_loop`.  The coordinator never executes tasks locally; it only
+    dispatches them to remote workers and monitors liveness.
+
+    Parameters
+    ----------
+    config:
+        Active daemon configuration (may be hot-reloaded via :meth:`update_config`).
+    tasks:
+        Shared in-memory task dict (same object as ``Daemon._tasks``).
+    tasks_lock:
+        Threading lock guarding iteration of *tasks*.
+    task_store:
+        Durable task store used to persist status changes.
+    worker_last_seen:
+        Map from machine name to last heartbeat timestamp (shared with daemon).
+    enqueue_task_entry:
+        Callable matching ``Daemon._enqueue_task_entry`` — used to requeue
+        stale dispatched tasks back into the local priority queue.
+    running_flag:
+        Callable returning ``bool`` — should return ``True`` while the daemon
+        is alive.  Typically a lambda closing over ``Daemon._running``.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: MaxwellDaemonConfig,
+        tasks: dict[str, Task],
+        tasks_lock: threading.Lock,
+        task_store: TaskStore,
+        worker_last_seen: dict[str, datetime],
+        enqueue_task_entry: Any,
+        running_flag: Any,
+    ) -> None:
+        self._config = config
+        self._tasks = tasks
+        self._tasks_lock = tasks_lock
+        self._task_store = task_store
+        self._worker_last_seen = worker_last_seen
+        self._enqueue_task_entry = enqueue_task_entry
+        self._running_flag = running_flag
+
+    def update_config(self, config: MaxwellDaemonConfig) -> None:
+        """Swap the active config (used during hot-reload)."""
+        self._config = config
+
+    async def run_loop(self) -> None:
+        """Coordinator event loop — runs until the daemon stops."""
+        poll_seconds = self._config.fleet_coordinator_poll_seconds
+        while self._running_flag():
+            try:
+                await self._dispatch_tick()
+            except Exception:
+                log.exception("coordinator dispatch error")
+            await asyncio.sleep(poll_seconds)
+
+    async def _dispatch_tick(self) -> None:  # noqa: C901
+        """One coordinator dispatch tick: probe machines, plan, submit, requeue stale tasks."""
+        from maxwell_daemon.daemon.task_models import TaskStatus
+        from maxwell_daemon.fleet.client import RemoteDaemonClient, RemoteDaemonError
+        from maxwell_daemon.fleet.dispatcher import (
+            FleetDispatcher,
+            MachineState,
+            TaskRequirement,
+        )
+
+        fleet_machines = self._config.fleet_machines
+        if not fleet_machines:
+            return
+
+        # Build initial MachineState snapshots from config.
+        initial_machines = tuple(
+            MachineState(
+                name=m.name,
+                host=m.host,
+                port=m.port,
+                capacity=m.capacity,
+                tags=tuple(m.tags),
+            )
+            for m in fleet_machines
+        )
+
+        client = RemoteDaemonClient(
+            auth_token=self._config.api_auth_token,
+        )
+
+        # Probe all machines in parallel to get live health.
+        machines = await client.refresh_all(initial_machines)
+
+        # Requeue tasks dispatched to machines that have gone offline.
+        now = datetime.now(timezone.utc)
+        stale_threshold = self._config.fleet_heartbeat_seconds * 3
+        with self._tasks_lock:
+            tasks_snapshot = dict(self._tasks)
+
+        for t in tasks_snapshot.values():
+            if t.status is not TaskStatus.DISPATCHED or t.dispatched_to is None:
+                continue
+            machine_name = t.dispatched_to
+            machine_healthy = any(m.name == machine_name and m.healthy for m in machines)
+            if not machine_healthy:
+                last_seen = self._worker_last_seen.get(machine_name)
+                stale = True
+                if last_seen is not None:
+                    elapsed = (now - last_seen).total_seconds()
+                    stale = elapsed > stale_threshold
+                if stale:
+                    self._handle_stale_dispatched_task(t, machine_name)
+
+        # Collect tasks still QUEUED after potential requeuing above.
+        with self._tasks_lock:
+            tasks_snapshot = dict(self._tasks)
+
+        queued_tasks = [t for t in tasks_snapshot.values() if t.status is TaskStatus.QUEUED]
+        if not queued_tasks:
+            return
+
+        task_requirements = tuple(TaskRequirement(task_id=t.id) for t in queued_tasks)
+
+        # Tally active_tasks on each machine from known DISPATCHED tasks.
+        dispatched_counts: dict[str, int] = {}
+        for t in tasks_snapshot.values():
+            if t.status is TaskStatus.DISPATCHED and t.dispatched_to:
+                dispatched_counts[t.dispatched_to] = dispatched_counts.get(t.dispatched_to, 0) + 1
+
+        machines_with_load = tuple(
+            MachineState(
+                name=m.name,
+                host=m.host,
+                port=m.port,
+                capacity=m.capacity,
+                tags=m.tags,
+                active_tasks=dispatched_counts.get(m.name, 0),
+                healthy=m.healthy,
+            )
+            for m in machines
+        )
+
+        dispatcher = FleetDispatcher()
+        plan = dispatcher.plan(machines_with_load, task_requirements)
+
+        # Build lookup maps for fast resolution.
+        tasks_by_id = {t.id: t for t in queued_tasks}
+        machines_by_name = {m.name: m for m in machines}
+
+        for assignment in plan.assignments:
+            assigned_task = tasks_by_id.get(assignment.task_id)
+            machine = machines_by_name.get(assignment.machine_name)
+            if assigned_task is None or machine is None:
+                continue
+
+            task_payload: dict[str, Any] = {
+                "task_id": assigned_task.id,
+                "prompt": assigned_task.prompt,
+                "kind": assigned_task.kind.value,
+                "repo": assigned_task.repo,
+                "backend": assigned_task.backend,
+                "model": assigned_task.model,
+                "issue_repo": assigned_task.issue_repo,
+                "issue_number": assigned_task.issue_number,
+                "issue_mode": assigned_task.issue_mode,
+                "priority": assigned_task.priority,
+            }
+
+            try:
+                result = await client.submit_task(machine, task_payload=task_payload)
+            except RemoteDaemonError:
+                log.exception(
+                    "failed to dispatch task %s to machine %s",
+                    assigned_task.id,
+                    machine.name,
+                )
+                continue
+
+            if result.status == "submitted":
+                assigned_task.status = TaskStatus.DISPATCHED
+                assigned_task.dispatched_to = machine.name
+                log.info("dispatched task %s to machine %s", assigned_task.id, machine.name)
+                try:
+                    self._task_store.save(assigned_task)
+                except Exception as exc:  # noqa: BLE001
+                    log.warning(
+                        "Failed to persist DISPATCHED state for task %s: %s",
+                        assigned_task.id,
+                        exc,
+                        exc_info=True,
+                    )
+            else:
+                log.warning(
+                    "machine %s rejected task %s: %s",
+                    machine.name,
+                    assigned_task.id,
+                    result.detail,
+                )
+
+        if plan.unassigned:
+            log.debug(
+                "coordinator: %d task(s) could not be placed this tick: %s",
+                len(plan.unassigned),
+                plan.unassigned,
+            )
+
+    def _handle_stale_dispatched_task(self, task: Task, machine_name: str) -> None:
+        """Fail or requeue a dispatched task whose worker machine is no longer healthy."""
+        if task.side_effects_started:
+            log.warning(
+                "worker %s appears offline after task %s started side effects; "
+                "failing instead of transparent failover",
+                machine_name,
+                task.id,
+            )
+            from maxwell_daemon.daemon.task_models import TaskStatus
+
+            task.status = TaskStatus.FAILED
+            task.error = (
+                f"worker {machine_name} became stale after side effects started; "
+                "retry as a new attempt"
+            )
+            task.finished_at = datetime.now(timezone.utc)
+            self._task_store.save(task)
+            return
+
+        log.warning(
+            "worker %s appears offline before task %s started side effects; requeueing",
+            machine_name,
+            task.id,
+        )
+        from maxwell_daemon.daemon.task_models import TaskStatus
+
+        task.status = TaskStatus.QUEUED
+        task.dispatched_to = None
+        self._task_store.save(task)
+        self._enqueue_task_entry(task.priority, task)

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -67,6 +67,8 @@ log = get_logger("maxwell_daemon.daemon")
 # Task data models are extracted to task_models.py (phase 1 of #798).
 # Re-exported here for backwards-compatibility so existing import paths
 # (e.g. ``from maxwell_daemon.daemon.runner import Task``) keep working.
+# Fleet coordinator logic is extracted to fleet_coordinator.py (phase 2 of #798).
+from maxwell_daemon.daemon.fleet_coordinator import FleetCoordinator  # noqa: E402
 from maxwell_daemon.daemon.task_models import (  # noqa: E402
     DaemonState,
     DuplicateTaskIdError,
@@ -81,6 +83,7 @@ __all__ = [
     "Daemon",
     "DaemonState",
     "DuplicateTaskIdError",
+    "FleetCoordinator",
     "QueueSaturationError",
     "Task",
     "TaskKind",
@@ -236,6 +239,8 @@ class Daemon:
         # Fleet coordination: track last-seen time per worker machine for heartbeat.
         # Keys are machine names; values are the UTC datetime of last contact.
         self._worker_last_seen: dict[str, datetime] = {}
+        # Created lazily in start() when role == "coordinator" (see fleet_coordinator.py).
+        self._fleet_coordinator: FleetCoordinator | None = None
         self._active_execution_tasks: dict[str, asyncio.Task[None]] = {}
         self._last_stream_event_at: dict[str, datetime] = {}
         self._last_stream_event_kind: dict[str, str] = {}
@@ -291,6 +296,8 @@ class Daemon:
                     mode=ApprovalMode(new_config.tools.approval_tier),
                     workspace_root=self._workspace_root,
                 )
+            if hasattr(self, "_fleet_coordinator"):
+                self._fleet_coordinator.update_config(new_config)
 
         log.info("config reloaded from %s", path)
         return path
@@ -373,7 +380,18 @@ class Daemon:
             # Coordinator: runs discovery and dispatches to remote workers — no local execution.
             self._worker_count = 0
             log.info("daemon started as coordinator (no local workers)")
-            coord_task = asyncio.create_task(self._coordinator_loop(), name="coordinator-loop")
+            self._fleet_coordinator = FleetCoordinator(
+                config=self._config,
+                tasks=self._tasks,
+                tasks_lock=self._tasks_lock,
+                task_store=self._task_store,
+                worker_last_seen=self._worker_last_seen,
+                enqueue_task_entry=self._enqueue_task_entry,
+                running_flag=lambda: self._running,
+            )
+            coord_task = asyncio.create_task(
+                self._fleet_coordinator.run_loop(), name="coordinator-loop"
+            )
             self._bg_tasks.add(coord_task)
             coord_task.add_done_callback(self._bg_tasks.discard)
         elif role == "worker":
@@ -1426,188 +1444,11 @@ class Daemon:
         log.info("reprioritized task=%s old=%d new=%d", task_id, old_priority, new_priority)
         return task
 
-    # -- coordinator loop ----------------------------------------------------
-
-    async def _coordinator_loop(self) -> None:
-        """Periodically flush QUEUED tasks to remote workers via FleetDispatcher."""
-        poll_seconds = self._config.fleet_coordinator_poll_seconds
-        while self._running:
-            try:
-                await self._dispatch_to_fleet()
-            except Exception:
-                log.exception("coordinator dispatch error")
-            await asyncio.sleep(poll_seconds)
-
-    async def _dispatch_to_fleet(self) -> None:  # noqa: C901
-        """One coordinator dispatch tick: probe machines, plan, submit, requeue stale tasks."""
-        from maxwell_daemon.fleet.client import RemoteDaemonClient, RemoteDaemonError
-        from maxwell_daemon.fleet.dispatcher import (
-            FleetDispatcher,
-            MachineState,
-            TaskRequirement,
-        )
-
-        fleet_machines = self._config.fleet_machines
-        if not fleet_machines:
-            return
-
-        # Build initial MachineState snapshots from config.
-        initial_machines = tuple(
-            MachineState(
-                name=m.name,
-                host=m.host,
-                port=m.port,
-                capacity=m.capacity,
-                tags=tuple(m.tags),
-            )
-            for m in fleet_machines
-        )
-
-        client = RemoteDaemonClient(
-            auth_token=self._config.api_auth_token,
-        )
-
-        # Probe all machines in parallel to get live health.
-        machines = await client.refresh_all(initial_machines)
-
-        # Requeue tasks dispatched to machines that have gone offline.
-        now = datetime.now(timezone.utc)
-        stale_threshold = self._config.fleet_heartbeat_seconds * 3
-        with self._tasks_lock:
-            tasks_snapshot = dict(self._tasks)
-
-        for t in tasks_snapshot.values():
-            if t.status is not TaskStatus.DISPATCHED or t.dispatched_to is None:
-                continue
-            machine_name = t.dispatched_to
-            machine_healthy = any(m.name == machine_name and m.healthy for m in machines)
-            if not machine_healthy:
-                last_seen = self._worker_last_seen.get(machine_name)
-                stale = True
-                if last_seen is not None:
-                    elapsed = (now - last_seen).total_seconds()
-                    stale = elapsed > stale_threshold
-                if stale:
-                    self._handle_stale_dispatched_task(t, machine_name)
-
-        # Collect tasks still QUEUED after potential requeuing above.
-        with self._tasks_lock:
-            tasks_snapshot = dict(self._tasks)
-
-        queued_tasks = [t for t in tasks_snapshot.values() if t.status is TaskStatus.QUEUED]
-        if not queued_tasks:
-            return
-
-        task_requirements = tuple(TaskRequirement(task_id=t.id) for t in queued_tasks)
-
-        # Tally active_tasks on each machine from known DISPATCHED tasks.
-        dispatched_counts: dict[str, int] = {}
-        for t in tasks_snapshot.values():
-            if t.status is TaskStatus.DISPATCHED and t.dispatched_to:
-                dispatched_counts[t.dispatched_to] = dispatched_counts.get(t.dispatched_to, 0) + 1
-
-        machines_with_load = tuple(
-            MachineState(
-                name=m.name,
-                host=m.host,
-                port=m.port,
-                capacity=m.capacity,
-                tags=m.tags,
-                active_tasks=dispatched_counts.get(m.name, 0),
-                healthy=m.healthy,
-            )
-            for m in machines
-        )
-
-        dispatcher = FleetDispatcher()
-        plan = dispatcher.plan(machines_with_load, task_requirements)
-
-        # Build lookup maps for fast resolution.
-        tasks_by_id = {t.id: t for t in queued_tasks}
-        machines_by_name = {m.name: m for m in machines}
-
-        for assignment in plan.assignments:
-            assigned_task = tasks_by_id.get(assignment.task_id)
-            machine = machines_by_name.get(assignment.machine_name)
-            if assigned_task is None or machine is None:
-                continue
-
-            task_payload: dict[str, Any] = {
-                "task_id": assigned_task.id,
-                "prompt": assigned_task.prompt,
-                "kind": assigned_task.kind.value,
-                "repo": assigned_task.repo,
-                "backend": assigned_task.backend,
-                "model": assigned_task.model,
-                "issue_repo": assigned_task.issue_repo,
-                "issue_number": assigned_task.issue_number,
-                "issue_mode": assigned_task.issue_mode,
-                "priority": assigned_task.priority,
-            }
-
-            try:
-                result = await client.submit_task(machine, task_payload=task_payload)
-            except RemoteDaemonError:
-                log.exception(
-                    "failed to dispatch task %s to machine %s",
-                    assigned_task.id,
-                    machine.name,
-                )
-                continue
-
-            if result.status == "submitted":
-                assigned_task.status = TaskStatus.DISPATCHED
-                assigned_task.dispatched_to = machine.name
-                log.info("dispatched task %s to machine %s", assigned_task.id, machine.name)
-                try:
-                    self._task_store.save(assigned_task)
-                except Exception as exc:  # noqa: BLE001
-                    log.warning(
-                        "Failed to persist DISPATCHED state for task %s: %s",
-                        assigned_task.id,
-                        exc,
-                        exc_info=True,
-                    )
-            else:
-                log.warning(
-                    "machine %s rejected task %s: %s",
-                    machine.name,
-                    assigned_task.id,
-                    result.detail,
-                )
-
-        if plan.unassigned:
-            log.debug(
-                "coordinator: %d task(s) could not be placed this tick: %s",
-                len(plan.unassigned),
-                plan.unassigned,
-            )
-
-    def _handle_stale_dispatched_task(self, task: Task, machine_name: str) -> None:
-        if task.side_effects_started:
-            log.warning(
-                "worker %s appears offline after task %s started side effects; failing instead of transparent failover",
-                machine_name,
-                task.id,
-            )
-            task.status = TaskStatus.FAILED
-            task.error = (
-                f"worker {machine_name} became stale after side effects started; "
-                "retry as a new attempt"
-            )
-            task.finished_at = datetime.now(timezone.utc)
-            self._task_store.save(task)
-            return
-
-        log.warning(
-            "worker %s appears offline before task %s started side effects; requeueing",
-            machine_name,
-            task.id,
-        )
-        task.status = TaskStatus.QUEUED
-        task.dispatched_to = None
-        self._task_store.save(task)
-        self._enqueue_task_entry(task.priority, task)
+    # -- coordinator loop (see daemon/fleet_coordinator.py) -----------------
+    # The _coordinator_loop, _dispatch_to_fleet, and _handle_stale_dispatched_task
+    # methods have been extracted to FleetCoordinator (phase 2 of #798).
+    # Daemon.start() creates a FleetCoordinator instance and drives it via
+    # FleetCoordinator.run_loop() when role == "coordinator".
 
     async def _reload_config_signal(self) -> None:
         """Signal handler wrapper — logs errors rather than crashing the event loop."""

--- a/tests/unit/daemon/test_fleet_coordinator.py
+++ b/tests/unit/daemon/test_fleet_coordinator.py
@@ -1,0 +1,114 @@
+"""Unit tests for FleetCoordinator (issue #798, phase 2).
+
+Tests focus on the stale-task handling logic which is pure synchronous code
+and can be exercised without running a real fleet.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from maxwell_daemon.daemon.fleet_coordinator import FleetCoordinator
+from maxwell_daemon.daemon.task_models import Task, TaskKind, TaskStatus
+
+
+def _make_task(
+    *,
+    status: TaskStatus = TaskStatus.DISPATCHED,
+    dispatched_to: str | None = "worker-1",
+    side_effects_started: bool = False,
+) -> Task:
+    """Build a minimal Task for fleet coordinator tests."""
+    return Task(
+        id="test-task-abc",
+        prompt="test",
+        kind=TaskKind.PROMPT,
+        status=status,
+        dispatched_to=dispatched_to,
+        side_effects_started=side_effects_started,
+    )
+
+
+def _make_coordinator(
+    *,
+    tasks: dict | None = None,
+    task_store: MagicMock | None = None,
+    enqueue_fn: MagicMock | None = None,
+) -> FleetCoordinator:
+    """Build a FleetCoordinator with minimal mock dependencies."""
+    config = SimpleNamespace(
+        fleet_machines=[],
+        fleet_coordinator_poll_seconds=5,
+        fleet_heartbeat_seconds=30,
+        api_auth_token=None,
+    )
+    return FleetCoordinator(
+        config=config,
+        tasks=tasks or {},
+        tasks_lock=threading.Lock(),
+        task_store=task_store or MagicMock(),
+        worker_last_seen={},
+        enqueue_task_entry=enqueue_fn or MagicMock(),
+        running_flag=lambda: False,
+    )
+
+
+class TestHandleStaleDispatchedTask:
+    def test_requeueing_when_no_side_effects_started(self) -> None:
+        """Tasks with no side effects should be requeued transparently."""
+        enqueue_fn = MagicMock()
+        task_store = MagicMock()
+        coordinator = _make_coordinator(enqueue_fn=enqueue_fn, task_store=task_store)
+        task = _make_task(side_effects_started=False)
+
+        coordinator._handle_stale_dispatched_task(task, "worker-1")
+
+        assert task.status is TaskStatus.QUEUED
+        assert task.dispatched_to is None
+        task_store.save.assert_called_once_with(task)
+        enqueue_fn.assert_called_once_with(task.priority, task)
+
+    def test_failing_when_side_effects_started(self) -> None:
+        """Tasks that started side effects must not be transparently failed."""
+        enqueue_fn = MagicMock()
+        task_store = MagicMock()
+        coordinator = _make_coordinator(enqueue_fn=enqueue_fn, task_store=task_store)
+        task = _make_task(side_effects_started=True)
+
+        coordinator._handle_stale_dispatched_task(task, "worker-1")
+
+        assert task.status is TaskStatus.FAILED
+        assert task.error is not None
+        assert "side effects" in task.error
+        task_store.save.assert_called_once_with(task)
+        # Must NOT re-enqueue when side effects already started
+        enqueue_fn.assert_not_called()
+
+    def test_failed_task_has_finished_at_set(self) -> None:
+        """A failed stale task should record a finish timestamp."""
+        coordinator = _make_coordinator()
+        task = _make_task(side_effects_started=True)
+
+        coordinator._handle_stale_dispatched_task(task, "worker-1")
+
+        assert task.finished_at is not None
+        # finished_at should be close to now
+        age = datetime.now(timezone.utc) - task.finished_at
+        assert age < timedelta(seconds=5)
+
+
+class TestUpdateConfig:
+    def test_config_is_swapped(self) -> None:
+        """update_config should replace the internal config reference."""
+        coordinator = _make_coordinator()
+        new_config = SimpleNamespace(
+            fleet_machines=[],
+            fleet_coordinator_poll_seconds=10,
+            fleet_heartbeat_seconds=60,
+            api_auth_token="token",
+        )
+        coordinator.update_config(new_config)
+        assert coordinator._config is new_config


### PR DESCRIPTION
## Summary

Phase 2 of issue #798: extract the fleet coordinator logic from the monolithic `runner.py` into a focused `FleetCoordinator` class.

- Moves `_coordinator_loop`, `_dispatch_to_fleet`, and `_handle_stale_dispatched_task` into `maxwell_daemon/daemon/fleet_coordinator.py`
- `runner.py` shrinks from **2,056 → 1,897 lines** (159 lines extracted)
- `FleetCoordinator` is now independently unit-testable without spinning up a full `Daemon`
- Config hot-reload propagates to `FleetCoordinator.update_config()` during SIGHUP/SIGUSR1
- Backwards-compatible: `FleetCoordinator` is re-exported from `runner.py`

## Test plan

- [x] 4 new unit tests in `tests/unit/daemon/test_fleet_coordinator.py`
  - Stale task requeuing (no side effects started)
  - Stale task failing (side effects started — no transparent failover)
  - `finished_at` timestamp set on failed stale tasks
  - `update_config()` swaps internal config reference
- [x] `ruff check .` passes (0 errors)
- [x] `ruff format --check` passes on changed files

Closes #798 (partial — this is phase 2; task_models.py was phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)