### PR TITLE
test(ci): update concurrency-group assertion to match lint policy

### DIFF
--- a/tests/unit/test_fleet_dispatch_workflow.py
+++ b/tests/unit/test_fleet_dispatch_workflow.py
@@ -90,4 +90,7 @@ class TestJobShape:
         data = _load()
         conc = data["concurrency"]
         assert conc["group"] == "maxwell-daemon-fleet-dispatch"
-        assert conc["cancel-in-progress"] is False
+        # cancel-in-progress: true is required by the workflow lint policy
+        # introduced in lint-workflow-files.yml to prevent queue saturation
+        # (see: post-2026-05-15 fleet-queue protection rule).
+        assert conc["cancel-in-progress"] is True


### PR DESCRIPTION
## Summary

- The `lint-workflow-files.yml` workflow lint rule requires `cancel-in-progress: true` on all workflows (added post-2026-05-15 to prevent queue saturation on the fleet).
- Commit 9739b27 updated `maxwell-daemon-fleet-dispatch.yml` to satisfy this rule, changing `cancel-in-progress: false` → `true`.
- `TestJobShape::test_concurrency_group_set` was not updated to match and has been failing on all Python versions (`assert True is False`).
- This PR updates the assertion from `is False` to `is True` with an explanatory comment.

Closes #891 (partially — the test flakiness issue has already been fixed by the `skipif` markers added in #892; this PR addresses the remaining CI failure).

## Test plan
- [x] `pytest tests/unit/test_fleet_dispatch_workflow.py` passes locally (9/9 tests pass)
- [x] No logic changes — test assertion updated to match current workflow policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)