### PR TITLE
fix(security): SSH safe-closed + session-pool credential isolation + reject wildcard CORS (#965 #966 #968)

### DIFF
--- a/maxwell_daemon/api/routes/ssh.py
+++ b/maxwell_daemon/api/routes/ssh.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json as _json_mod
 from typing import Any
 
-from fastapi import Depends, FastAPI, Query, WebSocket, WebSocketDisconnect, status
+from fastapi import Depends, FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect, status
 from pydantic import BaseModel
 
 from maxwell_daemon.audit import AuditLogger
@@ -27,6 +27,33 @@ __all__ = [
     "SSHRunRequest",
     "register",
 ]
+
+
+def make_require_auth_configured(auth_token: str | None, jwt_config: JWTConfig | None) -> Any:
+    """Return a dependency that fails *closed* when no auth is configured.
+
+    SSH endpoints expose remote command execution against any host with a
+    stored/agent key. Unlike read-only routes, they must never run in the
+    fully-open dev mode that ``make_rbac_dep`` falls back to when neither a
+    static ``auth_token`` nor a ``jwt_config`` is set (issue #965). This guard
+    mirrors the safe-closed contract of ``POST /api/dispatch``: with no auth
+    configured the request is rejected before any side effect, returning
+    ``503 Service Unavailable`` (the server is misconfigured for this surface)
+    rather than silently admitting an unauthenticated caller.
+    """
+
+    async def _dep() -> None:
+        if auth_token is None and jwt_config is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "SSH endpoints are disabled: configure api.auth_token or "
+                    "api.jwt_secret to enable authenticated SSH access."
+                ),
+            )
+
+    return _dep
+
 
 _SSH_ALLOWED_COMMANDS: frozenset[str] = frozenset({"bash", "sh", "zsh", "fish", "rbash"})
 
@@ -58,6 +85,11 @@ def register(  # noqa: C901
 ) -> None:
     """Attach SSH endpoints to ``app``."""
 
+    # Safe-closed guard: SSH (remote command execution) must reject every
+    # request when no auth is configured, instead of falling through to the
+    # open dev mode that ``require_admin`` permits (issue #965).
+    require_auth_configured = make_require_auth_configured(auth_token, jwt_config)
+
     _ssh_pool_ref: dict[str, Any] = {}
 
     def _ssh_pool() -> Any:
