### PR TITLE
fix(daemon): bounded stall-retry, observable queue saturation, single-instance guard (#971 #972 #975)

### DIFF
--- a/maxwell_daemon/config/fleet.py
+++ b/maxwell_daemon/config/fleet.py
@@ -155,9 +155,15 @@ def _candidate_paths() -> list[Path]:
     if env:
         paths.append(Path(env))
     paths.append(Path.cwd() / _CWD_FILENAME)
-    home = os.environ.get("HOME")
-    if home:
-        paths.append(Path(home) / _DEFAULT_HOME_SUBPATH)
+    # ``Path.home()`` resolves the user home on every platform (USERPROFILE on
+    # Windows); ``os.environ["HOME"]`` is unset on Windows, which silently
+    # dropped the default ~/.maxwell-daemon/fleet.yaml candidate there (#981).
+    try:
+        home = Path.home()
+    except RuntimeError:
+        home = None
+    if home is not None:
+        paths.append(home / _DEFAULT_HOME_SUBPATH)
     return paths
 
 

--- a/maxwell_daemon/core/task_store.py
+++ b/maxwell_daemon/core/task_store.py
@@ -84,7 +84,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     dispatched_to TEXT,
     side_effects_started INTEGER NOT NULL DEFAULT 0,
     depends_on TEXT NOT NULL DEFAULT '[]',
-    dry_run INTEGER NOT NULL DEFAULT 0
+    dry_run INTEGER NOT NULL DEFAULT 0,
+    retry_count INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_created ON tasks(created_at);
@@ -121,6 +122,9 @@ _MIGRATIONS = [
     # their dependency ordering and dry-run tasks re-run live (issue #970).
     ("depends_on", "ALTER TABLE tasks ADD COLUMN depends_on TEXT NOT NULL DEFAULT '[]'"),
     ("dry_run", "ALTER TABLE tasks ADD COLUMN dry_run INTEGER NOT NULL DEFAULT 0"),
+    # Bounded stall-retry accounting (issue #971); persisted so retry budget
+    # survives daemon restart instead of resetting to zero.
+    ("retry_count", "ALTER TABLE tasks ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0"),
 ]
 
 _TERMINAL_STATUS_VALUES = ("completed", "failed", "cancelled")
@@ -219,6 +223,7 @@ class TaskStore:
             int(task.side_effects_started),
             json.dumps(list(task.depends_on)),
             int(task.dry_run),
+            task.retry_count,
             _completed_at(task),
         )
         with self._lock, self._connect() as conn:
@@ -232,12 +237,12 @@ class TaskStore:
                     priority, result, error, waived_by, waiver_reason,
                     waived_at, pr_url, cost_usd, started_at,
                     finished_at, dispatched_to, side_effects_started,
-                    depends_on, dry_run, completed_at
+                    depends_on, dry_run, retry_count, completed_at
                 ) VALUES (
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?
+                    ?, ?, ?
                 )
                 ON CONFLICT(id) DO UPDATE SET
                     updated_at=excluded.updated_at,
@@ -266,6 +271,7 @@ class TaskStore:
                     side_effects_started=excluded.side_effects_started,
                     depends_on=excluded.depends_on,
                     dry_run=excluded.dry_run,
+                    retry_count=excluded.retry_count,
                     completed_at=excluded.completed_at
                 """,
                 row,
@@ -594,6 +600,10 @@ def _row_to_task(row: sqlite3.Row) -> Task:
     except (IndexError, KeyError):
         side_effects_started = False
     try:
+        retry_count = row["retry_count"]
+    except (IndexError, KeyError):
+        retry_count = 0
+    try:
         route_reason = row["route_reason"]
     except (IndexError, KeyError):
         route_reason = None
@@ -662,4 +672,5 @@ def _row_to_task(row: sqlite3.Row) -> Task:
         side_effects_started=side_effects_started,
         depends_on=depends_on,
         dry_run=dry_run,
+        retry_count=retry_count if retry_count is not None else 0,
     )

--- a/maxwell_daemon/daemon/fleet_coordinator.py
+++ b/maxwell_daemon/daemon/fleet_coordinator.py
@@ -74,10 +74,40 @@ class FleetCoordinator:
         self._worker_last_seen = worker_last_seen
         self._enqueue_task_entry = enqueue_task_entry
         self._running_flag = running_flag
+        # One long-lived RemoteDaemonClient per machine, reused across ticks
+        # rather than a fresh httpx pool per poll (#978b). Keyed by machine name
+        # because each machine carries its own ``tls_verify``. Lazily created so
+        # importing this module never requires httpx.
+        self._clients: dict[str, Any] = {}
 
     def update_config(self, config: MaxwellDaemonConfig) -> None:
         """Swap the active config (used during hot-reload)."""
         self._config = config
+
+    async def aclose(self) -> None:
+        """Release every per-machine remote client's connection pool."""
+        clients = list(self._clients.values())
+        self._clients.clear()
+        for client in clients:
+            await client.aclose()
+
+    def _client_for(self, machine: Any) -> Any:
+        """Return the long-lived client for ``machine``, creating it on first use.
+
+        Each client forwards the machine's ``tls_verify`` to httpx so a
+        self-signed fleet member with ``tls_verify=False`` is actually probed
+        instead of failing every health check (#978b).
+        """
+        from maxwell_daemon.fleet.client import RemoteDaemonClient
+
+        client = self._clients.get(machine.name)
+        if client is None:
+            client = RemoteDaemonClient(
+                auth_token=self._config.api_auth_token,
+                tls_verify=getattr(machine, "tls_verify", True),
+            )
+            self._clients[machine.name] = client
+        return client
 
     async def run_loop(self) -> None:
         """Coordinator event loop — runs until the daemon stops."""
@@ -92,7 +122,7 @@ class FleetCoordinator:
     async def _dispatch_tick(self) -> None:  # noqa: C901
         """One coordinator dispatch tick: probe machines, plan, submit, requeue stale tasks."""
         from maxwell_daemon.daemon.task_models import TaskStatus
-        from maxwell_daemon.fleet.client import RemoteDaemonClient, RemoteDaemonError
+        from maxwell_daemon.fleet.client import RemoteDaemonError
         from maxwell_daemon.fleet.dispatcher import (
             FleetDispatcher,
             MachineState,
@@ -103,7 +133,9 @@ class FleetCoordinator:
         if not fleet_machines:
             return
 
-        # Build initial MachineState snapshots from config.
+        # Build initial MachineState snapshots from config. ``tls``/``tls_verify``
+        # must be carried through so the scheme and certificate-verification
+        # policy reach the per-machine client (#978b).
         initial_machines = tuple(
             MachineState(
                 name=m.name,
@@ -111,16 +143,34 @@ class FleetCoordinator:
                 port=m.port,
                 capacity=m.capacity,
                 tags=tuple(m.tags),
+                tls=getattr(m, "tls", True),
+                tls_verify=getattr(m, "tls_verify", True),
             )
             for m in fleet_machines
         )
 
-        client = RemoteDaemonClient(
-            auth_token=self._config.api_auth_token,
-        )
+        # Probe all machines in parallel to get live health, each via its own
+        # long-lived per-machine client so per-machine ``tls_verify`` is honored
+        # and no httpx pool is leaked per tick (#978b).
+        async def _probe(m: MachineState) -> bool:
+            healthy: bool = await self._client_for(m).health_check(m)
+            return healthy
 
-        # Probe all machines in parallel to get live health.
-        machines = await client.refresh_all(initial_machines)
+        health = await asyncio.gather(*(_probe(m) for m in initial_machines))
+        machines = tuple(
+            MachineState(
+                name=m.name,
+                host=m.host,
+                port=m.port,
+                capacity=m.capacity,
+                tags=m.tags,
+                active_tasks=m.active_tasks,
+                healthy=healthy,
+                tls=m.tls,
+                tls_verify=m.tls_verify,
+            )
+            for m, healthy in zip(initial_machines, health, strict=True)
+        )
 
         # Requeue tasks dispatched to machines that have gone offline.
         now = datetime.now(timezone.utc)
@@ -198,7 +248,9 @@ class FleetCoordinator:
             }
 
             try:
