### PR TITLE
fix(task-store): persist depends_on/dry_run and honor created_before (#970 #977)

### DIFF
--- a/maxwell_daemon/core/task_store.py
+++ b/maxwell_daemon/core/task_store.py
@@ -36,6 +36,7 @@ outside an event loop.
 from __future__ import annotations
 
 import asyncio
+import json
 import sqlite3
 import threading
 from collections.abc import Iterator
@@ -81,7 +82,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     started_at TEXT,
     finished_at TEXT,
     dispatched_to TEXT,
-    side_effects_started INTEGER NOT NULL DEFAULT 0
+    side_effects_started INTEGER NOT NULL DEFAULT 0,
+    depends_on TEXT NOT NULL DEFAULT '[]',
+    dry_run INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at);
@@ -114,6 +117,10 @@ _MIGRATIONS = [
         "side_effects_started",
         "ALTER TABLE tasks ADD COLUMN side_effects_started INTEGER NOT NULL DEFAULT 0",
     ),
+    # DAG edges and dry-run flag must survive restart, else recovered tasks lose
+    # their dependency ordering and dry-run tasks re-run live (issue #970).
+    ("depends_on", "ALTER TABLE tasks ADD COLUMN depends_on TEXT NOT NULL DEFAULT '[]'"),
+    ("dry_run", "ALTER TABLE tasks ADD COLUMN dry_run INTEGER NOT NULL DEFAULT 0"),
 ]
 
 _TERMINAL_STATUS_VALUES = ("completed", "failed", "cancelled")
@@ -210,6 +217,8 @@ class TaskStore:
             _iso(task.finished_at),
             task.dispatched_to,
             int(task.side_effects_started),
+            json.dumps(list(task.depends_on)),
+            int(task.dry_run),
             _completed_at(task),
         )
         with self._lock, self._connect() as conn:
@@ -222,11 +231,13 @@ class TaskStore:
                     thread_id, turn_count, max_turns,
                     priority, result, error, waived_by, waiver_reason,
                     waived_at, pr_url, cost_usd, started_at,
-                    finished_at, dispatched_to, side_effects_started, completed_at
+                    finished_at, dispatched_to, side_effects_started,
+                    depends_on, dry_run, completed_at
                 ) VALUES (
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?
                 )
                 ON CONFLICT(id) DO UPDATE SET
                     updated_at=excluded.updated_at,
@@ -253,6 +264,8 @@ class TaskStore:
                     started_at=excluded.started_at, finished_at=excluded.finished_at,
                     dispatched_to=excluded.dispatched_to,
                     side_effects_started=excluded.side_effects_started,
