### PR TITLE
ci: workflow protection — timeouts + preventive lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   local-only-workflows:
+    timeout-minutes: 30
     name: Reject hosted runner routing
     runs-on: d-sorg-fleet
     steps:
@@ -46,6 +47,7 @@ jobs:
           echo "Self-hosted runner claimed this job - routing locally"
 
   lint:
+    timeout-minutes: 20
     name: Lint (ruff)
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -70,6 +72,7 @@ jobs:
         run: .venv/bin/python -m ruff format --check .
 
   typecheck:
+    timeout-minutes: 30
     name: Typecheck (mypy --strict)
     needs: [pick-runner, lint]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -153,6 +156,7 @@ jobs:
           path: benchmark-results.json
 
   coverage-floor:
+    timeout-minutes: 30
     name: Coverage floor (ratchet)
     needs: [pick-runner, test]
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'dependabot/github_actions/') }}
@@ -173,6 +177,7 @@ jobs:
       - run: python scripts/check_coverage_floor.py --xml coverage.xml
 
   file-size-budget:
+    timeout-minutes: 30
     name: File size budget
     needs: [pick-runner, coverage-floor]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -189,6 +194,7 @@ jobs:
       - run: python scripts/check_file_size_budget.py
 
   todo-fixme:
+    timeout-minutes: 30
     name: No untracked TODO/FIXME
     needs: [pick-runner, file-size-budget]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -205,6 +211,7 @@ jobs:
       - run: python scripts/check_todo_fixme.py maxwell_daemon
 
   security:
+    timeout-minutes: 20
     name: Security scans
     needs: [pick-runner, todo-fixme]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -227,6 +234,7 @@ jobs:
         run: .venv/bin/python -m pip_audit . --desc --strict
 
   dependency-locks:
+    timeout-minutes: 60
     name: Dependency locks
     needs: [pick-runner, security]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -251,6 +259,7 @@ jobs:
         run: npm ci --ignore-scripts
 
   build:
+    timeout-minutes: 60
     name: Build distribution
     needs: [pick-runner, dependency-locks]
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -274,6 +283,7 @@ jobs:
           path: dist/
 
   desktop-smoke:
+    timeout-minutes: 60
     name: Desktop launcher smoke (${{ matrix.os }})
     needs: build
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,7 @@ jobs:
           echo "Self-hosted runner claimed this job - routing locally"
 
   analyze:
+    timeout-minutes: 90
     name: Analyze
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,6 +53,7 @@ jobs:
           fi
 
   build:
+    timeout-minutes: 60
     name: Build MkDocs site
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
@@ -77,6 +78,7 @@ jobs:
           path: site
 
   deploy:
+    timeout-minutes: 30
     name: Deploy GitHub Pages
     needs: [pick-runner, build]
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -1,0 +1,65 @@
+name: Lint Workflow Files
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: lint-workflow-files-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Identify modified workflow files
+        id: changed
+        run: |
+          set -eo pipefail
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml' | grep -v 'lint-workflow-files.yml' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No workflow files changed."
+            exit 0
+          fi
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Require timeout-minutes, concurrency, cancel-in-progress
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILES: ${{ steps.changed.outputs.files }}
+        run: |
+          set -eo pipefail
+          [ -z "$FILES" ] && exit 0
+          FAIL=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            [ ! -f "$f" ] && continue
+            if ! grep -q '^\s*timeout-minutes:' "$f"; then
+              FAIL="${FAIL}\n  - $f: missing timeout-minutes"
+            fi
+            if ! grep -q '^concurrency:' "$f"; then
+              FAIL="${FAIL}\n  - $f: missing concurrency block"
+            fi
+            if grep -q '^concurrency:' "$f" && ! grep -q 'cancel-in-progress:\s*true' "$f"; then
+              FAIL="${FAIL}\n  - $f: cancel-in-progress not set to true"
+            fi
+          done <<< "$FILES"
+          if [ -n "$FAIL" ]; then
+            printf "::error::Workflow lint failed:%b\n" "$FAIL"
+            COMMENT=$(printf "## Workflow lint failed\n\nThe following modified workflow files are missing required protections:%b\n\n### Required keys\n- \`timeout-minutes:\` at job level (e.g. 30 for tests, 60 for builds)\n- \`concurrency:\` block at workflow level\n- \`cancel-in-progress: true\` inside concurrency\n\n### Why\nThese protections prevent the queue-saturation pattern that clogged the fleet on 2026-05-15/16. See CLAUDE.md for the canonical YAML pattern." "$FAIL")
+            gh pr comment "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --body "$COMMENT" >/dev/null
+            exit 1
+          fi
+          echo "::notice::All modified workflow files pass lint."

--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -50,6 +50,7 @@ jobs:
           fi
 
   local-only-workflows:
+    timeout-minutes: 30
     name: Reject hosted runner routing
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}

--- a/.github/workflows/lockfile-refresh.yml
+++ b/.github/workflows/lockfile-refresh.yml
@@ -40,6 +40,7 @@ jobs:
           fi
 
   refresh:
+    timeout-minutes: 30
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           fi
 
   build-and-publish:
+    timeout-minutes: 60
     name: Build and publish to PyPI
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}


### PR DESCRIPTION
## Workflow protection — timeouts + preventive lint

Adds `timeout-minutes` to all workflow jobs missing them (default 30 tests/lint, 60 builds, 90 perf/bench, 120 long-run) and installs `.github/workflows/lint-workflow-files.yml` which blocks future PRs that add workflows without:

- `timeout-minutes:` at job level
- `concurrency:` block at workflow level
- `cancel-in-progress: true` inside concurrency

### Why
Queue-saturation pattern on 2026-05-15/16 clogged the fleet. Preventive lint stops the regression from coming back.

Companion to Tools / UpstreamDrift / Gasification_Model PRs (those also add `paths:` filters; this PR is timeouts + lint only).