-                result = await client.submit_task(machine, task_payload=task_payload)
+                result = await self._client_for(machine).submit_task(
+                    machine, task_payload=task_payload
+                )
             except RemoteDaemonError:
                 log.exception(
                     "failed to dispatch task %s to machine %s",
@@ -208,8 +260,24 @@ class FleetCoordinator:
                 continue
 
             if result.status == "submitted":
-                assigned_task.status = TaskStatus.DISPATCHED
-                assigned_task.dispatched_to = machine.name
+                # Re-check the task is still QUEUED under the lock before flipping
+                # to DISPATCHED: a cancel racing the submit_task await window must
+                # not be overwritten, which would run a cancelled task remotely
+                # (#978d). The snapshot above is stale across the await.
+                with self._tasks_lock:
+                    live = self._tasks.get(assigned_task.id)
+                    if live is None or live.status is not TaskStatus.QUEUED:
+                        log.info(
+                            "task %s no longer QUEUED (status=%s) after remote submit to %s; "
+                            "not marking DISPATCHED",
+                            assigned_task.id,
+                            None if live is None else live.status.value,
+                            machine.name,
+                        )
+                        continue
+                    live.status = TaskStatus.DISPATCHED
+                    live.dispatched_to = machine.name
+                    assigned_task = live
                 log.info("dispatched task %s to machine %s", assigned_task.id, machine.name)
                 try:
                     self._task_store.save(assigned_task)

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -50,6 +50,7 @@ from maxwell_daemon.core.task_store import TaskStore
 from maxwell_daemon.core.work_item_store import WorkItemStore
 from maxwell_daemon.core.work_items import WorkItem, WorkItemStatus
 from maxwell_daemon.daemon.retry_policy import DEFAULT_RETRY_POLICY
+from maxwell_daemon.daemon.single_instance import InstanceLock
 from maxwell_daemon.director import (
     GraphNodeExecutor,
     GraphStatus,
@@ -179,6 +180,9 @@ class Daemon:
         # embedded instances isolate all SQLite state with one parameter.
         default_store = storage_root / "tasks.db"
         self._task_store = TaskStore(task_store_path or default_store)
+        # Single-instance guard keyed on the storage root (#975): a second
+        # daemon against the same root would corrupt state / double-spend.
+        self._instance_lock = InstanceLock(storage_root)
         default_work_item_store = storage_root / "work_items.db"
         self._work_item_store = WorkItemStore(work_item_store_path or default_work_item_store)
         default_task_graph_store = storage_root / "task_graphs.db"
@@ -424,6 +428,10 @@ class Daemon:
     async def start(self, *, worker_count: int = 2, recover: bool = True) -> None:
         if self._running:
             return
+        # Acquire the single-instance lock BEFORE recovery — recovery mutates
+        # shared on-disk state, which is exactly what must not happen twice
+        # against one storage root (#975). Raises InstanceLockError if held.
+        self._instance_lock.acquire()
         if recover:
             self.recover()
         self._running = True
@@ -573,6 +581,9 @@ class Daemon:
                 await close_method()
 
         await self._mcp_manager.stop()
+
+        # Release the single-instance lock so a clean restart can re-acquire it.
+        self._instance_lock.release()
 
         log.info("Daemon shut down")
 
@@ -756,8 +767,97 @@ class Daemon:
                 ),
             )
         )
+
+        # A task that already started irreversible side effects (opened a PR,
+        # posted a comment) must NOT be auto-retried — a re-run would duplicate
+        # them. Leave it permanently FAILED with a clear reason (#971).
+        if task.side_effects_started:
+            log.warning("stalled task %s had side_effects_started; not auto-retrying", task.id)
+            return
+
+        # Gate the stall retry on the RetryPolicy so a perpetually-stalling task
+        # fails permanently after max_retries instead of looping forever with
+        # zero backoff and unbounded spend (#971).
+        if not DEFAULT_RETRY_POLICY.should_retry(task):
+            log.warning(
+                "stalled task %s exhausted retry budget (retry_count=%d); failing permanently",
+                task.id,
+                task.retry_count,
+            )
+            return
+
+        delay = DEFAULT_RETRY_POLICY.next_retry_delay(task.retry_count)
         retried = self.retry_task(task.id, expected_status=TaskStatus.FAILED)
-        self._enqueue_task_entry(retried.priority, retried)
+        retried.retry_count += 1
+        try:
+            self._task_store.save(retried)
+        except Exception:
+            log.exception("task store write failed while bumping retry_count task=%s", task.id)
+        # Re-enqueue after the backoff delay rather than immediately, so retries
+        # don't form a tight cancel/re-run loop.
+        self._schedule_delayed_enqueue(retried, delay.total_seconds())
+
+    def _schedule_delayed_enqueue(self, task: Task, delay_seconds: float) -> None:
+        """Re-enqueue ``task`` after ``delay_seconds`` via a tracked bg task."""
+
+        async def _delayed() -> None:
+            try:
+                if delay_seconds > 0:
+                    await asyncio.sleep(delay_seconds)
+                self._enqueue_task_entry(task.priority, task)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                log.warning("delayed re-enqueue failed for task=%s", task.id, exc_info=True)
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop (e.g. unit context): enqueue inline.
+            self._enqueue_task_entry(task.priority, task)
+            return
+        bg = loop.create_task(_delayed())
+        self._bg_tasks.add(bg)
+        bg.add_done_callback(self._bg_tasks.discard)
+
+    def _fail_saturated_task(self, task: Task | None) -> None:
+        """Mark a task FAILED + emit an event when the on-loop enqueue is full.
+
+        The on-loop submission path defers the actual queue ``put`` to a
+        callback that runs after the HTTP response is already sent. If the queue
+        is saturated at that point we cannot return 429, so we make the drop
+        observable instead of leaving the persisted task stranded in QUEUED with
+        no queue entry and no error (#972).
+        """
+        if task is None:
+            return
+        message = (
+            f"Task queue saturated (max_depth={self._config.agent.max_queue_depth}); "
+            "submission dropped before it could be enqueued."
+        )
+        log.warning("queue saturated; failing dropped task %s", task.id)
+        task.status = TaskStatus.FAILED
+        task.error = message
+        task.finished_at = datetime.now(timezone.utc)
+        try:
+            self._task_store.save(task)
+        except Exception:
+            log.exception("task store write failed while failing saturated task=%s", task.id)
+        bg = asyncio.ensure_future(
+            self._events.publish(
+                Event(
+                    kind=EventKind.TASK_FAILED,
+                    payload=attach_observability(
+                        {"id": task.id, "error": message, "reason": "queue_saturated"},
+                        task_id=task.id,
+                        backend=task.backend,
+                        model=task.model,
+                    ),
+                )
+            )
+        )
+        self._bg_tasks.add(bg)
+        bg.add_done_callback(self._bg_tasks.discard)
 
     async def _dream_cycle_loop(self) -> None:
         """Periodically consolidate raw markdown memory when explicitly enabled."""
@@ -832,19 +932,16 @@ class Daemon:
             def _put_inline() -> None:
                 try:
                     if self._queue.full():
-                        log.warning(
-                            "queue is saturated (max_depth=%d); dropped task %s",
-                            self._config.agent.max_queue_depth,
-                            getattr(task, "id", None),
-                        )
+                        # The HTTP 200 has already been returned by the time this
+                        # deferred callback runs, so we cannot raise 429 here.
+                        # Instead of silently dropping the task (leaving it
+                        # stranded QUEUED forever), transition it to FAILED and
+                        # emit an event so the saturation is observable (#972).
+                        self._fail_saturated_task(task)
                         return
                     self._queue.put_nowait(item)
                 except asyncio.QueueFull:
-                    log.warning(
-                        "queue is saturated (max_depth=%d); dropped task %s",
-                        self._config.agent.max_queue_depth,
-                        getattr(task, "id", None),
-                    )
+                    self._fail_saturated_task(task)
 
             self._loop.call_soon_threadsafe(_put_inline)
             return

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import functools
 import signal
 import threading
@@ -2146,8 +2147,20 @@ def main() -> None:
         await daemon.start()
         stop = asyncio.Event()
         loop = asyncio.get_event_loop()
+
+        # ``loop.add_signal_handler`` raises NotImplementedError on Windows'
+        # ProactorEventLoop. Guard every install so the daemon starts there too,
+        # matching the SIGUSR1 path in start() (#981). Fall back to
+        # ``signal.signal`` for SIGINT/SIGTERM so Ctrl-C still stops the daemon.
+        def _request_stop() -> None:
+            loop.call_soon_threadsafe(stop.set)
+
         for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, stop.set)
+            try:
+                loop.add_signal_handler(sig, stop.set)
+            except (NotImplementedError, OSError):
+                with contextlib.suppress(ValueError, OSError):
+                    signal.signal(sig, lambda _signum, _frame: _request_stop())
 
         def _sighup_handler() -> None:
             """Reload config in-place on SIGHUP without stopping workers."""
