### PR TITLE
policy(ci): restore local-only-runner-guard tripwire to ubuntu-latest

### DIFF
--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 30
     name: Reject hosted runner routing
     needs: pick-runner
-    runs-on: ${{ needs.pick-runner.outputs.runner }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository without external actions
         shell: bash


### PR DESCRIPTION
This restores the named tripwire job to run on `ubuntu-latest`.

## Why this matters

The `local-only-workflows` job ("Reject hosted runner routing") exists as an intentional tripwire: it MUST run on GitHub-hosted infrastructure so that if any other workflow is mis-routed to hosted runners, this guard catches it and fails closed. A prior fleet-wide "move everything to d-sorg-fleet" campaign drifted this workflow too, which silently disabled the hosted-runner policy across the fleet.

This PR is surgical: it only touches the `runs-on:` line of the tripwire job. No other changes.

## Background

This is the ONLY workflow in the fleet that should run on `ubuntu-latest`. Co-restoring drift detected across 15 fleet repos.