### PR TITLE
policy(ci): migrate hosted-runner workflows to d-sorg-fleet (keep guard tripwire on hosted)

### DIFF
--- a/.github/workflows/anti-phantom-merge.yml
+++ b/.github/workflows/anti-phantom-merge.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   guard:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     if: github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master'
     steps:
       - name: Checkout PR head with full history

--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Fleet-wide policy: no jobs may run on GitHub-hosted runners (`ubuntu-latest`, `windows-latest`, `macos-latest`). All work routes to the self-hosted `d-sorg-fleet` pool.

## Files / jobs migrated

| File | Job | Before | After |
|------|-----|--------|-------|
| `.github/workflows/anti-phantom-merge.yml` | `guard` | `ubuntu-latest` | `d-sorg-fleet` |
| `.github/workflows/lint-workflow-files.yml` | `lint` | `ubuntu-latest` | `d-sorg-fleet` |

## Intentionally left unchanged

- `.github/workflows/local-only-runner-guard.yml` — already on `d-sorg-fleet` in this repo (no `ubuntu-latest` to retain as tripwire).

All other workflows (`ci.yml`, `codeql.yml`, `docs.yml`, `lockfile-refresh.yml`, `maxwell-daemon-fleet-dispatch.yml`, `release.yml`) already use `d-sorg-fleet` or `\${{ needs.pick-runner.outputs.runner }}`.

## Verification

- `python -c "import yaml; yaml.safe_load(open(...))"` parses both files
- `git diff` shows only the two `runs-on:` line changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)