### PR TITLE
ci: fix anti-phantom-merge.yml gh CLI compatibility

### DIFF
--- a/.github/workflows/anti-phantom-merge.yml
+++ b/.github/workflows/anti-phantom-merge.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   guard:
     runs-on: d-sorg-fleet
+    timeout-minutes: 10
     if: github.event.pull_request.base.ref == 'main' || github.event.pull_request.base.ref == 'master'
     steps:
       - name: Checkout PR head with full history

--- a/.github/workflows/anti-phantom-merge.yml
+++ b/.github/workflows/anti-phantom-merge.yml
@@ -54,7 +54,7 @@ jobs:
           FILES=$(echo "$STATS" | jq -r .changedFiles)
           TITLE=$(gh pr view "$PR" --repo "$REPO" --json title --jq .title)
           BODY=$(gh pr view "$PR" --repo "$REPO" --json body --jq .body)
-          PR_FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only)
+          PR_FILES=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename')
 
           FAIL=""
           fail() { FAIL="${FAIL}- $1\n"; }


### PR DESCRIPTION
## Summary

The fleet runners ship `gh 2.4`; `gh pr diff --name-only` was added in a later release, so the anti-phantom guard step in `.github/workflows/anti-phantom-merge.yml` exits 1 with `unknown flag: --name-only` on every PR before any rule logic runs.

Swap to the API-call form (already adopted by [Repository_Management](https://github.com/D-sorganization/Repository_Management/blob/main/.github/workflows/anti-phantom-merge.yml) and [Controls](https://github.com/D-sorganization/Controls/pull/196)):

```
gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename'
```

This unblocks at minimum [#888](https://github.com/D-sorganization/Maxwell_Daemon/pull/888) and [#889](https://github.com/D-sorganization/Maxwell_Daemon/pull/889) which are both held up on the guard step.

## Test plan

- [x] YAML syntax / shell substitution checked locally
- [ ] CI green on this PR
- [ ] Verify by retrying a previously-blocked PR after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)