@@ -2158,7 +2171,9 @@ def main() -> None:
 
         sighup = getattr(signal, "SIGHUP", None)
         if sighup is not None:
-            loop.add_signal_handler(sighup, _sighup_handler)
+            # No SIGHUP on Windows — hot-reload-on-signal is simply unavailable.
+            with contextlib.suppress(NotImplementedError, OSError):
+                loop.add_signal_handler(sighup, _sighup_handler)
         await stop.wait()
         await daemon.stop()
 

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -378,6 +378,32 @@ class Daemon:
             except asyncio.QueueFull:
                 await self._queue.put(deferred_item)
 
+    def _classify_dependencies_locked(self, task: Task) -> tuple[str | None, bool]:
+        """Classify a task's dependencies. Caller must hold ``_tasks_lock``.
+
+        Returns ``(failed_dependency, deps_pending)``:
+
+        * ``failed_dependency`` is the id of the first dependency that terminally
+          failed/cancelled — such a dependency will never reach COMPLETED, so
+          deferring on it would strand the dependent in a tight re-enqueue loop
+          forever (#978c). When set, the dependent should be failed.
+        * ``deps_pending`` is True when at least one dependency is still
+          unfinished (missing or not yet COMPLETED) and none has failed — the
+          dependent should be deferred.
+        """
+        for dep in task.depends_on:
+            dep_task = self._tasks.get(dep)
+            if dep_task is not None and dep_task.status in (
+                TaskStatus.FAILED,
+                TaskStatus.CANCELLED,
+            ):
+                return dep, False
+        deps_pending = any(
+            self._tasks.get(dep) is None or self._tasks[dep].status is not TaskStatus.COMPLETED
+            for dep in task.depends_on
+        )
+        return None, deps_pending
+
     async def _claim_next_queued_task(self) -> tuple[bool, Task | None]:
         deferred: list[tuple[int, Task]] = []
         claimed: Task | None = None
@@ -396,27 +422,55 @@ class Daemon:
             task = payload
 
             kind_cap = self._kind_cap_for(task)
+            failed_dependency: str | None = None
             with self._tasks_lock:
                 if task.status is not TaskStatus.QUEUED:
                     continue
                 if task.depends_on:
-                    unfinished = [
-                        dep
-                        for dep in task.depends_on
-                        if self._tasks.get(dep) is None
-                        or self._tasks[dep].status is not TaskStatus.COMPLETED
-                    ]
-                    if unfinished:
+                    failed_dependency, deps_pending = self._classify_dependencies_locked(task)
+                    if failed_dependency is None and deps_pending:
                         deferred.append((priority, task))
                         continue
-                if kind_cap is not None:
-                    kind_key = self._task_kind_key(task)
-                    if self._count_running_tasks_locked(kind_key=kind_key) >= kind_cap:
-                        deferred.append((priority, task))
-                        continue
-                task.status = TaskStatus.RUNNING
-                task.started_at = datetime.now(timezone.utc)
-                claimed = task
+                if failed_dependency is not None:
+                    dep_message = f"dependency {failed_dependency} failed"
+                    task.status = TaskStatus.FAILED
+                    task.error = dep_message
+                    task.finished_at = datetime.now(timezone.utc)
+                else:
+                    if kind_cap is not None:
+                        kind_key = self._task_kind_key(task)
+                        if self._count_running_tasks_locked(kind_key=kind_key) >= kind_cap:
+                            deferred.append((priority, task))
+                            continue
+                    task.status = TaskStatus.RUNNING
+                    task.started_at = datetime.now(timezone.utc)
+                    claimed = task
+            # Persist + publish the dependency-failure outside the lock (no store
+            # I/O or awaiting while holding the threading lock), then keep draining
+            # the queue rather than claiming the failed task for execution.
+            if failed_dependency is not None:
+                try:
+                    self._task_store.save(task)
+                except Exception:
+                    log.exception(
+                        "task store write failed while failing dependent task=%s", task.id
+                    )
+                await self._events.publish(
+                    Event(
+                        kind=EventKind.TASK_FAILED,
+                        payload=attach_observability(
+                            {
+                                "id": task.id,
+                                "error": task.error,
+                                "reason": "dependency_failed",
+                            },
+                            task_id=task.id,
+                            backend=task.backend,
+                            model=task.model,
+                        ),
+                    )
+                )
+                continue
             # ``put_nowait``/await of deferred entries must happen OUTSIDE the
             # threading lock (no awaiting while holding it).
             if claimed is not None:
@@ -581,6 +635,11 @@ class Daemon:
                 await close_method()
 
         await self._mcp_manager.stop()
+
+        # Release the long-lived per-machine fleet clients' connection pools
+        # (#978b) so a coordinator shutdown leaves no leaked httpx sockets.
+        if self._fleet_coordinator is not None:
+            await self._fleet_coordinator.aclose()
 
         # Release the single-instance lock so a clean restart can re-acquire it.
         self._instance_lock.release()
@@ -1151,19 +1210,23 @@ class Daemon:
             priority=priority,
             dry_run=dry_run,
         )
-        # See note in submit(): queue mutation must stay loop-affine once the
-        # daemon has started.
+        # See note in submit(): the queue mutation waits for the daemon loop to
+        # run a callback, so it must happen *outside* _tasks_lock — holding the
+        # lock across the cross-thread enqueue can deadlock the loop. Persist and
+        # track under the lock, enqueue after release, and roll back on
+        # saturation so a rejected task leaves no orphaned store/registry row.
         with self._tasks_lock:
             if task_id is not None:
                 self._reject_duplicate_task_id(task.id)
             self._task_store.save(task)
             self._tasks[task.id] = task
-            try:
-                self._enqueue_task_entry(task.priority, task)
-            except QueueSaturationError:
+        try:
+            self._enqueue_task_entry(task.priority, task)
+        except QueueSaturationError:
+            with self._tasks_lock:
                 del self._tasks[task.id]
-                self._task_store.delete(task.id)
-                raise
+            self._task_store.delete(task.id)
+            raise
         try:
             loop = asyncio.get_running_loop()
             bg = loop.create_task(

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -807,7 +807,7 @@ class Daemon:
                 self._enqueue_task_entry(task.priority, task)
             except asyncio.CancelledError:
                 raise
-            except Exception:  # noqa: BLE001
+            except (QueueSaturationError, RuntimeError):
                 log.warning("delayed re-enqueue failed for task=%s", task.id, exc_info=True)
 
         try:

--- a/maxwell_daemon/daemon/single_instance.py
+++ b/maxwell_daemon/daemon/single_instance.py
@@ -1,0 +1,165 @@
+"""Single-instance guard for the daemon storage root (#975).
+
+Two daemons sharing one storage root corrupt each other's state: instance B's
+crash-recovery marks instance A's in-flight tasks FAILED and re-enqueues every
+QUEUED row, so both instances execute every task — duplicate LLM spend,
+duplicate PRs. This module provides a cross-platform exclusive lock file so a
+second daemon against the same storage root refuses to start.
+
+The lock is advisory (``flock`` on POSIX, ``msvcrt.locking`` on Windows) and is
+held for the process lifetime. A stale lock left by a crashed process is
+detected via the recorded PID and reclaimed, so a clean restart is never
+blocked by a previous crash.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+from types import TracebackType
+
+from maxwell_daemon.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class InstanceLockError(RuntimeError):
+    """Raised when the storage root is already locked by a live daemon."""
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Best-effort check whether ``pid`` names a running process."""
+    if pid <= 0:
+        return False
+    if os.name == "nt":  # pragma: no cover - exercised on Windows only
+        import ctypes
+
+        # ``windll`` only exists on the Windows ctypes build; reach it via
+        # getattr so static analysis on POSIX doesn't flag a missing attribute.
+        kernel32 = getattr(ctypes, "windll").kernel32  # noqa: B009
+        process_query_limited_information = 0x1000
+        handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+        if not handle:
+            return False
+        kernel32.CloseHandle(handle)
+        return True
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by another user — treat as alive.
+        return True
+    return True
+
+
+class InstanceLock:
+    """Exclusive, PID-stamped lock file for one storage root.
+
+    Usage::
+
+        lock = InstanceLock(storage_root)
+        lock.acquire()   # raises InstanceLockError if a live daemon holds it
+        ...
+        lock.release()
+    """
+
+    def __init__(self, storage_root: Path, *, name: str = "daemon.lock") -> None:
+        self._path = Path(storage_root).expanduser() / name
+        self._fh: object | None = None
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _read_recorded_pid(self) -> int | None:
+        try:
+            text = self._path.read_text(encoding="utf-8").strip()
+        except (OSError, ValueError):
+            return None
+        try:
+            return int(text)
+        except ValueError:
+            return None
+
+    def acquire(self) -> None:
+        if self._fh is not None:
+            return  # already held by this instance
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+        # If a lock file exists and names a live PID, refuse. A stale lock from a
+        # crashed process is reclaimed below by simply taking the OS-level lock.
+        recorded = self._read_recorded_pid()
+        if recorded is not None and recorded != os.getpid() and _pid_is_alive(recorded):
+            raise InstanceLockError(
+                f"another daemon (pid {recorded}) already holds {self._path}. "
+                "Refusing to start a second instance against the same storage root."
+            )
+
+        fh = open(self._path, "a+", encoding="utf-8")  # noqa: SIM115 - held for lifetime
+        try:
+            self._os_lock(fh)
+        except OSError as exc:
+            fh.close()
+            raise InstanceLockError(
+                f"storage root {self._path.parent} is locked by another daemon"
+            ) from exc
+
+        fh.seek(0)
+        fh.truncate()
+        fh.write(str(os.getpid()))
+        fh.flush()
+        os.fsync(fh.fileno())
+        self._fh = fh
+        log.info("acquired single-instance lock", path=str(self._path), pid=os.getpid())
+
+    def release(self) -> None:
+        fh = self._fh
+        if fh is None:
+            return
+        try:
+            self._os_unlock(fh)
+        except OSError:
+            log.warning("failed to release instance lock cleanly", exc_info=True)
+        finally:
+            with contextlib.suppress(OSError):
+                fh.close()  # type: ignore[attr-defined]
+            self._fh = None
+
+    # -- platform-specific locking ------------------------------------------- #
+
+    @staticmethod
+    def _os_lock(fh: object) -> None:
+        if os.name == "nt":  # pragma: no cover - Windows path
+            import msvcrt
+
+            msvcrt.locking(fh.fileno(), msvcrt.LK_NBLCK, 1)  # type: ignore[attr-defined]
+        else:
+            import fcntl
+
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)  # type: ignore[attr-defined]
+
+    @staticmethod
+    def _os_unlock(fh: object) -> None:
+        if os.name == "nt":  # pragma: no cover - Windows path
+            import msvcrt
+
+            fh.seek(0)  # type: ignore[attr-defined]
+            msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)  # type: ignore[attr-defined]
+        else:
+            import fcntl
+
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)  # type: ignore[attr-defined]
+
+    def __enter__(self) -> InstanceLock:
+        self.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.release()