@@ -80,7 +112,10 @@ def register(  # noqa: C901
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
 
-    @app.get("/api/v1/ssh/sessions", dependencies=[Depends(require_admin)])
+    @app.get(
+        "/api/v1/ssh/sessions",
+        dependencies=[Depends(require_auth_configured), Depends(require_admin)],
+    )
     async def ssh_sessions() -> Any:
         """List active SSH sessions."""
         pool = _ssh_pool()
@@ -88,7 +123,10 @@ def register(  # noqa: C901
             return _ssh_unavailable()
         return {"sessions": pool.sessions()}
 
-    @app.get("/api/v1/ssh/keys", dependencies=[Depends(require_admin)])
+    @app.get(
+        "/api/v1/ssh/keys",
+        dependencies=[Depends(require_auth_configured), Depends(require_admin)],
+    )
     async def ssh_list_keys() -> Any:
         """List machines that have stored SSH keys."""
         try:
@@ -98,7 +136,10 @@ def register(  # noqa: C901
         store = SSHKeyStore()
         return {"machines": store.list_machines()}
 
-    @app.get("/api/v1/ssh/keys/{machine}", dependencies=[Depends(require_admin)])
+    @app.get(
+        "/api/v1/ssh/keys/{machine}",
+        dependencies=[Depends(require_auth_configured), Depends(require_admin)],
+    )
     async def ssh_get_key(machine: str) -> Any:
         """Return the public key for *machine*, generating it if absent."""
         try:
@@ -109,7 +150,10 @@ def register(  # noqa: C901
         _, pub = store.get_or_generate(machine)
         return {"machine": machine, "public_key": pub}
 
-    @app.delete("/api/v1/ssh/keys/{machine}", dependencies=[Depends(require_admin)])
+    @app.delete(
+        "/api/v1/ssh/keys/{machine}",
+        dependencies=[Depends(require_auth_configured), Depends(require_admin)],
+    )
     async def ssh_delete_key(machine: str) -> Any:
         """Remove stored SSH keys for *machine*."""
         try:
@@ -119,7 +163,10 @@ def register(  # noqa: C901
         SSHKeyStore().remove(machine)
         return {"machine": machine, "deleted": True}
 
-    @app.post("/api/v1/ssh/connect", dependencies=[Depends(auth), Depends(require_admin)])
+    @app.post(
+        "/api/v1/ssh/connect",
+        dependencies=[Depends(require_auth_configured), Depends(auth), Depends(require_admin)],
+    )
     async def ssh_connect(payload: SSHConnectRequest) -> Any:
         """Open (or reuse) an SSH session and return its summary."""
         pool = _ssh_pool()
@@ -138,7 +185,10 @@ def register(  # noqa: C901
             "age_seconds": round(session.age_seconds, 1),
         }
 
-    @app.post("/api/v1/ssh/run", dependencies=[Depends(auth), Depends(require_admin)])
+    @app.post(
+        "/api/v1/ssh/run",
+        dependencies=[Depends(require_auth_configured), Depends(auth), Depends(require_admin)],
+    )
     async def ssh_run(payload: SSHRunRequest) -> Any:
         """Run a command on a remote machine and return its output."""
         pool = _ssh_pool()
@@ -152,7 +202,10 @@ def register(  # noqa: C901
             "exit_code": result.exit_code,
         }
 
-    @app.get("/api/v1/ssh/files", dependencies=[Depends(require_admin)])
+    @app.get(
+        "/api/v1/ssh/files",
+        dependencies=[Depends(require_auth_configured), Depends(require_admin)],
+    )
     async def ssh_list_files(
         host: str = Query(...),
         user: str = Query(...),
@@ -196,6 +249,11 @@ def register(  # noqa: C901
         Session ends when the command exits or the client disconnects.
         Max session duration: 1 hour.
         """
+        # Safe-closed: refuse the interactive shell entirely when no auth is
+        # configured, rather than admitting via open dev mode (issue #965).
+        if auth_token is None and jwt_config is None:
+            await ws.close(code=status.WS_1008_POLICY_VIOLATION, reason="SSH auth not configured")
+            return
         if not await websocket_auth_or_close(
             ws,
             Role.admin,

--- a/maxwell_daemon/api/routes/ssh.py
+++ b/maxwell_daemon/api/routes/ssh.py
@@ -13,7 +13,7 @@ import json as _json_mod
 from typing import Any
 
 from fastapi import Depends, FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from maxwell_daemon.audit import AuditLogger
 from maxwell_daemon.auth import JWTConfig, Role
@@ -62,7 +62,10 @@ class SSHConnectRequest(BaseModel):
     host: str
     port: int = 22
     user: str
-    password: str | None = None
+    # repr=False keeps the plaintext password out of model repr / tracebacks /
+    # structured-log dumps; it is still accepted in the request body and passed
+    # to the SSH layer, never logged (issue #966).
+    password: str | None = Field(default=None, repr=False)
 
 
 class SSHRunRequest(BaseModel):

--- a/maxwell_daemon/config/models.py
+++ b/maxwell_daemon/config/models.py
@@ -312,7 +312,12 @@ class APIConfig(BaseModel):
         default_factory=list,
         description=(
             "Allowed CORS origins. Empty list disables CORS middleware. "
-            'Use ["*"] for development only — never in production.'
+            "List explicit origins, e.g. "
+            '["https://your-dashboard.example.com"]. The wildcard "*" is '
+            "rejected: the API serves credentialed responses "
+            "(allow_credentials=True), and the browser CORS spec forbids "
+            'combining "*" with credentials — it would let any site issue '
+            "authenticated cross-origin requests."
         ),
     )
     # WebSocket connection cap (per-server process). Protects against connection
@@ -333,6 +338,23 @@ class APIConfig(BaseModel):
             raise ValueError(
                 f"Refusing to bind API to {self.host} without JWT configured. "
                 "Set api.jwt_secret to expose the daemon on a non-loopback interface."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_cors_origins(self) -> APIConfig:
+        # The CORS middleware is installed with allow_credentials=True, so it
+        # echoes the request Origin and sets Access-Control-Allow-Credentials.
+        # Combined with a "*" entry that would let *any* site make credentialed
+        # cross-origin requests once auth is wired up — the classic
+        # echo-origin + credentials hole. Reject it at config time rather than
+        # shipping an insecure middleware setup (issue #968).
+        if "*" in self.cors_allowed_origins:
+            raise ValueError(
+                'api.cors_allowed_origins must not contain "*": the API serves '
+                "credentialed responses (allow_credentials=True) and the CORS "
+                'spec forbids combining "*" with credentials. List explicit '
+                'origins instead, e.g. ["https://your-dashboard.example.com"].'
             )
         return self
 

--- a/maxwell_daemon/ssh/session.py
+++ b/maxwell_daemon/ssh/session.py
@@ -1,7 +1,15 @@
 """SSH session pool with async shell access and SFTP support.
 
-Sessions are cached by (host, port, user) and reused for up to
+Sessions are cached by ``(host, port, user, principal)`` and reused for up to
 ``SESSION_TTL_SECONDS``.  The pool evicts idle connections in the background.
+
+**Session reuse semantics (issue #966):** the *principal* component of the
+pool key is derived from the authenticating credential — a non-reversible
+SHA-256 digest of the password, or the sentinel ``"key"`` for key/agent auth.
+A session is therefore only reused by a caller presenting the *same*
+credential; a caller with a different password (or key-vs-password) opens a
+fresh connection and cannot ride another caller's authenticated session.  The
+plaintext password is never stored in the key, in ``repr``, or in logs.
 
 Usage::
 
@@ -22,6 +30,7 @@ Usage::
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -33,6 +42,24 @@ from maxwell_daemon.ssh.keys import SSHKeyStore, _require_asyncssh
 __all__ = ["CommandResult", "DirEntry", "SSHSession", "SSHSessionPool"]
 
 SESSION_TTL_SECONDS = 3600  # 1 hour max session lifetime
+
+# Sentinel principal used when authentication is key/agent based (no password).
+_KEY_AUTH_PRINCIPAL = "key"
+
+
+def _credential_principal(password: str | None) -> str:
+    """Derive a stable, non-reversible principal id for the auth material.
+
+    Sessions are pooled per *(host, port, user, principal)* so a caller can
+    only reuse a session that was opened with the *same* credential. We never
+    store the plaintext password — only a salted-domain SHA-256 digest — so the
+    principal can sit safely in an in-memory key and in repr/log output
+    (issue #966).
+    """
+    if password is None:
+        return _KEY_AUTH_PRINCIPAL
+    digest = hashlib.sha256(f"pw:{password}".encode()).hexdigest()
+    return f"pw:{digest}"
 
 
 @dataclass
@@ -150,9 +177,10 @@ class _PoolKey:
     host: str
     port: int
     user: str
+    principal: str = _KEY_AUTH_PRINCIPAL
 
     def __hash__(self) -> int:
-        return hash((self.host, self.port, self.user))
+        return hash((self.host, self.port, self.user, self.principal))
 
 
 class SSHSessionPool:
@@ -190,7 +218,15 @@ class SSHSessionPool:
     ) -> SSHSession:
         """Return a cached session for (host, port, user), creating one if needed."""
         asyncssh = _require_asyncssh()
-        key = _PoolKey(host=host, port=port, user=user)
+        # Scope the session to the authenticating principal so a caller with
+        # different credentials cannot ride another caller's open session for
+        # the same (host, port, user) tuple (issue #966).
+        key = _PoolKey(
+            host=host,
+            port=port,
+            user=user,
+            principal=_credential_principal(password),
+        )
 
         async with self._lock:
             existing = self._pool.get(key)

--- a/tests/integration/test_ssh_safe_closed.py
+++ b/tests/integration/test_ssh_safe_closed.py
@@ -1,0 +1,167 @@
+"""SSH admin endpoints fail *closed* when no auth is configured (issue #965).
+
+SSH routes expose remote command execution against any host that has a stored
+or agent SSH key. Before this fix they inherited the fully-open dev mode that
+``make_rbac_dep`` falls back to when neither a static ``auth_token`` nor a
+``jwt_config`` is configured — so an unauthenticated local process (or a
+browser via DNS-rebinding on 127.0.0.1) could run arbitrary remote commands.
+This contrasted with ``POST /api/dispatch``, which is safe-closed (refuses
+when no token is set).
+
+These tests prove every SSH route now rejects with ``503`` and never executes
+when no auth is configured, and that the safe-closed guard steps out of the way
+once auth *is* configured (the request then reaches the normal auth layer,
+which returns ``401`` for a missing token rather than ``503``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from maxwell_daemon.api import create_app
+from maxwell_daemon.config import MaxwellDaemonConfig
+from maxwell_daemon.daemon import Daemon
+
+# Every SSH route, as (method, path, json-body-or-None). The guard must fire
+# *before* any handler side effect, so a bogus body is fine.
+_SSH_ROUTES: list[tuple[str, str, dict[str, object] | None]] = [
+    ("GET", "/api/v1/ssh/sessions", None),
+    ("GET", "/api/v1/ssh/keys", None),
+    ("GET", "/api/v1/ssh/keys/somehost", None),
+    ("DELETE", "/api/v1/ssh/keys/somehost", None),
+    ("GET", "/api/v1/ssh/files?host=h&user=u", None),
+    (
+        "POST",
+        "/api/v1/ssh/connect",
+        {"host": "h", "port": 22, "user": "u"},
+    ),
+    (
+        "POST",
+        "/api/v1/ssh/run",
+        {"host": "h", "port": 22, "user": "u", "command": "id"},
+    ),
+]
+
+_STATIC_TOKEN = "s" * 32  # nosec B105
+
+
+def _make_config(**api: object) -> MaxwellDaemonConfig:
+    return MaxwellDaemonConfig.model_validate(
+        {
+            "backends": {"primary": {"type": "recording", "model": "test-model"}},
+            "agent": {"default_backend": "primary"},
+            "api": dict(api),
+        }
+    )
+
+
+def _make_daemon(
+    cfg: MaxwellDaemonConfig, tmp_path: Path
+) -> tuple[Daemon, asyncio.AbstractEventLoop]:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    daemon = Daemon(
+        cfg,
+        ledger_path=tmp_path / "ledger.db",
+        task_store_path=tmp_path / "tasks.db",
+        work_item_store_path=tmp_path / "work_items.db",
+        task_graph_store_path=tmp_path / "task_graphs.db",
+        artifact_store_path=tmp_path / "artifacts.db",
+        artifact_blob_root=tmp_path / "artifacts",
+        action_store_path=tmp_path / "actions.db",
+        delegate_lifecycle_store_path=tmp_path / "delegate_sessions.db",
+    )
+    loop.run_until_complete(daemon.start(worker_count=1))
+    return daemon, loop
+
+
+def _client(cfg: MaxwellDaemonConfig, tmp_path: Path) -> Iterator[TestClient]:
+    daemon, loop = _make_daemon(cfg, tmp_path)
+    # These tests cover the open-mode default and the static-token path only;
+    # JWT wiring is covered by tests/integration/test_serve_jwt_wiring.py.
+    app = create_app(daemon, auth_token=cfg.api.auth_token, jwt_config=None)
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        loop.run_until_complete(daemon.stop())
+        pending = asyncio.all_tasks(loop)
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.close()
+        asyncio.set_event_loop(None)
+
+
+@pytest.fixture
+def open_mode_client(register_recording_backend: None, tmp_path: Path) -> Iterator[TestClient]:
+    """App built with NO auth configured (the dangerous default)."""
+    yield from _client(_make_config(), tmp_path)
+
+
+@pytest.fixture
+def static_token_client(register_recording_backend: None, tmp_path: Path) -> Iterator[TestClient]:
+    """App built with a static admin token configured."""
+    yield from _client(_make_config(auth_token=_STATIC_TOKEN), tmp_path)
+
+
+def _call(client: TestClient, method: str, path: str, body: dict[str, object] | None):  # type: ignore[no-untyped-def]
+    if method == "GET":
+        return client.get(path)
+    if method == "DELETE":
+        return client.delete(path)
+    return client.post(path, json=body)
+
+
+class TestSshSafeClosedWhenUnconfigured:
+    """With no auth configured, every SSH route returns 503 and never runs."""
+
+    @pytest.mark.parametrize(("method", "path", "body"), _SSH_ROUTES)
+    def test_route_returns_503(
+        self,
+        open_mode_client: TestClient,
+        method: str,
+        path: str,
+        body: dict[str, object] | None,
+    ) -> None:
+        resp = _call(open_mode_client, method, path, body)
+        assert resp.status_code == 503, (method, path, resp.status_code, resp.text)
+        assert "auth" in resp.json()["detail"].lower()
+
+    def test_websocket_shell_closed_when_unconfigured(self, open_mode_client: TestClient) -> None:
+        from starlette.websockets import WebSocketDisconnect
+
+        with (
+            pytest.raises(WebSocketDisconnect) as excinfo,
+            open_mode_client.websocket_connect("/api/v1/ssh/shell?host=h&user=u") as ws,
+        ):
+            ws.receive_text()
+        assert excinfo.value.code == 1008
+
+
+class TestSshReachableWhenConfigured:
+    """Once auth is configured, the safe-closed guard steps aside.
+
+    The request then reaches the normal auth layer: a missing/invalid token is
+    a ``401`` (auth failure), distinctly *not* the ``503`` that means
+    "auth not configured". This proves the guard only suppresses the dangerous
+    open-mode default and does not block legitimately-secured deployments.
+    """
+
+    @pytest.mark.parametrize(("method", "path", "body"), _SSH_ROUTES)
+    def test_route_not_503_when_token_configured(
+        self,
+        static_token_client: TestClient,
+        method: str,
+        path: str,
+        body: dict[str, object] | None,
+    ) -> None:
+        resp = _call(static_token_client, method, path, body)
+        assert resp.status_code != 503, (method, path, resp.text)
+        assert resp.status_code == 401, (method, path, resp.status_code, resp.text)

--- a/tests/integration/test_ssh_safe_closed.py
+++ b/tests/integration/test_ssh_safe_closed.py
@@ -145,6 +145,18 @@ class TestSshSafeClosedWhenUnconfigured:
         assert excinfo.value.code == 1008
 
 
+class TestSshConnectPasswordRedaction:
+    """Issue #966 — the plaintext password never appears in model repr."""
+
+    def test_password_excluded_from_repr(self) -> None:
+        from maxwell_daemon.api.routes.ssh import SSHConnectRequest
+
+        req = SSHConnectRequest(host="h", user="u", password="s3cr3t-pw")
+        assert "s3cr3t-pw" not in repr(req)
+        # The value is still usable by the handler / SSH layer.
+        assert req.password == "s3cr3t-pw"
+
+
 class TestSshReachableWhenConfigured:
     """Once auth is configured, the safe-closed guard steps aside.
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -288,3 +288,32 @@ class TestAPIConfigJWT:
         assert secret is not None
         jwt_cfg = JWTConfig(secret, expiry_seconds=cfg.api.jwt_expiry_seconds)
         assert jwt_cfg.expiry_seconds == 1800
+
+
+class TestAPIConfigCors:
+    """Issue #968 — reject wildcard CORS origin with credentialed responses."""
+
+    def _base_cfg(self) -> dict[str, object]:
+        return {"backends": {"claude": {"type": "claude", "model": "claude-sonnet-4-6"}}}
+
+    def test_wildcard_origin_rejected(self) -> None:
+        raw = self._base_cfg()
+        raw["api"] = {"cors_allowed_origins": ["*"]}
+        with pytest.raises(ValueError, match=r'must not contain "\*"'):
+            MaxwellDaemonConfig.model_validate(raw)
+
+    def test_wildcard_rejected_even_among_explicit_origins(self) -> None:
+        raw = self._base_cfg()
+        raw["api"] = {"cors_allowed_origins": ["https://ok.example.com", "*"]}
+        with pytest.raises(ValueError, match=r'must not contain "\*"'):
+            MaxwellDaemonConfig.model_validate(raw)
+
+    def test_explicit_origins_allowed(self) -> None:
+        raw = self._base_cfg()
+        raw["api"] = {"cors_allowed_origins": ["https://dash.example.com"]}
+        cfg = MaxwellDaemonConfig.model_validate(raw)
+        assert cfg.api.cors_allowed_origins == ["https://dash.example.com"]
+
+    def test_empty_origins_default_disables_cors(self) -> None:
+        cfg = MaxwellDaemonConfig.model_validate(self._base_cfg())
+        assert cfg.api.cors_allowed_origins == []

--- a/tests/unit/test_ssh.py
+++ b/tests/unit/test_ssh.py
@@ -281,6 +281,64 @@ class TestSSHSessionPool:
 
         asyncio.run(_run())
 
+    def test_different_password_does_not_reuse_session(self, tmp_path: Path) -> None:
+        """Issue #966 — a caller with different credentials gets its own session.
+
+        Before the fix the pool key was only (host, port, user), so any caller
+        could ride an existing authenticated session for that tuple without
+        presenting matching credentials.
+        """
+        store = SSHKeyStore(tmp_path)
+        pool = SSHSessionPool(store, known_hosts=None)
+
+        def _conn() -> MagicMock:
+            c = MagicMock()
+            c.close = MagicMock()
+            c.wait_closed = AsyncMock()
+            return c
+
+        async def _run() -> tuple[SSHSession, SSHSession]:
+            with patch("asyncssh.connect", AsyncMock(side_effect=[_conn(), _conn()])) as connect:
+                s_a = await pool.get("myhost", user="ubuntu", password="alice-secret")
+                s_b = await pool.get("myhost", user="ubuntu", password="mallory-secret")
+                # Two distinct credentials → two distinct connections, no reuse.
+                assert connect.call_count == 2
+            return s_a, s_b
+
+        s_a, s_b = asyncio.run(_run())
+        assert s_a is not s_b
+
+    def test_same_password_reuses_session(self, tmp_path: Path) -> None:
+        """Issue #966 — identical credentials still pool to one session."""
+        store = SSHKeyStore(tmp_path)
+        pool = SSHSessionPool(store, known_hosts=None)
+
+        mock_conn = MagicMock()
+        mock_conn.close = MagicMock()
+        mock_conn.wait_closed = AsyncMock()
+
+        async def _run() -> tuple[SSHSession, SSHSession]:
+            with patch("asyncssh.connect", AsyncMock(return_value=mock_conn)) as connect:
+                s1 = await pool.get("myhost", user="ubuntu", password="same-secret")
+                s2 = await pool.get("myhost", user="ubuntu", password="same-secret")
+                assert connect.call_count == 1
+            return s1, s2
+
+        s1, s2 = asyncio.run(_run())
+        assert s1 is s2
+
+    def test_pool_key_principal_does_not_leak_password(self) -> None:
+        """Issue #966 — the principal is a digest, never the plaintext password."""
+        from maxwell_daemon.ssh.session import _credential_principal, _PoolKey
+
+        principal = _credential_principal("hunter2")
+        assert "hunter2" not in principal
+        assert principal.startswith("pw:")
+        # Key auth has a stable, password-free principal.
+        assert _credential_principal(None) == "key"
+        key = _PoolKey(host="h", port=22, user="u", principal=principal)
+        assert "hunter2" not in repr(key)
+
     def test_get_replaces_expired_session(self, tmp_path: Path) -> None:
         import time
 


### PR DESCRIPTION
## Summary

A focused SSH/CORS auth-security hardening PR closing three issues from epic #1000.

## #965 — SSH admin routes fail closed when no auth configured (P1)

SSH admin endpoints (`/api/v1/ssh/*`) expose **remote command execution** against any host with a stored or agent SSH key. They were gated only by `Depends(require_admin)`, but in the default config (no static `auth_token`, no `jwt_config`) the RBAC dependency falls through to fully-open dev mode — so an unauthenticated local process, or a browser via DNS-rebinding on `127.0.0.1`, could run arbitrary remote commands. This contrasted with `POST /api/dispatch`, which is safe-closed.

- New `make_require_auth_configured` dependency returns **503** before any side effect when neither auth mechanism is configured; applied to every SSH HTTP route.
- Equivalent early-close (WS 1008) on the `/api/v1/ssh/shell` WebSocket.
- When auth **is** configured the guard steps aside and the normal 401/403 layer runs unchanged.

## #966 — SSH session-pool credential isolation + password redaction (P2)

- The pool key was `(host, port, user)`, so any caller could ride an existing authenticated session for that tuple without presenting matching credentials. Added a `principal` component derived from the auth material — a SHA-256 digest of the password, or the `"key"` sentinel for key/agent auth — so a different-credential caller opens a fresh connection. The plaintext password is never stored in the key, repr, or logs.
- `SSHConnectRequest.password` is now `Field(repr=False)` so it cannot leak into model repr / tracebacks / structured-log dumps.
- Documented session-reuse semantics in the module docstring.

## #968 — Reject wildcard CORS origin with credentialed responses (P2)

The CORS middleware is installed with `allow_credentials=True`. A `"*"` origin then lets any site make credentialed cross-origin requests (echo-origin + credentials hole). Config validation now rejects `"*"` in `api.cors_allowed_origins`, and the field docstring no longer recommends it.

## Tests

- SSH safe-closed: every HTTP route returns 503 with no auth (parametrized), WS shell closes 1008, and with a static token every route returns 401 (not 503).
- SSH credential isolation: different passwords → no reuse; same password → reuse; principal digest never leaks the password; request `password` redacted from repr.
- CORS: wildcard rejected (alone and among explicit origins); explicit origins and empty default accepted.

All pass; `ruff check`, `ruff format --check`, `mypy --strict` clean on changed files; all changed lines covered.

Closes #965
Closes #966
Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)
