### PR TITLE
feat(tracing): instrument daemon dispatch path with OTel spans

### DIFF
--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -61,6 +61,7 @@ from maxwell_daemon.events import Event, EventBus, EventKind, attach_observabili
 from maxwell_daemon.fleet.capabilities import InMemoryFleetCapabilityRegistry
 from maxwell_daemon.logging import get_logger
 from maxwell_daemon.metrics import record_request
+from maxwell_daemon.tracing import span as _trace_span
 
 log = get_logger("maxwell_daemon.daemon")
 
@@ -1599,39 +1600,58 @@ class Daemon:
                 )
             )
             self._record_stream_event(task.id, EventKind.TASK_STARTED.value)
-            snapshot.budget.require_under_budget()
-            decision = snapshot.router.route(
-                repo=task.repo,
-                backend_override=task.backend,
-                model_override=task.model,
-            )
-            task.backend = decision.backend_name
-            task.route_reason = decision.reason
-            if task.kind is not TaskKind.ISSUE:
-                task.model = decision.model
-            decision_backend = task.backend
-            decision_model = task.model or decision.model
-            try:
-                self._task_store.save(task)
-            except Exception:
-                log.exception("task store write failed while recording route for task=%s", task.id)
+            # Wrap the dispatch path (routing → backend completion) in a span so
+            # a trace shows the task lifecycle end-to-end. The span is a no-op
+            # when tracing is disabled (zero-cost default install). Exceptions
+            # propagate *through* the span — it records them and sets an ERROR
+            # status — and are then handled by the except clauses below.
+            async with _trace_span(
+                "maxwell_daemon.task.dispatch",
+                {"task_id": task.id, "kind": task.kind.value},
+            ):
+                snapshot.budget.require_under_budget()
+                decision = snapshot.router.route(
+                    repo=task.repo,
+                    backend_override=task.backend,
+                    model_override=task.model,
+                )
+                task.backend = decision.backend_name
+                task.route_reason = decision.reason
+                if task.kind is not TaskKind.ISSUE:
+                    task.model = decision.model
+                decision_backend = task.backend
+                decision_model = task.model or decision.model
+                try:
+                    self._task_store.save(task)
+                except Exception:
+                    log.exception(
+                        "task store write failed while recording route for task=%s", task.id
+                    )
 
-            if task.kind is TaskKind.ISSUE:
-                await self._execute_issue(task, decision)
-                return
+                if task.kind is TaskKind.ISSUE:
+                    await self._execute_issue(task, decision)
+                    return
 
-            prompt_content = task.prompt
-            if task.repo and repo_path:
-                from maxwell_daemon.core.repo_overrides import RepoSchematic
+                prompt_content = task.prompt
+                if task.repo and repo_path:
+                    from maxwell_daemon.core.repo_overrides import RepoSchematic
 
-                schematic = RepoSchematic(task.repo, repo_path).generate()
-                prompt_content = f"{schematic}\n\n{prompt_content}"
+                    schematic = RepoSchematic(task.repo, repo_path).generate()
+                    prompt_content = f"{schematic}\n\n{prompt_content}"
 
-            resp = await decision.backend.complete(
-                [Message(role=MessageRole.USER, content=prompt_content)],
-                model=decision.model,
-                dry_run=task.dry_run,
-            )
+                async with _trace_span(
+                    "maxwell_daemon.task.backend_complete",
+                    {
+                        "task_id": task.id,
+                        "backend": decision.backend_name,
+                        "model": decision.model,
+                    },
+                ):
+                    resp = await decision.backend.complete(
+                        [Message(role=MessageRole.USER, content=prompt_content)],
+                        model=decision.model,
+                        dry_run=task.dry_run,
+                    )
             task.result = resp.content
             estimated_cost = decision.backend.estimate_cost(resp.usage, decision.model)
             task.cost_usd = estimated_cost if estimated_cost is not None else 0.0

