### PR TITLE
chore(testing): adopt fleet testing standards Phase 1 (#860)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,12 +117,50 @@ max-complexity = 15
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"
+timeout = 60
+timeout_method = "thread"
 # ``tests/benchmarks/`` is intentionally excluded from the default run.
 # Performance benchmarks are timing-sensitive and must be invoked
 # explicitly via ``pytest tests/benchmarks/ --benchmark-only``; including
 # them in the standard unit/integration lane would bias coverage and
 # potentially cause flakes on slow runners.
-addopts = "-ra --strict-markers --cov=maxwell_daemon --cov-report=term-missing --cov-fail-under=85.0 --ignore=tests/benchmarks"
+#
+# Default lane: fast, deterministic, offline. See
+# Repository_Management/docs/FLEET_TESTING_STANDARDS.md §2.
+addopts = """
+  -ra
+  --strict-markers
+  --strict-config
+  --durations=20
+  --cov=maxwell_daemon
+  --cov-report=term-missing
+  --cov-fail-under=85.0
+  --ignore=tests/benchmarks
+  -m "not slow and not live_simulation and not e2e and not requires_network"
+"""
+
+markers = [
+  # ---- tier markers ----
+  "unit: pure logic, fully mocked, < 100 ms wall-clock",
+  "integration: cross-module / file-system / process boundaries, < 5 s",
+  "e2e: full-stack smoke tests; nightly + release gate only",
+  "slow: > 1 s wall-clock; deselect with -m 'not slow'",
+  "live_simulation: requires a real physics / math engine; deselect by default",
+
+  # ---- environment markers ----
+  "requires_network: needs real outbound network; deselect by default",
+  "requires_gpu: needs CUDA / Metal / ROCm",
+  "requires_gl: needs OpenGL or a display",
+  "headless_safe: verified under QT_QPA_PLATFORM=offscreen",
+
+  # ---- workflow markers ----
+  "serial: must run with -n 0 (xdist parallel breaks this test)",
+  "benchmark: deterministic perf smoke; not a primary correctness gate",
+  "smoke: release-blocking smoke; subset of e2e",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,16 +2,34 @@
 
 Reusable building blocks kept here so individual test modules stay focused on
 behavior rather than scaffolding.
+
+Top-level conftest: enforce thread-safety and disable real network.
+See Repository_Management/docs/FLEET_TESTING_STANDARDS.md §5.
 """
 
 from __future__ import annotations
 
 import os
+
+# C-extension thread safety. Many "xdist worker crashed" failures
+# come from MKL/OpenBLAS forking under xdist. Pin to single-threaded
+# for tests; production code can re-thread itself if it needs to.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+
+# matplotlib headless backend, set before any matplotlib import.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+# Qt headless backend, for repos that import PyQt/PySide indirectly.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+os.environ["MAXWELL_AGGRESSIVE_COMPRESSION"] = "1"
+
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
 from typing import Any
-
-os.environ["MAXWELL_AGGRESSIVE_COMPRESSION"] = "1"
 
 import pytest
 import structlog
@@ -25,6 +43,34 @@ from maxwell_daemon.backends import (
     registry,
 )
 from maxwell_daemon.config import MaxwellDaemonConfig
+
+
+@pytest.fixture(autouse=True)
+def _no_real_network_in_unit_lane(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Block real outbound HTTP from unit-marked tests by default.
+
+    See FLEET_TESTING_STANDARDS.md §5.
+    """
+    if "unit" not in request.keywords:
+        return
+
+    def _refuse(*_a: Any, **_kw: Any) -> None:
+        raise RuntimeError(
+            "Unit test made a real network call. Mock with `respx` "
+            "or `pytest-httpx`, or mark the test "
+            "`@pytest.mark.requires_network`."
+        )
+
+    for module in ("httpx", "requests", "urllib.request"):
+        try:
+            mod = __import__(module, fromlist=["*"])
+            for attr in ("get", "post", "put", "delete", "request"):
+                if hasattr(mod, attr):
+                    monkeypatch.setattr(mod, attr, _refuse, raising=False)
+        except ImportError:
+            pass
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Phase 1 of the fleet testing alignment for Maxwell_Daemon (Applications tier, 75% coverage gate target).

- Added the §2 `markers = [...]` block to `[tool.pytest.ini_options]` (tier / env / workflow markers; `benchmark` already in use preserved).
- Enabled `--strict-config` alongside existing `--strict-markers`, plus default-lane exclusion `-m "not slow and not live_simulation and not e2e and not requires_network"`. Added `timeout=60` / `timeout_method=thread`.
- Hoisted §5 thread-safety env vars (OMP/OPENBLAS/MKL/NUMEXPR, MPLBACKEND, QT_QPA_PLATFORM) above heavy imports in `tests/conftest.py`.
- Added §5 network-blocker autouse fixture (refuses real `httpx`/`requests`/`urllib.request` calls in `@pytest.mark.unit` tests).

`asyncio_mode = "auto"` and `fail_under=85` unchanged.

Standards: `Repository_Management/docs/FLEET_TESTING_STANDARDS.md` §2 + §5.

Closes part of #860. Tracks EPIC D-sorganization/Repository_Management#1140. Phase 3 (MCP stdio mocking, `port=0`) remains pending — issue stays open.

## Test plan

- [x] `pytest --collect-only` succeeds with `--strict-markers --strict-config` (2468 tests collected, no unknown-marker errors).
- [ ] CI green on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)