### PR TITLE
fix: initialize stream event timestamp for issue tasks to prevent premature stall detection

### DIFF
--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -1805,6 +1805,10 @@ class Daemon:
                 task.id,
             )
 
+        # Record initial activity timestamp so stall detection doesn't trigger
+        # before any output is produced.
+        self._record_stream_event(task.id, EventKind.TASK_STARTED.value)
+
         async def _emit_test_output(chunk: str, stream: str) -> None:
             self._record_stream_event(task.id, f"{EventKind.TEST_OUTPUT.value}:{stream}")
             await self._events.publish(


### PR DESCRIPTION
## Problem

The stall detection logic in `_reconcile_stalled_runs()` uses the last stream event timestamp to determine if a task is making progress. For ISSUE tasks, the `_execute_issue()` method was not recording an initial stream event, causing the stall detection to trigger before any output was produced.

## Solution

This fix adds a `_record_stream_event()` call at the start of `_execute_issue()` to initialize the stream event tracking, matching the behavior of regular tasks in `_execute()`.

## Testing

- Fixed failing test: `test_issue_stream_activity_prevents_stall_retry`
- All 41 daemon tests pass
- All 2411 unit tests pass with 85.49% coverage

## Related

Fixes test_issue_stream_activity_prevents_stall_retry which was failing because stall detection was triggering before the mock executor's first callback.