--- a/maxwell_daemon/daemon/task_models.py
+++ b/maxwell_daemon/daemon/task_models.py
@@ -117,6 +117,10 @@ class Task:
     # Fleet dispatch tracking: set when a coordinator sends this task to a remote worker.
     dispatched_to: str | None = None  # machine name of the worker that received this task
     side_effects_started: bool = False
+    # Number of automatic retries already attempted (e.g. after a stall). Gated
+    # by RetryPolicy.should_retry so stalled tasks fail permanently instead of
+    # retrying forever (#971).
+    retry_count: int = 0
 
     @property
     def continuation_thread_id(self) -> str:

--- a/maxwell_daemon/daemon/workspace_hooks.py
+++ b/maxwell_daemon/daemon/workspace_hooks.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -47,9 +48,12 @@ async def _run_hook(
     name: str, command: str, cwd: Path, timeout_seconds: float
 ) -> tuple[int, bytes, bytes]:
     """Run a single hook command safely without shell=True."""
-    # We split using shlex to avoid shell=True while still allowing basic args
+    # We split using shlex to avoid shell=True while still allowing basic args.
+    # POSIX-mode shlex treats backslash as an escape, which mangles Windows
+    # paths (``C:\tools\x.exe`` -> ``C:toolsx.exe``); split in non-POSIX mode on
+    # Windows so native paths survive intact (#981).
     try:
-        args = shlex.split(command)
+        args = shlex.split(command, posix=(os.name != "nt"))
     except ValueError as e:
         raise WorkspaceHookError(f"Failed to parse hook command {command!r}: {e}") from e
 

--- a/maxwell_daemon/daemon/workspace_hooks.py
+++ b/maxwell_daemon/daemon/workspace_hooks.py
@@ -72,6 +72,9 @@ async def _run_hook(
 
             with contextlib.suppress(OSError):
                 proc.kill()
+            # Reap the killed child so it does not linger as a zombie (#980).
+            with contextlib.suppress(Exception):
+                await proc.wait()
             raise WorkspaceHookError(f"Hook {name!r} timed out after {timeout_seconds}s") from None
     except Exception as e:
         if isinstance(e, WorkspaceHookError):

--- a/maxwell_daemon/fleet/client.py
+++ b/maxwell_daemon/fleet/client.py
@@ -90,10 +90,30 @@ class RemoteDaemonClient:
         timeout_seconds: float = 30.0,
         tls_verify: bool = True,
     ) -> None:
-        self._http = http_client if http_client is not None else _make_default_http(timeout_seconds)
+        # Forward tls_verify into the default httpx adapter so ``tls_verify=False``
+        # actually reaches httpx; otherwise self-signed fleets fail every probe
+        # and surface only as "machine unhealthy" (#978b). We own the transport
+        # only when we created it — an injected client is the caller's to close.
+        self._owns_http = http_client is None
+        self._http = (
+            http_client
+            if http_client is not None
+            else _make_default_http(timeout_seconds, tls_verify=tls_verify)
+        )
         self._auth_token = auth_token
         self._timeout_seconds = timeout_seconds
         self._tls_verify = tls_verify
+
+    async def aclose(self) -> None:
+        """Release the underlying connection pool if we created it.
+
+        Injected transports are owned by the caller and left untouched so the
+        coordinator can hold one long-lived client per remote (#978b).
+        """
+        if self._owns_http:
+            aclose = getattr(self._http, "aclose", None)
+            if aclose is not None:
+                await aclose()
 
     # ------------------------------------------------------------------ headers
     def _headers(self) -> dict[str, str]:

--- a/maxwell_daemon/gh/client.py
+++ b/maxwell_daemon/gh/client.py
@@ -12,6 +12,7 @@ and other bounded inputs get regex-validated before they reach the subprocess.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import re
 import time
@@ -66,12 +67,15 @@ RateLimitError = GitHubRateLimitError
 
 # Exit codes emitted by `gh` when GitHub returns 403 or 429 (rate-limited).
 _RATE_LIMIT_EXIT_CODES: frozenset[int] = frozenset({4})  # gh uses rc=4 for HTTP 4xx
-# Error substrings that indicate a rate-limit response rather than an auth error.
+# Error substrings that indicate a genuine rate-limit response rather than an
+# auth error. A bare "403" is deliberately NOT here: GitHub returns 403 for both
+# secondary rate limits AND auth/SSO failures, so treating every 403 as a rate
+# limit masks bad-token errors as ~15s+ sleeps (#980). A 403 only counts as a
+# rate limit when one of these co-occurring markers is present.
 _RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "rate limit",
     "rate_limit",
     "429",
-    "403",
     "secondary rate",
     "abuse detection",
 )
@@ -120,14 +124,34 @@ class PullRequest:
         return cls(number=int(match.group(1)), url=url, draft=draft)
 
 
-async def _default_runner(*argv: str, cwd: str | None = None) -> tuple[int, bytes, bytes]:
+# Wall-clock ceiling for a single `gh` invocation. A hung `gh` (e.g. a stuck
+# network call or auth prompt) must not pin a worker until the stall reconciler
+# fires and feeds the retry loop (#980).
+_GH_SUBPROCESS_TIMEOUT_SECONDS = 120.0
+
+
+async def _default_runner(
+    *argv: str,
+    cwd: str | None = None,
+    timeout: float = _GH_SUBPROCESS_TIMEOUT_SECONDS,
+) -> tuple[int, bytes, bytes]:
     proc = await asyncio.create_subprocess_exec(
         *argv,
         cwd=cwd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, stderr = await proc.communicate()
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        # Kill and reap so the hung child does not linger as a zombie, then
+        # surface a clear error instead of blocking the worker indefinitely.
+        proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        raise GhCliError(
+            f"gh {' '.join(argv)} timed out after {timeout:.0f}s and was killed"
+        ) from None
     return proc.returncode or 0, stdout, stderr
 
 

--- a/tests/unit/test_daemon.py
+++ b/tests/unit/test_daemon.py
@@ -368,7 +368,10 @@ class TestTaskExecution:
         reason="flaky on Python 3.11 self-hosted runner — see issue #891",
     )
     def test_stalled_issue_task_is_cancelled_and_retried(
-        self, isolated_ledger_path: Path, minimal_config: MaxwellDaemonConfig
+        self,
+        isolated_ledger_path: Path,
+        minimal_config: MaxwellDaemonConfig,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         class _RetryingIssueExecutor:
             def __init__(self) -> None:
@@ -389,6 +392,18 @@ class TestTaskExecution:
                 }
             )
             executor = _RetryingIssueExecutor()
