### PR TITLE
fix(ci): correct download-artifact version from @v8 to @v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: 'pip'
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v4
         with:
           name: coverage-xml
       - run: python scripts/check_coverage_floor.py --xml coverage.xml
@@ -342,7 +342,7 @@ jobs:
         with:
           python-version: "3.12"
           cache: 'pip'
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
## Summary

`actions/download-artifact@v8` does not exist (latest is v4). This invalid version caused the `local-only-runner-guard.yml` workflow to report \"This run likely failed because of a workflow file issue\" on every push after PR #920 was merged.

Fixes: two uses of `@v8` in the `coverage-floor` and `desktop-smoke` jobs in `.github/workflows/ci.yml`.

## Test plan
- [x] Pre-commit YAML check passes
- [ ] CI guard workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)