+                    depends_on=excluded.depends_on,
+                    dry_run=excluded.dry_run,
                     completed_at=excluded.completed_at
                 """,
                 row,
@@ -465,6 +478,7 @@ class TaskStore:
             kind=kind,
             cursor=cursor,
             completed_before=completed_before,
+            created_before=created_before,
         )
 
     def recover_pending(self) -> list[Task]:
@@ -543,6 +557,7 @@ class TaskStore:
                 kind=kind,
                 cursor=cursor,
                 completed_before=completed_before,
+                created_before=created_before,
             ),
         )
 
@@ -606,6 +621,15 @@ def _row_to_task(row: sqlite3.Row) -> Task:
         waived_at = row["waived_at"]
     except (IndexError, KeyError):
         waived_at = None
+    try:
+        raw_depends_on = row["depends_on"]
+        depends_on = list(json.loads(raw_depends_on)) if raw_depends_on else []
+    except (IndexError, KeyError, ValueError, TypeError):
+        depends_on = []
+    try:
+        dry_run = bool(row["dry_run"])
+    except (IndexError, KeyError):
+        dry_run = False
 
     return Task(
         id=row["id"],
@@ -636,4 +660,6 @@ def _row_to_task(row: sqlite3.Row) -> Task:
         finished_at=_parse_iso(row["finished_at"]),
         dispatched_to=dispatched_to,
         side_effects_started=side_effects_started,
+        depends_on=depends_on,
+        dry_run=dry_run,
     )

--- a/tests/unit/test_task_store.py
+++ b/tests/unit/test_task_store.py
@@ -136,6 +136,130 @@ class TestList:
 
         assert [task.id for task in listed] == [old.id]
 
+    def test_filter_by_created_before(self, store: TaskStore) -> None:
+        # Regression for #964/#977: list_tasks/alist_tasks silently dropped the
+        # created_before filter, so creation-time pagination repeated page one.
+        old = _fresh_task(created_at=datetime.now(timezone.utc) - timedelta(days=8))
+        recent = _fresh_task(created_at=datetime.now(timezone.utc))
+        store.save(old)
+        store.save(recent)
+
+        listed = store.list_tasks(
+            limit=10,
+            created_before=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+
+        assert [task.id for task in listed] == [old.id]
+
+    def test_created_before_paginates_instead_of_repeating(self, store: TaskStore) -> None:
+        base = datetime.now(timezone.utc)
+        tasks = [_fresh_task(created_at=base - timedelta(hours=i)) for i in range(3)]
+        for task in tasks:
+            store.save(task)
+
+        # First page: newest only.
+        page1 = store.list_tasks(limit=1)
+        assert page1[0].id == tasks[0].id
+
+        # Second page keyed on the oldest seen created_at must advance, not repeat.
+        page2 = store.list_tasks(limit=1, created_before=page1[0].created_at)
+        assert page2[0].id == tasks[1].id
+        assert page2[0].id != page1[0].id
+
+    async def test_alist_created_before_filters(self, store: TaskStore) -> None:
+        old = _fresh_task(created_at=datetime.now(timezone.utc) - timedelta(days=8))
+        recent = _fresh_task(created_at=datetime.now(timezone.utc))
+        store.save(old)
+        store.save(recent)
+
+        listed = await store.alist_tasks(
+            limit=10,
+            created_before=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+
+        assert [task.id for task in listed] == [old.id]
+
+
+class TestDependsOnAndDryRunPersistence:
+    """Regression for #970: DAG edges and dry_run must survive save/restart."""
+
+    def test_roundtrips_depends_on_and_dry_run(self, store: TaskStore) -> None:
+        task = _fresh_task(depends_on=["dep-a", "dep-b"], dry_run=True)
+        store.save(task)
+
+        loaded = store.get(task.id)
+
+        assert loaded is not None
+        assert loaded.depends_on == ["dep-a", "dep-b"]
+        assert loaded.dry_run is True
+
+    def test_defaults_when_unset(self, store: TaskStore) -> None:
+        task = _fresh_task()
+        store.save(task)
+
+        loaded = store.get(task.id)
+
+        assert loaded is not None
+        assert loaded.depends_on == []
+        assert loaded.dry_run is False
+
+    def test_survives_recover_pending(self, store: TaskStore) -> None:
+        # A queued task with unmet deps must not lose its edges across restart —
+        # otherwise it would run immediately and a dry_run task would run live.
+        task = _fresh_task(depends_on=["upstream"], dry_run=True)
+        store.save(task)
+
+        recovered = {t.id: t for t in store.recover_pending()}
+
+        assert task.id in recovered
+        assert recovered[task.id].depends_on == ["upstream"]
+        assert recovered[task.id].dry_run is True
+
+    def test_migration_applies_to_legacy_db(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        db = tmp_path / "legacy.db"
+        # Simulate a pre-#970 DB: tasks table without depends_on / dry_run.
+        with sqlite3.connect(db) as conn:
+            conn.execute(
+                """
+                CREATE TABLE tasks (
+                    id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    prompt TEXT NOT NULL,
+                    repo TEXT, backend TEXT, model TEXT, route_reason TEXT,
+                    issue_repo TEXT, issue_number INTEGER, issue_mode TEXT,
+                    result TEXT, error TEXT, pr_url TEXT,
+                    cost_usd REAL NOT NULL DEFAULT 0,
+                    started_at TEXT, finished_at TEXT
+                )
+                """
+            )
+            now = datetime.now(timezone.utc).isoformat()
+            conn.execute(
+                "INSERT INTO tasks (id, created_at, updated_at, kind, status, prompt) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("legacy-1", now, now, TaskKind.PROMPT.value, TaskStatus.QUEUED.value, "x"),
+            )
+            conn.commit()
+
+        # Opening with TaskStore must migrate cleanly and read legacy rows.
+        store = TaskStore(db)
+        loaded = store.get("legacy-1")
+        assert loaded is not None
+        assert loaded.depends_on == []
+        assert loaded.dry_run is False
+
+        # And new writes round-trip the new columns.
+        store.save(_fresh_task(id="new-1", depends_on=["legacy-1"], dry_run=True))
+        new = store.get("new-1")
+        assert new is not None
+        assert new.depends_on == ["legacy-1"]
+        assert new.dry_run is True
+
 
 class TestRecoverPending:
     def test_recovers_queued(self, store: TaskStore) -> None:


### PR DESCRIPTION
## Summary

Two P1 daemon-correctness fixes in `maxwell_daemon/core/task_store.py`, both proven by regression tests.

### #977 — `created_before` filter silently discarded
`list_tasks` / `alist_tasks` accepted `created_before` but never forwarded it to `_list_sync`, so creation-time pagination loops repeated page one forever. Now forwarded in both sync and async wrappers.

### #970 — `depends_on` / `dry_run` not persisted
The `tasks` table had no columns for these, so recovered tasks came back with `depends_on=[]` / `dry_run=False`. On restart a queued task with unmet deps ran immediately, and a `dry_run=True` task re-ran live (real spend, real PRs). Added a JSON `depends_on` column and an integer `dry_run` column to the base schema and to `_MIGRATIONS` (legacy DBs upgrade cleanly), wrote them in `_save_sync`, and restored them in `_row_to_task`.

## Tests
- `created_before` filters in sync + async wrappers; pagination advances instead of repeating.
- `depends_on` / `dry_run` round-trip through save/load; defaults when unset; survive `recover_pending`; legacy-DB migration applies cleanly and round-trips new writes.

All 34 `test_task_store.py` tests pass; ruff + ruff format + `mypy --strict` clean.

Closes #970
Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)