### PR TITLE
ci: caching campaign (per fleet caching audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run: uv venv .venv --python $(which python)
       - run: uv sync --all-extras
@@ -83,6 +84,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run: uv venv .venv --python $(which python)
       - run: uv sync --all-extras
@@ -113,6 +115,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run: uv venv .venv --python $(which python)
       - run: uv sync --all-extras
@@ -167,6 +170,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - uses: actions/download-artifact@v8
         with:
           name: coverage-xml
@@ -186,6 +190,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: python scripts/check_file_size_budget.py
 
   todo-fixme:
@@ -202,6 +207,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: python scripts/check_todo_fixme.py maxwell_daemon
 
   security:
@@ -218,6 +224,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run: uv venv .venv --python $(which python)
       - run: uv pip install bandit pip-audit
@@ -240,12 +247,14 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: python -m pip install uv
       - name: Verify uv.lock is fresh
         run: uv lock --check
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
+          cache: 'npm'
       - name: Verify desktop package lock
         working-directory: apps/desktop-electron
         run: npm ci --ignore-scripts
@@ -264,6 +273,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - run: uv venv .venv --python $(which python)
       - run: uv pip install build
@@ -291,6 +301,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - uses: actions/download-artifact@v8
         with:
           name: dist
@@ -310,6 +321,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
+          cache: 'npm'
       - name: Install desktop dependencies
         working-directory: apps/desktop-electron
         run: npm ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
+        cache: 'pip'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,6 +66,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: python -m venv .venv
       - run: .venv/bin/python -m pip install --upgrade pip
       - run: .venv/bin/python -m pip install ".[docs]"

--- a/.github/workflows/lockfile-refresh.yml
+++ b/.github/workflows/lockfile-refresh.yml
@@ -60,6 +60,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Update uv lockfile
         run: uv lock --upgrade

--- a/.github/workflows/maxwell-daemon-fleet-dispatch.yml
+++ b/.github/workflows/maxwell-daemon-fleet-dispatch.yml
@@ -97,6 +97,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
 
       - name: Install maxwell-daemon
         run: pip install -e ".[dev]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: 'pip'
       - run: |
           pip install build twine
           python -m build


### PR DESCRIPTION
Part of the fleet caching campaign. Audit found ~337 hrs/wk total recoverable across the fleet, ~40 hrs/wk in this batch of repos.

This PR adds pip/npm caches where missing. Per-OS cache keys are handled automatically by `actions/setup-{python,node}` built-in cache.

## Stats
- Modified files: 6
- Added pip caches: 15
- Added npm caches: 2

## Constraints honored
- Did not change workflow logic beyond cache directives
- Did not modify files in conflict with open PRs (cache lines are net-new)
- Per-OS keys via built-in setup-* cache mechanism
- All modified YAMLs validated parseable