### PR TITLE
ci: drop macOS leg from desktop-smoke matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [d-sorg-fleet, [self-hosted, macOS], [self-hosted, Windows]]
+        # macOS leg removed: org has zero macOS self-hosted runners, so the
+        # job sat queued for 200+ minutes and was eventually cancelled. Re-add
+        # only when a macOS runner is provisioned, or switch to `macos-14`
+        # (GH-hosted) if Actions-minute cost is acceptable.
+        os: [d-sorg-fleet, [self-hosted, Windows]]
     steps:
       - name: Clear stale checkout locks
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary
- Removes `[self-hosted, macOS]` from the `desktop-smoke` matrix in `.github/workflows/ci.yml`.
- The org has zero macOS self-hosted runners, so this leg sat queued for 200+ minutes on runs 26006047215 and 26007766345 before being cancelled.
- macOS is not an active deliverable for this repo; re-add later with `macos-14` (GH-hosted) or a provisioned self-hosted runner if needed.

## Test plan
- [ ] CI completes without the perpetually-queued macOS leg
- [ ] `local-only-runner-guard` workflow still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)