+            # The stall retry now applies RetryPolicy backoff (#971); collapse it
+            # to ~0 here so the test exercises the retry-then-complete path
+            # without waiting the production 60s backoff. DEFAULT_RETRY_POLICY is
+            # frozen+slots, so swap the module attribute for a zero-delay policy.
+            import maxwell_daemon.daemon.runner as runner_mod
+            from maxwell_daemon.daemon.retry_policy import RetryPolicy
+
+            monkeypatch.setattr(
+                runner_mod,
+                "DEFAULT_RETRY_POLICY",
+                RetryPolicy(base_delay_seconds=0.0, max_delay_seconds=0.0),
+            )
             d = Daemon(
                 cfg,
                 ledger_path=isolated_ledger_path,

--- a/tests/unit/test_daemon_correctness.py
+++ b/tests/unit/test_daemon_correctness.py
@@ -1,0 +1,192 @@
+"""Daemon correctness regressions: stall-retry policy, queue-saturation
+visibility, and the single-instance storage guard (#971 #972 #975)."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Awaitable
+from pathlib import Path
+from typing import TypeVar
+
+import pytest
+
+from maxwell_daemon.config import MaxwellDaemonConfig
+from maxwell_daemon.daemon import Daemon
+from maxwell_daemon.daemon.single_instance import InstanceLockError
+from maxwell_daemon.daemon.task_models import Task, TaskKind, TaskStatus
+from maxwell_daemon.events import EventKind
+
+T = TypeVar("T")
+
+
+def _run(coro: Awaitable[T]) -> T:
+    return asyncio.new_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+
+def _make_daemon(tmp_path: Path, cfg: MaxwellDaemonConfig, suffix: str = "a") -> Daemon:
+    return Daemon(
+        cfg,
+        ledger_path=tmp_path / f"ledger-{suffix}.db",
+        task_store_path=tmp_path / f"tasks-{suffix}.db",
+    )
+
+
+# ── #971: stall-retry gated on RetryPolicy ───────────────────────────────────
+
+
+class TestStallRetryPolicy:
+    def test_side_effects_started_is_not_auto_retried(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        d = _make_daemon(tmp_path, minimal_config)
+        task = Task(id="t1", prompt="p", kind=TaskKind.PROMPT, side_effects_started=True)
+        d._tasks[task.id] = task
+        d._task_store.save(task)
+
+        _run(d._handle_stalled_task(task))
+
+        # Permanently FAILED, never re-queued.
+        assert task.status is TaskStatus.FAILED
+        assert task.retry_count == 0
+        assert d._queue.empty()
+
+    def test_exhausted_retry_budget_fails_permanently(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        d = _make_daemon(tmp_path, minimal_config)
+        # Already at the policy ceiling (default max_retries=3).
+        task = Task(id="t2", prompt="p", kind=TaskKind.PROMPT, retry_count=3)
+        d._tasks[task.id] = task
+        d._task_store.save(task)
+
+        _run(d._handle_stalled_task(task))
+
+        assert task.status is TaskStatus.FAILED
+        assert d._queue.empty()
+        # retry_count not bumped past the ceiling.
+        assert task.retry_count == 3
+
+    def test_within_budget_increments_and_requeues(
+        self,
+        tmp_path: Path,
+        minimal_config: MaxwellDaemonConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import maxwell_daemon.daemon.runner as runner_mod
+        from maxwell_daemon.daemon.retry_policy import RetryPolicy
+
+        # Zero backoff so the delayed re-enqueue runs on the next loop tick.
+        monkeypatch.setattr(
+            runner_mod,
+            "DEFAULT_RETRY_POLICY",
+            RetryPolicy(base_delay_seconds=0.0, max_delay_seconds=0.0),
+        )
+
+        async def body() -> None:
+            d = _make_daemon(tmp_path, minimal_config)
+            task = Task(id="t3", prompt="p", kind=TaskKind.PROMPT, retry_count=0)
+            d._tasks[task.id] = task
+            d._task_store.save(task)
+
+            await d._handle_stalled_task(task)
+            # Let the scheduled zero-delay re-enqueue run.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            assert task.retry_count == 1
+            assert not d._queue.empty()
+            reloaded = d._task_store.get("t3")
+            assert reloaded is not None
+            assert reloaded.retry_count == 1
+            assert reloaded.status is TaskStatus.QUEUED
+
+        _run(body())
+
+
+# ── #972: on-loop queue saturation is observable ─────────────────────────────
+
+
+class TestQueueSaturationVisibility:
+    def test_fail_saturated_task_marks_failed_and_emits_event(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        async def body() -> None:
+            d = _make_daemon(tmp_path, minimal_config)
+            task = Task(id="sat", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.QUEUED)
+            d._tasks[task.id] = task
+            d._task_store.save(task)
+
+            subscription = d._events.subscribe()
+            try:
+                d._fail_saturated_task(task)
+                # Allow the fire-and-forget event publish to run, then read the
+                # single emitted event without blocking forever.
+                await asyncio.sleep(0)
+                event = await asyncio.wait_for(subscription.__anext__(), timeout=2.0)
+            finally:
+                await subscription.aclose()
+
+            assert task.status is TaskStatus.FAILED
+            assert "saturated" in (task.error or "")
+            reloaded = d._task_store.get("sat")
+            assert reloaded is not None and reloaded.status is TaskStatus.FAILED
+            assert event.kind == EventKind.TASK_FAILED
+            assert event.payload.get("reason") == "queue_saturated"
+
+        _run(body())
+
+
+# ── #975: single-instance storage guard ──────────────────────────────────────
+
+
+class TestSingleInstanceGuard:
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="same-process flock conflict semantics differ on Windows; CI is Linux",
+    )
+    def test_second_daemon_same_root_refuses_to_start(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        async def body() -> None:
+            first = Daemon(
+                minimal_config,
+                ledger_path=tmp_path / "ledger.db",
+                task_store_path=tmp_path / "tasks.db",
+            )
+            await first.start(worker_count=1)
+            try:
+                # Same storage root (same task_store parent dir).
+                second = Daemon(
+                    minimal_config,
+                    ledger_path=tmp_path / "ledger2.db",
+                    task_store_path=tmp_path / "tasks2.db",
+                )
+                with pytest.raises(InstanceLockError):
+                    await second.start(worker_count=1)
+            finally:
+                await first.stop()
+
+        _run(body())
+
+    def test_restart_after_stop_succeeds(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        async def body() -> None:
+            d1 = Daemon(
+                minimal_config,
+                ledger_path=tmp_path / "ledger.db",
+                task_store_path=tmp_path / "tasks.db",
+            )
+            await d1.start(worker_count=1)
+            await d1.stop()
+
+            d2 = Daemon(
+                minimal_config,
+                ledger_path=tmp_path / "ledger.db",
+                task_store_path=tmp_path / "tasks.db",
+            )
+            await d2.start(worker_count=1)  # must not raise
+            await d2.stop()
+
+        _run(body())

--- a/tests/unit/test_daemon_robustness.py
+++ b/tests/unit/test_daemon_robustness.py
@@ -1,0 +1,309 @@
+"""Daemon robustness cluster regressions (#978).
+
+Four related defects on the runner / fleet-coordinator paths:
+
+* (a) ``submit_issue`` must not enqueue while holding ``_tasks_lock``.
+* (b) the coordinator must reuse one client per remote and forward ``tls_verify``.
+* (c) a dependent of a terminally-failed dependency must FAIL, not churn forever.
+* (d) a cancel racing the dispatch await window must not be overwritten with
+  DISPATCHED.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Awaitable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, TypeVar
+from unittest.mock import MagicMock
+
+from maxwell_daemon.config import MaxwellDaemonConfig
+from maxwell_daemon.daemon import Daemon
+from maxwell_daemon.daemon.fleet_coordinator import FleetCoordinator
+from maxwell_daemon.daemon.task_models import Task, TaskKind, TaskStatus
+from maxwell_daemon.events import EventKind
+
+T = TypeVar("T")
+
+
+def _run(coro: Awaitable[T]) -> T:
+    return asyncio.new_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+
+def _make_daemon(tmp_path: Path, cfg: MaxwellDaemonConfig, suffix: str = "a") -> Daemon:
+    return Daemon(
+        cfg,
+        ledger_path=tmp_path / f"ledger-{suffix}.db",
+        task_store_path=tmp_path / f"tasks-{suffix}.db",
+    )
+
+
+# ── (a) submit_issue enqueues outside _tasks_lock ────────────────────────────
+
+
+class TestSubmitIssueLockDiscipline:
+    def test_enqueue_runs_without_holding_tasks_lock(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        """The enqueue must observe an *unlocked* _tasks_lock (#978a).
+
+        We assert the lock is acquirable from inside the enqueue callback — if
+        submit_issue still held it, ``acquire(blocking=False)`` would fail.
+        """
+        d = _make_daemon(tmp_path, minimal_config)
+        observed: dict[str, bool] = {}
+        original = d._enqueue_task_entry
+
+        def _spy(priority: int, task: Task) -> None:
+            got = d._tasks_lock.acquire(blocking=False)
+            observed["lock_free"] = got
+            if got:
+                d._tasks_lock.release()
+            original(priority, task)
+
+        d._enqueue_task_entry = _spy  # type: ignore[method-assign]
+        task = d.submit_issue(repo="owner/repo", issue_number=1)
+        assert observed["lock_free"] is True
+        assert d._tasks[task.id].status is TaskStatus.QUEUED
+
+    def test_saturation_rolls_back_store_and_registry(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        """A saturated enqueue leaves no orphaned task in the store or registry."""
+        from maxwell_daemon.daemon.runner import QueueSaturationError
+
+        d = _make_daemon(tmp_path, minimal_config)
+
+        def _boom(priority: int, task: Task) -> None:
+            raise QueueSaturationError("queue full")
+
+        d._enqueue_task_entry = _boom  # type: ignore[method-assign]
+        try:
+            d.submit_issue(repo="owner/repo", issue_number=2)
+        except QueueSaturationError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected QueueSaturationError")
+        assert d._tasks == {}
+        assert d._task_store.get("__none__") is None
+
+
+# ── (c) failed dependency fails the dependent ────────────────────────────────
+
+
+class TestFailedDependencyFailsDependent:
+    def test_dependent_of_failed_dep_transitions_to_failed(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        d = _make_daemon(tmp_path, minimal_config)
+
+        dep = Task(id="dep", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.FAILED)
+        dependent = Task(
+            id="child",
+            prompt="p",
+            kind=TaskKind.PROMPT,
+            status=TaskStatus.QUEUED,
+            depends_on=["dep"],
+        )
+        d._tasks[dep.id] = dep
+        d._tasks[dependent.id] = dependent
+        d._task_store.save(dep)
+        d._task_store.save(dependent)
+        d._queue.put_nowait((dependent.priority, dependent))
+
+        events: list[Any] = []
+
+        async def _capture(event: Any) -> None:
+            events.append(event)
+
+        d._events.publish = _capture  # type: ignore[method-assign]
+
+        _stopped, claimed = _run(d._claim_next_queued_task())
+
+        assert claimed is None
+        assert dependent.status is TaskStatus.FAILED
+        assert "dep" in (dependent.error or "")
+        # Persisted failure + a TASK_FAILED event with the dependency reason.
+        assert d._task_store.get("child").status is TaskStatus.FAILED
+        assert any(e.kind is EventKind.TASK_FAILED for e in events)
+
+    def test_completed_dependency_still_allows_claim(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        """A COMPLETED dependency must not be mistaken for a failed one."""
+        d = _make_daemon(tmp_path, minimal_config)
+        dep = Task(id="dep", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.COMPLETED)
+        dependent = Task(
+            id="child",
+            prompt="p",
+            kind=TaskKind.PROMPT,
+            status=TaskStatus.QUEUED,
+            depends_on=["dep"],
+        )
+        d._tasks[dep.id] = dep
+        d._tasks[dependent.id] = dependent
+        d._queue.put_nowait((dependent.priority, dependent))
+
+        _stopped, claimed = _run(d._claim_next_queued_task())
+
+        assert claimed is dependent
+        assert dependent.status is TaskStatus.RUNNING
+
+
+# ── (b)/(d) fleet coordinator: client reuse, tls_verify, cancel race ──────────
+
+
+@dataclass
+class _FakeHTTPResponse:
+    status_code: int
+    _body: dict[str, Any] = field(default_factory=dict)
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+@dataclass
+class _RecordingHTTP:
+    """Records calls; health 200, submit 202. Tracks aclose() for leak checks."""
+
+    submitted: list[dict[str, Any]] = field(default_factory=list)
+    closed: bool = False
+
+    async def get(self, url: str, *, headers: dict[str, str]) -> _FakeHTTPResponse:
+        return _FakeHTTPResponse(status_code=200)
+
+    async def post(
+        self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+    ) -> _FakeHTTPResponse:
+        self.submitted.append({"url": url, "payload": json})
+        return _FakeHTTPResponse(status_code=202)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _make_coordinator(
+    *,
+    tasks: dict[str, Task],
+    machines: list[Any],
+    task_store: Any = None,
+) -> FleetCoordinator:
+    config = SimpleNamespace(
+        fleet_machines=machines,
+        fleet_coordinator_poll_seconds=5,
+        fleet_heartbeat_seconds=30,
+        api_auth_token=None,
+    )
+    return FleetCoordinator(
+        config=config,
+        tasks=tasks,
+        tasks_lock=threading.Lock(),
+        task_store=task_store or MagicMock(),
+        worker_last_seen={},
+        enqueue_task_entry=MagicMock(),
+        running_flag=lambda: False,
+    )
+
+
+class TestCoordinatorClientLifecycle:
+    def test_tls_verify_false_reaches_httpx(self) -> None:
+        """tls_verify on the machine config must reach the default httpx client (#978b)."""
+        from maxwell_daemon.fleet.client import RemoteDaemonClient
+
+        client = RemoteDaemonClient(tls_verify=False)
+        # The default adapter stores the verify flag on its httpx client.
+        assert client._tls_verify is False
+        assert client._owns_http is True
+
+    def test_injected_client_is_not_closed(self) -> None:
+        """aclose() only releases transports the client created itself (#978b)."""
+        from maxwell_daemon.fleet.client import RemoteDaemonClient
+
+        http = _RecordingHTTP()
+        client = RemoteDaemonClient(http_client=http)
+        _run(client.aclose())
+        assert http.closed is False  # caller owns an injected transport
+
+    def test_one_persistent_client_per_machine_reused(self) -> None:
+        """Two ticks must reuse one client per machine, not build a new pool each tick."""
+        task = Task(id="t1", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.QUEUED)
+        machine = SimpleNamespace(
+            name="w1", host="h", port=8080, capacity=1, tags=[], tls=False, tls_verify=False
+        )
+        coordinator = _make_coordinator(tasks={"t1": task}, machines=[machine])
+
+        created: list[Any] = []
+        import maxwell_daemon.fleet.client as fleet_client_mod
+
+        original_cls = fleet_client_mod.RemoteDaemonClient
+
+        class _PatchedClient(original_cls):  # type: ignore[misc,valid-type]
+            def __init__(self, **kw: Any) -> None:
+                super().__init__(http_client=_RecordingHTTP(), **kw)
+                self.aclose_calls = 0
+                created.append(self)
+
+            async def aclose(self) -> None:
+                self.aclose_calls += 1
+                await super().aclose()
+
+        fleet_client_mod.RemoteDaemonClient = _PatchedClient  # type: ignore[misc]
+        try:
+            _run(coordinator._dispatch_tick())
+            # Reset task to QUEUED for a second tick and dispatch again.
+            task.status = TaskStatus.QUEUED
+            task.dispatched_to = None
+            _run(coordinator._dispatch_tick())
+        finally:
+            fleet_client_mod.RemoteDaemonClient = original_cls  # type: ignore[misc]
+
+        # One client built for the single machine, reused across both ticks
+        # rather than a fresh pool per tick (#978b).
+        assert len(created) == 1
+        assert created[0]._tls_verify is False
+        # coordinator.aclose() propagates to every cached per-machine client.
+        _run(coordinator.aclose())
+        assert created[0].aclose_calls == 1
+        assert coordinator._clients == {}
+
+    def test_cancel_during_dispatch_await_is_not_overwritten(self) -> None:
+        """A task cancelled while submit_task awaits stays CANCELLED, not DISPATCHED (#978d)."""
+        task = Task(id="t1", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.QUEUED)
+        machine = SimpleNamespace(
+            name="w1", host="h", port=8080, capacity=1, tags=[], tls=False, tls_verify=True
+        )
+        tasks = {"t1": task}
+        coordinator = _make_coordinator(tasks=tasks, machines=[machine])
+
+        import maxwell_daemon.fleet.client as fleet_client_mod
+
+        original_cls = fleet_client_mod.RemoteDaemonClient
+
+        class _RacingHTTP(_RecordingHTTP):
+            async def post(
+                self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+            ) -> _FakeHTTPResponse:
+                # Simulate a cancel landing during the dispatch await window.
+                task.status = TaskStatus.CANCELLED
+                return await super().post(url, json=json, headers=headers)
+
+        class _PatchedClient(original_cls):  # type: ignore[misc,valid-type]
+            def __init__(self, **kw: Any) -> None:
+                super().__init__(http_client=_RacingHTTP(), **kw)
+
+        fleet_client_mod.RemoteDaemonClient = _PatchedClient  # type: ignore[misc]
+        try:
+            _run(coordinator._dispatch_tick())
+        finally:
+            fleet_client_mod.RemoteDaemonClient = original_cls  # type: ignore[misc]
+
+        assert task.status is TaskStatus.CANCELLED
+        assert task.dispatched_to is None
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)

--- a/tests/unit/test_fleet_config.py
+++ b/tests/unit/test_fleet_config.py
@@ -219,7 +219,13 @@ class TestLoadFleetManifest:
             """,
         )
         monkeypatch.chdir(empty_cwd)
-        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        # Patch Path.home() rather than $HOME so the home fallback resolves the
+        # same way on every platform (Windows uses USERPROFILE, not HOME) — #981.
+        home_dir = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home_dir))
+        from maxwell_daemon.config import fleet as _fleet_mod
+
+        monkeypatch.setattr(_fleet_mod.Path, "home", classmethod(lambda cls: home_dir))
         monkeypatch.delenv("MAXWELL_FLEET_CONFIG", raising=False)
         manifest = load_fleet_manifest()
         assert manifest.fleet.name == "HOME"

--- a/tests/unit/test_gh_client.py
+++ b/tests/unit/test_gh_client.py
@@ -313,6 +313,76 @@ class TestRateLimitHandling:
         assert GitHubClient._is_rate_limit_error(0, b"rate limit") is False  # rc=0 means success
         assert GitHubClient._is_rate_limit_error(1, b"Repository not found") is False
 
+    def test_bare_403_is_not_a_rate_limit(self) -> None:
+        """A 403 without rate-limit text is an auth error, not a rate limit (#980).
+
+        GitHub returns 403 for both secondary rate limits and auth/SSO failures;
+        only a co-occurring rate-limit marker should classify it as rate-limited.
+        """
+        assert GitHubClient._is_rate_limit_error(1, b"HTTP 403: Bad credentials") is False
+        assert (
+            GitHubClient._is_rate_limit_error(1, b"403 Forbidden: SSO authorization required")
+            is False
+        )
+        # A 403 that *is* a secondary rate limit still classifies correctly.
+        assert (
+            GitHubClient._is_rate_limit_error(1, b"403 You have exceeded a secondary rate limit")
+            is True
+        )
+
+    def test_bare_403_raises_without_sleeping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bare 403 surfaces as GhCliError immediately, with no backoff sleep (#980)."""
+        slept: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+        runner = self._make_runner([(4, b"", b"HTTP 403: Bad credentials")])
+        client = GitHubClient(runner=runner)  # type: ignore[arg-type]
+        with pytest.raises(GhCliError) as exc_info:
+            asyncio.run(client._gh("api", "user"))
+        assert "403" in str(exc_info.value)
+        assert not isinstance(exc_info.value, GitHubRateLimitError)
+        assert slept == []  # no rate-limit backoff for an auth failure
+
+    def test_subprocess_timeout_kills_and_reaps(self) -> None:
+        """_default_runner kills and reaps a hung gh and raises GhCliError (#980)."""
+        from maxwell_daemon.gh import client as gh_client_mod
+
+        killed = {"value": False}
+        waited = {"value": False}
+
+        class _HungProc:
+            returncode = None
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                await asyncio.sleep(10)  # longer than the test timeout
+                return b"", b""
+
+            def kill(self) -> None:
+                killed["value"] = True
+
+            async def wait(self) -> int:
+                waited["value"] = True
+                return -9
+
+        async def fake_create(*args: object, **kwargs: object) -> _HungProc:
+            return _HungProc()
+
+        async def _run() -> None:
+            orig = gh_client_mod.asyncio.create_subprocess_exec
+            gh_client_mod.asyncio.create_subprocess_exec = fake_create  # type: ignore[assignment]
+            try:
+                with pytest.raises(GhCliError, match="timed out"):
+                    await gh_client_mod._default_runner("gh", "api", "user", timeout=0.05)
+            finally:
+                gh_client_mod.asyncio.create_subprocess_exec = orig  # type: ignore[assignment]
+
+        asyncio.run(_run())
+        assert killed["value"] is True
+        assert waited["value"] is True
+
     def test_retries_once_on_rate_limit_with_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Client retries after a rate-limit error and succeeds on the second attempt."""
 

--- a/tests/unit/test_single_instance.py
+++ b/tests/unit/test_single_instance.py
@@ -1,0 +1,78 @@
+"""Tests for the single-instance storage-root guard (#975)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from maxwell_daemon.daemon.single_instance import InstanceLock, InstanceLockError
+
+# The byte-range lock taken on Windows (msvcrt.locking) blocks even same-process
+# reads of the locked file, which makes the read-back / same-process refusal
+# assertions environment-specific. The daemon's required CI runs on Linux
+# (d-sorg-fleet) where flock is advisory; gate the OS-lock-dependent assertions.
+_skip_on_windows = pytest.mark.skipif(
+    os.name == "nt", reason="msvcrt byte-range lock blocks same-process reads; CI is Linux"
+)
+
+
+@_skip_on_windows
+def test_acquire_writes_pid_and_creates_lockfile(tmp_path: Path) -> None:
+    lock = InstanceLock(tmp_path)
+    lock.acquire()
+    try:
+        assert lock.path.exists()
+        assert lock.path.read_text(encoding="utf-8").strip() == str(os.getpid())
+    finally:
+        lock.release()
+
+
+@_skip_on_windows
+def test_second_lock_against_same_root_refuses(tmp_path: Path) -> None:
+    first = InstanceLock(tmp_path)
+    first.acquire()
+    try:
+        second = InstanceLock(tmp_path)
+        with pytest.raises(InstanceLockError):
+            second.acquire()
+    finally:
+        first.release()
+
+
+@_skip_on_windows
+def test_release_allows_reacquire(tmp_path: Path) -> None:
+    first = InstanceLock(tmp_path)
+    first.acquire()
+    first.release()
+    # A fresh lock against the same root must now succeed.
+    second = InstanceLock(tmp_path)
+    second.acquire()
+    try:
+        assert second.path.read_text(encoding="utf-8").strip() == str(os.getpid())
+    finally:
+        second.release()
+
+
+def test_stale_lock_from_dead_pid_is_reclaimed(tmp_path: Path) -> None:
+    # Simulate a crashed daemon: a lock file naming a PID that is not alive.
+    lock_path = tmp_path / "daemon.lock"
+    dead_pid = 2_147_483_646  # implausibly high; not a running process
+    lock_path.write_text(str(dead_pid), encoding="utf-8")
+
+    lock = InstanceLock(tmp_path)
+    lock.acquire()  # must not raise — stale lock reclaimed
+    try:
+        assert lock.path.read_text(encoding="utf-8").strip() == str(os.getpid())
+    finally:
+        lock.release()
+
+
+def test_context_manager_releases(tmp_path: Path) -> None:
+    with InstanceLock(tmp_path):
+        pass
+    # After exit the lock is released, so another acquire succeeds.
+    again = InstanceLock(tmp_path)
+    again.acquire()
+    again.release()

--- a/tests/unit/test_windows_support.py
+++ b/tests/unit/test_windows_support.py
@@ -1,0 +1,160 @@
+"""Cross-platform (Windows) support regressions — #981.
+
+Three breakages that prevented the daemon from running on Windows:
+
+1. ``main()`` installed SIGINT/SIGTERM handlers via ``loop.add_signal_handler``
+   without a ``NotImplementedError`` guard (crashes on Windows' ProactorEventLoop).
+2. ``config/fleet.py`` resolved the home dir via ``os.environ["HOME"]`` (unset on
+   Windows) so ``~/.maxwell-daemon/fleet.yaml`` was silently never found.
+3. ``workspace_hooks._run_hook`` split commands with POSIX-mode shlex, mangling
+   Windows paths like ``C:\\tools\\x.exe``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+from pathlib import Path
+
+import pytest
+
+from maxwell_daemon.config import fleet as fleet_mod
+from maxwell_daemon.daemon import workspace_hooks
+
+# ── (1) main() signal-handler guard ──────────────────────────────────────────
+
+
+class TestSignalHandlerGuard:
+    def test_main_starts_when_add_signal_handler_unsupported(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A loop that raises NotImplementedError (Windows) must not crash main()."""
+        from maxwell_daemon.daemon import runner as runner_mod
+
+        signals_set: list[int] = []
+
+        class _FakeLoop:
+            def add_signal_handler(self, sig: int, cb: object) -> None:
+                raise NotImplementedError("Windows ProactorEventLoop")
+
+            def call_soon_threadsafe(self, cb: object, *a: object) -> None:
+                cb()
+
+        # Drive the daemon lifecycle with stubs so we exercise only the signal
+        # wiring in main()'s _run(), not a real daemon.
+        class _FakeDaemon:
+            _config = type("C", (), {"log_file": None})()
+
+            @classmethod
+            def from_config_path(cls) -> _FakeDaemon:
+                return cls()
+
+            async def start(self) -> None:
+                return None
+
+            async def stop(self) -> None:
+                return None
+
+            def reload_config(self) -> None:
+                return None
+
+        def _fake_signal(sig: int, handler: object) -> None:
+            signals_set.append(sig)
+
+        import maxwell_daemon.logging as logging_mod
+
+        monkeypatch.setattr(runner_mod.Daemon, "from_config_path", _FakeDaemon.from_config_path)
+        monkeypatch.setattr(runner_mod.asyncio, "get_event_loop", lambda: _FakeLoop())
+        monkeypatch.setattr(runner_mod.signal, "signal", _fake_signal)
+        monkeypatch.setattr(logging_mod, "configure_logging", lambda **kw: None)
+
+        # Make stop.wait() return immediately so _run() completes.
+        real_event = asyncio.Event
+
+        class _ImmediateEvent(real_event):  # type: ignore[misc,valid-type]
+            async def wait(self) -> bool:
+                return True
+
+        monkeypatch.setattr(runner_mod.asyncio, "Event", _ImmediateEvent)
+
+        # Should not raise despite add_signal_handler being unsupported.
+        runner_mod.main()
+        # Fallback path registered SIGINT/SIGTERM via signal.signal.
+        assert runner_mod.signal.SIGINT in signals_set
+        assert runner_mod.signal.SIGTERM in signals_set
+
+
+# ── (2) fleet.py home resolution ─────────────────────────────────────────────
+
+
+class TestFleetHomeResolution:
+    def test_home_candidate_uses_path_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The ~/.maxwell-daemon/fleet.yaml candidate is derived from Path.home()."""
+        # HOME unset (as on Windows) must not drop the home candidate.
+        monkeypatch.delenv("HOME", raising=False)
+        monkeypatch.setattr(fleet_mod.Path, "home", classmethod(lambda cls: tmp_path))
+
+        candidates = fleet_mod._candidate_paths()
+
+        expected = tmp_path / fleet_mod._DEFAULT_HOME_SUBPATH
+        assert expected in candidates
+
+    def test_unresolvable_home_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A RuntimeError from Path.home() degrades gracefully (no crash)."""
+
+        def _boom(cls: object) -> Path:
+            raise RuntimeError("no home")
+
+        monkeypatch.setattr(fleet_mod.Path, "home", classmethod(_boom))
+        # cwd candidate still present; the ~/.maxwell-daemon/fleet.yaml home
+        # candidate is simply omitted rather than raising.
+        candidates = fleet_mod._candidate_paths()
+        home_subpath = str(fleet_mod._DEFAULT_HOME_SUBPATH)
+        assert all(home_subpath not in str(p) for p in candidates)
+
+
+# ── (3) workspace_hooks Windows path splitting ───────────────────────────────
+
+
+class TestHookCommandSplitting:
+    def test_windows_path_survives_split(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On Windows (os.name == 'nt') a backslash path is not mangled."""
+        monkeypatch.setattr(workspace_hooks.os, "name", "nt")
+        # Mirror the production split to assert the policy directly.
+        args = shlex.split(r"C:\tools\x.exe --flag", posix=(workspace_hooks.os.name != "nt"))
+        assert args[0] == r"C:\tools\x.exe"
+
+    def test_posix_split_still_used_off_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On POSIX, normal quoting semantics are preserved."""
+        monkeypatch.setattr(workspace_hooks.os, "name", "posix")
+        args = shlex.split("echo 'a b'", posix=(workspace_hooks.os.name != "nt"))
+        assert args == ["echo", "a b"]
+
+    def test_run_hook_parses_windows_path_without_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """_run_hook on Windows splits a native path into a single argv[0]."""
+        monkeypatch.setattr(workspace_hooks.os, "name", "nt")
+        captured: dict[str, object] = {}
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                return b"", b""
+
+        async def fake_create(*args: object, **kwargs: object) -> _Proc:
+            captured["args"] = args
+            return _Proc()
+
+        monkeypatch.setattr(workspace_hooks.asyncio, "create_subprocess_exec", fake_create)
+
+        async def _run() -> None:
+            await workspace_hooks._run_hook(
+                "win", r"C:\tools\x.exe --flag", tmp_path, timeout_seconds=5
+            )
+
+        asyncio.run(_run())
+        assert captured["args"][0] == r"C:\tools\x.exe"  # type: ignore[index]

--- a/tests/unit/test_workspace_hooks_reap.py
+++ b/tests/unit/test_workspace_hooks_reap.py
@@ -1,0 +1,53 @@
+"""workspace_hooks._run_hook must reap timed-out children (no zombies) — #980."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from maxwell_daemon.daemon import workspace_hooks
+from maxwell_daemon.daemon.workspace_hooks import WorkspaceHookError, _run_hook
+
+
+class _HungProc:
+    """A subprocess that never finishes communicate() until killed."""
+
+    returncode = None
+
+    def __init__(self) -> None:
+        self.killed = False
+        self.waited = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        await asyncio.sleep(10)  # exceeds the test's tiny timeout
+        return b"", b""
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        self.waited = True
+        return -9
+
+
+def test_timed_out_hook_is_killed_and_reaped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proc = _HungProc()
+
+    async def fake_create(*args: object, **kwargs: object) -> _HungProc:
+        return proc
+
+    monkeypatch.setattr(workspace_hooks.asyncio, "create_subprocess_exec", fake_create)
+
+    async def _run() -> None:
+        with pytest.raises(WorkspaceHookError, match="timed out"):
+            await _run_hook("slow", "sleep 100", tmp_path, timeout_seconds=0.05)
+
+    asyncio.run(_run())
+
+    assert proc.killed is True
+    # The killed child must be reaped via proc.wait() so no zombie lingers.
+    assert proc.waited is True


### PR DESCRIPTION
Bounded daemon correctness fixes plus the robustness/gh-client/Windows tranche that stacked on top of this branch (PRs #1013 and #1014 merged here).

### #971 / #972 / #975 — correctness + single-instance
- **#971** Stalled tasks no longer retry forever: `RetryPolicy` is consulted and a persisted `retry_count` bounds re-dispatch, capping unbounded spend (survives restart via a new TaskStore column + migration).
- **#972** On-loop submissions hitting a saturated queue are now observable instead of silently dropped while the API reports success.
- **#975** Single-instance guard (`InstanceLock`, keyed on the storage root) prevents a second daemon against the same storage from corrupting state / double-spending; acquired before recovery in `Daemon.start`.

### #978 / #980 — robustness + gh client (merged via #1013)
- submit_issue enqueues outside `_tasks_lock` with saturation rollback; FleetCoordinator reuses one client per machine and forwards `tls_verify`; failed dependencies fail dependents instead of churning; cancel-during-dispatch is no longer overwritten with DISPATCHED.
- gh `_default_runner` times out + reaps a hung subprocess; bare 403 is an auth error, not a masked rate limit; timed-out workspace hooks are reaped.

### #981 — Windows support (merged via #1014)
- guarded `loop.add_signal_handler` (signal.signal fallback); `Path.home()` for fleet config; Windows-aware `shlex.split`.

All changes carry unit tests; ruff + ruff format + mypy --strict clean.

Closes #971
Closes #972
Closes #975
Closes #978
Closes #980
Closes #981