--- a/tests/unit/test_daemon_tracing.py
+++ b/tests/unit/test_daemon_tracing.py
@@ -1,0 +1,169 @@
+"""Daemon dispatch path emits OTel spans when tracing is configured.
+
+Phase 2 observability slice of #896: the daemon's task dispatch path
+(``Daemon._execute``) is instrumented with spans so a trace shows the
+end-to-end lifecycle of a prompt task — dispatch wrapper plus the backend
+completion call nested inside it.
+
+These tests use the in-memory exporter the tracing module already supports
+(``configure_tracing(use_memory_exporter=True)``) so they assert real span
+emission without an OTLP collector.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import TypeVar
+
+from maxwell_daemon.backends import registry
+from maxwell_daemon.config import MaxwellDaemonConfig
+from maxwell_daemon.daemon import Daemon
+from maxwell_daemon.daemon.runner import Task, TaskStatus
+from maxwell_daemon.tracing import _test_exporter, configure_tracing
+
+T = TypeVar("T")
+
+
+async def _wait_for_status(
+    daemon: Daemon, task_id: str, expected: TaskStatus, timeout: float = 10.0
+) -> Task:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        task = daemon.get_task(task_id)
+        if task and task.status == expected:
+            return task
+        await asyncio.sleep(0.02)
+    task = daemon.get_task(task_id)
+    if task and task.status == expected:
+        return task
+    raise AssertionError(
+        f"task {task_id} did not reach {expected}; final={task.status if task else None}"
+    )
+
+
+async def _with_daemon(
+    config: MaxwellDaemonConfig,
+    ledger_path: Path,
+    *,
+    body: Callable[[Daemon], Awaitable[T]],
+) -> T:
+    d = Daemon(
+        config,
+        ledger_path=ledger_path,
+        task_store_path=ledger_path.with_suffix(".tasks.db"),
+    )
+    await d.start(worker_count=1)
+    try:
+        return await body(d)
+    finally:
+        await d.stop()
+
+
+class TestDispatchSpans:
+    def test_prompt_dispatch_emits_dispatch_and_backend_spans(
+        self,
+        minimal_config: MaxwellDaemonConfig,
+        isolated_ledger_path: Path,
+    ) -> None:
+        try:
+            configure_tracing(use_memory_exporter=True)
+
+            async def _body(d: Daemon) -> None:
+                task = d.submit("hello", backend="primary")
+                await _wait_for_status(d, task.id, TaskStatus.COMPLETED)
+
+            asyncio.run(_with_daemon(minimal_config, isolated_ledger_path, body=_body))
+
+            names = {s.name for s in _test_exporter().get_finished_spans()}
+            assert "maxwell_daemon.task.dispatch" in names
+            assert "maxwell_daemon.task.backend_complete" in names
+        finally:
+            configure_tracing(endpoint=None)
+
+    def test_dispatch_span_carries_task_attributes(
+        self,
+        minimal_config: MaxwellDaemonConfig,
+        isolated_ledger_path: Path,
+    ) -> None:
+        try:
+            configure_tracing(use_memory_exporter=True)
+
+            async def _body(d: Daemon) -> str:
+                task = d.submit("hello", backend="primary")
+                await _wait_for_status(d, task.id, TaskStatus.COMPLETED)
+                return task.id
+
+            task_id = asyncio.run(_with_daemon(minimal_config, isolated_ledger_path, body=_body))
+
+            dispatch = next(
+                s
+                for s in _test_exporter().get_finished_spans()
+                if s.name == "maxwell_daemon.task.dispatch"
+            )
+            assert dispatch.attributes["task_id"] == task_id
+            assert dispatch.attributes["kind"] == "prompt"
+        finally:
+            configure_tracing(endpoint=None)
+
+    def test_failed_dispatch_records_exception_on_span(
+        self,
+        isolated_ledger_path: Path,
+    ) -> None:
+        from maxwell_daemon.backends.base import (
+            BackendCapabilities,
+            BackendResponse,
+            ILLMBackend,
+            Message,
+        )
+
+        class _RaisingBackend(ILLMBackend):
+            name = "recording"
+
+            def __init__(self, **_: object) -> None:
+                pass
+
+            async def complete(
+                self, messages: list[Message], *, model: str, **_: object
+            ) -> BackendResponse:
+                raise RuntimeError("backend boom")
+
+            async def stream(self, *a: object, **k: object):  # type: ignore[no-untyped-def]
+                if False:
+                    yield ""
+
+            async def health_check(self) -> bool:
+                return True
+
+            def capabilities(self, model: str) -> BackendCapabilities:
+                return BackendCapabilities()
+
+        try:
+            configure_tracing(use_memory_exporter=True)
+            registry._factories["recording"] = _RaisingBackend  # type: ignore[assignment]
+            config = MaxwellDaemonConfig.model_validate(
+                {
+                    "backends": {"primary": {"type": "recording", "model": "test-model"}},
+                    "agent": {"default_backend": "primary"},
+                }
+            )
+
+            async def _body(d: Daemon) -> None:
+                task = d.submit("hello", backend="primary")
+                await _wait_for_status(d, task.id, TaskStatus.FAILED)
+
+            asyncio.run(_with_daemon(config, isolated_ledger_path, body=_body))
+
+            dispatch_spans = [
+                s
+                for s in _test_exporter().get_finished_spans()
+                if s.name == "maxwell_daemon.task.dispatch"
+            ]
+            assert dispatch_spans, "dispatch span should be emitted even on failure"
+            # The span records the exception and sets an ERROR status because
+            # the backend error propagates through the span context manager.
+            assert any(s.status.status_code.name == "ERROR" for s in dispatch_spans)
+        finally:
+            registry._factories.pop("recording", None)
+            configure_tracing(endpoint=None)


### PR DESCRIPTION
## Summary

Phase 2 observability slice of #896. The tracing module (`maxwell_daemon/tracing.py`) shipped optional OTLP span infra, but the daemon dispatch path was never instrumented. This wires spans around `Daemon._execute`:

- `maxwell_daemon.task.dispatch` — wraps routing + backend completion (attributes: `task_id`, `kind`)
- `maxwell_daemon.task.backend_complete` — nested span around the backend `.complete()` call (attributes: `task_id`, `backend`, `model`)

Exceptions propagate **through** the span context manager (recording the exception + setting ERROR status) before reaching the existing `except` handlers, so failed dispatches are visible in traces. Spans are zero-cost no-ops when tracing is disabled, preserving the small default install.

## Tests

`tests/unit/test_daemon_tracing.py` (3 tests, in-memory exporter):
- dispatch + backend spans emitted on success
- dispatch span carries `task_id`/`kind` attributes
- ERROR status recorded on backend failure

## Principles

- **TDD** — tests written first against the in-memory exporter
- **DbC** — span attributes are postconditions asserted by tests
- **DRY** — reuses the same `tracing.span` helper as `gh/executor.py`
- **LoD** — runner only talks to the `span()` helper

Phase 1 is already done on main; Phases 3-4 are out of scope.

Part of #896

🤖 Generated with [Claude Code](https://claude.com/claude-code)