### PR TITLE
ci: flatten 8-deep serial chain so jobs run in parallel after pick-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
   typecheck:
     name: Typecheck (mypy --strict)
-    needs: [pick-runner, lint]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Clear stale checkout locks
@@ -93,7 +93,7 @@ jobs:
 
   test:
     name: Test (py${{ matrix.python-version }})
-    needs: [pick-runner, typecheck]
+    needs: pick-runner
     runs-on: [self-hosted, Linux, X64, d-sorg-fleet, deskcomputer]
     timeout-minutes: 45
     env:
@@ -174,7 +174,7 @@ jobs:
 
   file-size-budget:
     name: File size budget
-    needs: [pick-runner, coverage-floor]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Clear stale checkout locks
@@ -190,7 +190,7 @@ jobs:
 
   todo-fixme:
     name: No untracked TODO/FIXME
-    needs: [pick-runner, file-size-budget]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Clear stale checkout locks
@@ -206,7 +206,7 @@ jobs:
 
   security:
     name: Security scans
-    needs: [pick-runner, todo-fixme]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Clear stale checkout locks
@@ -228,7 +228,7 @@ jobs:
 
   dependency-locks:
     name: Dependency locks
-    needs: [pick-runner, security]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Clear stale checkout locks
@@ -252,7 +252,7 @@ jobs:
 
   build:
     name: Build distribution
-    needs: [pick-runner, dependency-locks]
+    needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     steps:
       - name: Clear stale checkout locks


### PR DESCRIPTION
## Summary

Flatten an 8-deep serial `needs:` chain in `ci.yml` so all gate jobs run in parallel after `pick-runner`. The chain was structural-only — no job consumed upstream `outputs:` (verified by grep). The only genuine data dependency (`coverage-floor` downloading the `coverage-xml` artifact from `test`) is preserved.

## Before

```
pick-runner -> lint -> typecheck -> test -> coverage-floor
            -> file-size-budget -> todo-fixme -> security
            -> dependency-locks -> build
```

## After

```
pick-runner -> { lint, typecheck, test, file-size-budget, todo-fixme,
                 security, dependency-locks, build }      # all parallel
            -> coverage-floor (needs: test, artifact dep preserved)
            -> desktop-smoke (needs: build, artifact dep preserved)
```

## Why this matters — failure-visibility win for remediation agents

Under the old chain, **a single failing gate caused all downstream jobs to be SKIPPED**. Agents remediating a failing PR would:

1. Push fix
2. Wait 30+ min in the saturated runner queue
3. See ONE failure (the first gate to fail)
4. Fix it, push, wait again
5. Hit the NEXT failure
6. Repeat 6 more times

With 8 chained gate jobs this loop could consume **half a day per PR**. After this flatten, agents see **all** gate failures in a single CI cycle and can batch-fix them.

## Wallclock savings

Each `needs:` hop pays GitHub Actions queue-wait again on a saturated self-hosted runner pool. Eliminating 6 unnecessary serial hops should shave roughly **30–60 minutes per green-path PR** and **multiple hours** off red-path remediation cycles. Recent run history shows CI durations from 11 min (early failure) to 287+ min on successful long runs — the flatten directly compresses the long tail.

## Intentionally preserved `needs:`

| Job | Keeps | Reason |
|-----|-------|--------|
| `coverage-floor` | `[pick-runner, test]` | Downloads `coverage-xml` artifact from `test` |
| `desktop-smoke` | `build` | Downloads `dist` wheel artifact from `build` |

## Behavior preserved

- All job names unchanged — required-status-check rules unaffected
- `test` matrix retains `fail-fast: false`
- No `workflow_call` / `workflow_run` from sibling workflows depends on this one (verified)

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses
- [x] Grep confirms no job consumes `needs.<other>.outputs.*` from the flattened links
- [ ] First CI run on this PR fans out gate jobs in parallel after `pick-runner`

🤖 Generated with [Claude Code](https://claude.com/claude-code)