### PR TITLE
fix(daemon): robustness cluster + gh client hardening (#978 #980)

### DIFF
--- a/maxwell_daemon/daemon/fleet_coordinator.py
+++ b/maxwell_daemon/daemon/fleet_coordinator.py
@@ -74,10 +74,40 @@ class FleetCoordinator:
         self._worker_last_seen = worker_last_seen
         self._enqueue_task_entry = enqueue_task_entry
         self._running_flag = running_flag
+        # One long-lived RemoteDaemonClient per machine, reused across ticks
+        # rather than a fresh httpx pool per poll (#978b). Keyed by machine name
+        # because each machine carries its own ``tls_verify``. Lazily created so
+        # importing this module never requires httpx.
+        self._clients: dict[str, Any] = {}
 
     def update_config(self, config: MaxwellDaemonConfig) -> None:
         """Swap the active config (used during hot-reload)."""
         self._config = config
+
+    async def aclose(self) -> None:
+        """Release every per-machine remote client's connection pool."""
+        clients = list(self._clients.values())
+        self._clients.clear()
+        for client in clients:
+            await client.aclose()
+
+    def _client_for(self, machine: Any) -> Any:
+        """Return the long-lived client for ``machine``, creating it on first use.
+
+        Each client forwards the machine's ``tls_verify`` to httpx so a
+        self-signed fleet member with ``tls_verify=False`` is actually probed
+        instead of failing every health check (#978b).
+        """
+        from maxwell_daemon.fleet.client import RemoteDaemonClient
+
+        client = self._clients.get(machine.name)
+        if client is None:
+            client = RemoteDaemonClient(
+                auth_token=self._config.api_auth_token,
+                tls_verify=getattr(machine, "tls_verify", True),
+            )
+            self._clients[machine.name] = client
+        return client
 
     async def run_loop(self) -> None:
         """Coordinator event loop — runs until the daemon stops."""
@@ -92,7 +122,7 @@ class FleetCoordinator:
     async def _dispatch_tick(self) -> None:  # noqa: C901
         """One coordinator dispatch tick: probe machines, plan, submit, requeue stale tasks."""
         from maxwell_daemon.daemon.task_models import TaskStatus
-        from maxwell_daemon.fleet.client import RemoteDaemonClient, RemoteDaemonError
+        from maxwell_daemon.fleet.client import RemoteDaemonError
         from maxwell_daemon.fleet.dispatcher import (
             FleetDispatcher,
             MachineState,
@@ -103,7 +133,9 @@ class FleetCoordinator:
         if not fleet_machines:
             return
 
-        # Build initial MachineState snapshots from config.
+        # Build initial MachineState snapshots from config. ``tls``/``tls_verify``
+        # must be carried through so the scheme and certificate-verification
+        # policy reach the per-machine client (#978b).
         initial_machines = tuple(
             MachineState(
                 name=m.name,
@@ -111,16 +143,34 @@ class FleetCoordinator:
                 port=m.port,
                 capacity=m.capacity,
                 tags=tuple(m.tags),
+                tls=getattr(m, "tls", True),
+                tls_verify=getattr(m, "tls_verify", True),
             )
             for m in fleet_machines
         )
 
-        client = RemoteDaemonClient(
-            auth_token=self._config.api_auth_token,
-        )
+        # Probe all machines in parallel to get live health, each via its own
+        # long-lived per-machine client so per-machine ``tls_verify`` is honored
+        # and no httpx pool is leaked per tick (#978b).
+        async def _probe(m: MachineState) -> bool:
+            healthy: bool = await self._client_for(m).health_check(m)
+            return healthy
 
-        # Probe all machines in parallel to get live health.
-        machines = await client.refresh_all(initial_machines)
+        health = await asyncio.gather(*(_probe(m) for m in initial_machines))
+        machines = tuple(
+            MachineState(
+                name=m.name,
+                host=m.host,
+                port=m.port,
+                capacity=m.capacity,
+                tags=m.tags,
+                active_tasks=m.active_tasks,
+                healthy=healthy,
+                tls=m.tls,
+                tls_verify=m.tls_verify,
+            )
+            for m, healthy in zip(initial_machines, health, strict=True)
+        )
 
         # Requeue tasks dispatched to machines that have gone offline.
         now = datetime.now(timezone.utc)
@@ -198,7 +248,9 @@ class FleetCoordinator:
             }
 
             try:
-                result = await client.submit_task(machine, task_payload=task_payload)
+                result = await self._client_for(machine).submit_task(
+                    machine, task_payload=task_payload
+                )
             except RemoteDaemonError:
                 log.exception(
                     "failed to dispatch task %s to machine %s",
@@ -208,8 +260,24 @@ class FleetCoordinator:
                 continue
 
             if result.status == "submitted":
-                assigned_task.status = TaskStatus.DISPATCHED
-                assigned_task.dispatched_to = machine.name
+                # Re-check the task is still QUEUED under the lock before flipping
+                # to DISPATCHED: a cancel racing the submit_task await window must
+                # not be overwritten, which would run a cancelled task remotely
+                # (#978d). The snapshot above is stale across the await.
+                with self._tasks_lock:
+                    live = self._tasks.get(assigned_task.id)
+                    if live is None or live.status is not TaskStatus.QUEUED:
+                        log.info(
+                            "task %s no longer QUEUED (status=%s) after remote submit to %s; "
+                            "not marking DISPATCHED",
+                            assigned_task.id,
+                            None if live is None else live.status.value,
+                            machine.name,
+                        )
+                        continue
+                    live.status = TaskStatus.DISPATCHED
+                    live.dispatched_to = machine.name
+                    assigned_task = live
                 log.info("dispatched task %s to machine %s", assigned_task.id, machine.name)
                 try:
                     self._task_store.save(assigned_task)

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -378,6 +378,32 @@ class Daemon:
             except asyncio.QueueFull:
                 await self._queue.put(deferred_item)
 
+    def _classify_dependencies_locked(self, task: Task) -> tuple[str | None, bool]:
+        """Classify a task's dependencies. Caller must hold ``_tasks_lock``.
+
+        Returns ``(failed_dependency, deps_pending)``:
+
+        * ``failed_dependency`` is the id of the first dependency that terminally
+          failed/cancelled — such a dependency will never reach COMPLETED, so
+          deferring on it would strand the dependent in a tight re-enqueue loop
+          forever (#978c). When set, the dependent should be failed.
+        * ``deps_pending`` is True when at least one dependency is still
+          unfinished (missing or not yet COMPLETED) and none has failed — the
+          dependent should be deferred.
+        """
+        for dep in task.depends_on:
+            dep_task = self._tasks.get(dep)
+            if dep_task is not None and dep_task.status in (
+                TaskStatus.FAILED,
+                TaskStatus.CANCELLED,
+            ):
+                return dep, False
+        deps_pending = any(
+            self._tasks.get(dep) is None or self._tasks[dep].status is not TaskStatus.COMPLETED
+            for dep in task.depends_on
+        )
+        return None, deps_pending
+
     async def _claim_next_queued_task(self) -> tuple[bool, Task | None]:
         deferred: list[tuple[int, Task]] = []
         claimed: Task | None = None
@@ -396,27 +422,55 @@ class Daemon:
             task = payload
 
             kind_cap = self._kind_cap_for(task)
+            failed_dependency: str | None = None
             with self._tasks_lock:
                 if task.status is not TaskStatus.QUEUED:
                     continue
                 if task.depends_on:
-                    unfinished = [
-                        dep
-                        for dep in task.depends_on
-                        if self._tasks.get(dep) is None
-                        or self._tasks[dep].status is not TaskStatus.COMPLETED
-                    ]
-                    if unfinished:
+                    failed_dependency, deps_pending = self._classify_dependencies_locked(task)
+                    if failed_dependency is None and deps_pending:
                         deferred.append((priority, task))
                         continue
-                if kind_cap is not None:
-                    kind_key = self._task_kind_key(task)
-                    if self._count_running_tasks_locked(kind_key=kind_key) >= kind_cap:
-                        deferred.append((priority, task))
-                        continue
-                task.status = TaskStatus.RUNNING
-                task.started_at = datetime.now(timezone.utc)
-                claimed = task
+                if failed_dependency is not None:
+                    dep_message = f"dependency {failed_dependency} failed"
+                    task.status = TaskStatus.FAILED
+                    task.error = dep_message
+                    task.finished_at = datetime.now(timezone.utc)
+                else:
+                    if kind_cap is not None:
+                        kind_key = self._task_kind_key(task)
+                        if self._count_running_tasks_locked(kind_key=kind_key) >= kind_cap:
+                            deferred.append((priority, task))
+                            continue
+                    task.status = TaskStatus.RUNNING
+                    task.started_at = datetime.now(timezone.utc)
+                    claimed = task
+            # Persist + publish the dependency-failure outside the lock (no store
+            # I/O or awaiting while holding the threading lock), then keep draining
+            # the queue rather than claiming the failed task for execution.
+            if failed_dependency is not None:
+                try:
+                    self._task_store.save(task)
+                except Exception:
+                    log.exception(
+                        "task store write failed while failing dependent task=%s", task.id
+                    )
+                await self._events.publish(
+                    Event(
+                        kind=EventKind.TASK_FAILED,
+                        payload=attach_observability(
+                            {
+                                "id": task.id,
+                                "error": task.error,
+                                "reason": "dependency_failed",
+                            },
+                            task_id=task.id,
+                            backend=task.backend,
+                            model=task.model,
+                        ),
+                    )
+                )
+                continue
             # ``put_nowait``/await of deferred entries must happen OUTSIDE the
             # threading lock (no awaiting while holding it).
             if claimed is not None:
@@ -581,6 +635,11 @@ class Daemon:
                 await close_method()
 
         await self._mcp_manager.stop()
+
+        # Release the long-lived per-machine fleet clients' connection pools
+        # (#978b) so a coordinator shutdown leaves no leaked httpx sockets.
+        if self._fleet_coordinator is not None:
+            await self._fleet_coordinator.aclose()
 
         # Release the single-instance lock so a clean restart can re-acquire it.
         self._instance_lock.release()
@@ -1151,19 +1210,23 @@ class Daemon:
             priority=priority,
             dry_run=dry_run,
         )
-        # See note in submit(): queue mutation must stay loop-affine once the
-        # daemon has started.
+        # See note in submit(): the queue mutation waits for the daemon loop to
+        # run a callback, so it must happen *outside* _tasks_lock — holding the
+        # lock across the cross-thread enqueue can deadlock the loop. Persist and
+        # track under the lock, enqueue after release, and roll back on
+        # saturation so a rejected task leaves no orphaned store/registry row.
         with self._tasks_lock:
             if task_id is not None:
                 self._reject_duplicate_task_id(task.id)
             self._task_store.save(task)
             self._tasks[task.id] = task
-            try:
-                self._enqueue_task_entry(task.priority, task)
-            except QueueSaturationError:
+        try:
+            self._enqueue_task_entry(task.priority, task)
+        except QueueSaturationError:
+            with self._tasks_lock:
                 del self._tasks[task.id]
-                self._task_store.delete(task.id)
-                raise
+            self._task_store.delete(task.id)
+            raise
         try:
             loop = asyncio.get_running_loop()
             bg = loop.create_task(

--- a/maxwell_daemon/daemon/workspace_hooks.py
+++ b/maxwell_daemon/daemon/workspace_hooks.py
@@ -72,6 +72,9 @@ async def _run_hook(
 
             with contextlib.suppress(OSError):
                 proc.kill()
+            # Reap the killed child so it does not linger as a zombie (#980).
+            with contextlib.suppress(Exception):
+                await proc.wait()
             raise WorkspaceHookError(f"Hook {name!r} timed out after {timeout_seconds}s") from None
     except Exception as e:
         if isinstance(e, WorkspaceHookError):

--- a/maxwell_daemon/fleet/client.py
+++ b/maxwell_daemon/fleet/client.py
@@ -90,10 +90,30 @@ class RemoteDaemonClient:
         timeout_seconds: float = 30.0,
         tls_verify: bool = True,
     ) -> None:
-        self._http = http_client if http_client is not None else _make_default_http(timeout_seconds)
+        # Forward tls_verify into the default httpx adapter so ``tls_verify=False``
+        # actually reaches httpx; otherwise self-signed fleets fail every probe
+        # and surface only as "machine unhealthy" (#978b). We own the transport
+        # only when we created it — an injected client is the caller's to close.
+        self._owns_http = http_client is None
+        self._http = (
+            http_client
+            if http_client is not None
+            else _make_default_http(timeout_seconds, tls_verify=tls_verify)
+        )
         self._auth_token = auth_token
         self._timeout_seconds = timeout_seconds
         self._tls_verify = tls_verify
+
+    async def aclose(self) -> None:
+        """Release the underlying connection pool if we created it.
+
+        Injected transports are owned by the caller and left untouched so the
+        coordinator can hold one long-lived client per remote (#978b).
+        """
+        if self._owns_http:
+            aclose = getattr(self._http, "aclose", None)
+            if aclose is not None:
+                await aclose()
 
     # ------------------------------------------------------------------ headers
     def _headers(self) -> dict[str, str]:

--- a/maxwell_daemon/gh/client.py
+++ b/maxwell_daemon/gh/client.py
@@ -12,6 +12,7 @@ and other bounded inputs get regex-validated before they reach the subprocess.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import re
 import time
@@ -66,12 +67,15 @@ RateLimitError = GitHubRateLimitError
 
 # Exit codes emitted by `gh` when GitHub returns 403 or 429 (rate-limited).
 _RATE_LIMIT_EXIT_CODES: frozenset[int] = frozenset({4})  # gh uses rc=4 for HTTP 4xx
-# Error substrings that indicate a rate-limit response rather than an auth error.
+# Error substrings that indicate a genuine rate-limit response rather than an
+# auth error. A bare "403" is deliberately NOT here: GitHub returns 403 for both
+# secondary rate limits AND auth/SSO failures, so treating every 403 as a rate
+# limit masks bad-token errors as ~15s+ sleeps (#980). A 403 only counts as a
+# rate limit when one of these co-occurring markers is present.
 _RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "rate limit",
     "rate_limit",
     "429",
-    "403",
     "secondary rate",
     "abuse detection",
 )
@@ -120,14 +124,34 @@ class PullRequest:
         return cls(number=int(match.group(1)), url=url, draft=draft)
 
 
-async def _default_runner(*argv: str, cwd: str | None = None) -> tuple[int, bytes, bytes]:
+# Wall-clock ceiling for a single `gh` invocation. A hung `gh` (e.g. a stuck
+# network call or auth prompt) must not pin a worker until the stall reconciler
+# fires and feeds the retry loop (#980).
+_GH_SUBPROCESS_TIMEOUT_SECONDS = 120.0
+
+
+async def _default_runner(
+    *argv: str,
+    cwd: str | None = None,
+    timeout: float = _GH_SUBPROCESS_TIMEOUT_SECONDS,
+) -> tuple[int, bytes, bytes]:
     proc = await asyncio.create_subprocess_exec(
         *argv,
         cwd=cwd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, stderr = await proc.communicate()
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        # Kill and reap so the hung child does not linger as a zombie, then
+        # surface a clear error instead of blocking the worker indefinitely.
+        proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        raise GhCliError(
+            f"gh {' '.join(argv)} timed out after {timeout:.0f}s and was killed"
+        ) from None
     return proc.returncode or 0, stdout, stderr
 
 

--- a/tests/unit/test_daemon_robustness.py
+++ b/tests/unit/test_daemon_robustness.py
@@ -1,0 +1,309 @@
+"""Daemon robustness cluster regressions (#978).
+
+Four related defects on the runner / fleet-coordinator paths:
+
+* (a) ``submit_issue`` must not enqueue while holding ``_tasks_lock``.
+* (b) the coordinator must reuse one client per remote and forward ``tls_verify``.
+* (c) a dependent of a terminally-failed dependency must FAIL, not churn forever.
+* (d) a cancel racing the dispatch await window must not be overwritten with
+  DISPATCHED.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Awaitable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, TypeVar
+from unittest.mock import MagicMock
+
+from maxwell_daemon.config import MaxwellDaemonConfig
+from maxwell_daemon.daemon import Daemon
+from maxwell_daemon.daemon.fleet_coordinator import FleetCoordinator
+from maxwell_daemon.daemon.task_models import Task, TaskKind, TaskStatus
+from maxwell_daemon.events import EventKind
+
+T = TypeVar("T")
+
+
+def _run(coro: Awaitable[T]) -> T:
+    return asyncio.new_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+
+def _make_daemon(tmp_path: Path, cfg: MaxwellDaemonConfig, suffix: str = "a") -> Daemon:
+    return Daemon(
+        cfg,
+        ledger_path=tmp_path / f"ledger-{suffix}.db",
+        task_store_path=tmp_path / f"tasks-{suffix}.db",
+    )
+
+
+# ── (a) submit_issue enqueues outside _tasks_lock ────────────────────────────
+
+
+class TestSubmitIssueLockDiscipline:
+    def test_enqueue_runs_without_holding_tasks_lock(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        """The enqueue must observe an *unlocked* _tasks_lock (#978a).
+
+        We assert the lock is acquirable from inside the enqueue callback — if
+        submit_issue still held it, ``acquire(blocking=False)`` would fail.
+        """
+        d = _make_daemon(tmp_path, minimal_config)
+        observed: dict[str, bool] = {}
+        original = d._enqueue_task_entry
+
+        def _spy(priority: int, task: Task) -> None:
+            got = d._tasks_lock.acquire(blocking=False)
+            observed["lock_free"] = got
+            if got:
+                d._tasks_lock.release()
+            original(priority, task)
+
+        d._enqueue_task_entry = _spy  # type: ignore[method-assign]
+        task = d.submit_issue(repo="owner/repo", issue_number=1)
+        assert observed["lock_free"] is True
+        assert d._tasks[task.id].status is TaskStatus.QUEUED
+
+    def test_saturation_rolls_back_store_and_registry(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        """A saturated enqueue leaves no orphaned task in the store or registry."""
+        from maxwell_daemon.daemon.runner import QueueSaturationError
+
+        d = _make_daemon(tmp_path, minimal_config)
+
+        def _boom(priority: int, task: Task) -> None:
+            raise QueueSaturationError("queue full")
+
+        d._enqueue_task_entry = _boom  # type: ignore[method-assign]
+        try:
+            d.submit_issue(repo="owner/repo", issue_number=2)
+        except QueueSaturationError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected QueueSaturationError")
+        assert d._tasks == {}
+        assert d._task_store.get("__none__") is None
+
+
+# ── (c) failed dependency fails the dependent ────────────────────────────────
+
+
+class TestFailedDependencyFailsDependent:
+    def test_dependent_of_failed_dep_transitions_to_failed(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        d = _make_daemon(tmp_path, minimal_config)
+
+        dep = Task(id="dep", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.FAILED)
+        dependent = Task(
+            id="child",
+            prompt="p",
+            kind=TaskKind.PROMPT,
+            status=TaskStatus.QUEUED,
+            depends_on=["dep"],
+        )
+        d._tasks[dep.id] = dep
+        d._tasks[dependent.id] = dependent
+        d._task_store.save(dep)
+        d._task_store.save(dependent)
+        d._queue.put_nowait((dependent.priority, dependent))
+
+        events: list[Any] = []
+
+        async def _capture(event: Any) -> None:
+            events.append(event)
+
+        d._events.publish = _capture  # type: ignore[method-assign]
+
+        _stopped, claimed = _run(d._claim_next_queued_task())
+
+        assert claimed is None
+        assert dependent.status is TaskStatus.FAILED
+        assert "dep" in (dependent.error or "")
+        # Persisted failure + a TASK_FAILED event with the dependency reason.
+        assert d._task_store.get("child").status is TaskStatus.FAILED
+        assert any(e.kind is EventKind.TASK_FAILED for e in events)
+
+    def test_completed_dependency_still_allows_claim(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        """A COMPLETED dependency must not be mistaken for a failed one."""
+        d = _make_daemon(tmp_path, minimal_config)
+        dep = Task(id="dep", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.COMPLETED)
+        dependent = Task(
+            id="child",
+            prompt="p",
+            kind=TaskKind.PROMPT,
+            status=TaskStatus.QUEUED,
+            depends_on=["dep"],
+        )
+        d._tasks[dep.id] = dep
+        d._tasks[dependent.id] = dependent
+        d._queue.put_nowait((dependent.priority, dependent))
+
+        _stopped, claimed = _run(d._claim_next_queued_task())
+
+        assert claimed is dependent
+        assert dependent.status is TaskStatus.RUNNING
+
+
+# ── (b)/(d) fleet coordinator: client reuse, tls_verify, cancel race ──────────
+
+
+@dataclass
+class _FakeHTTPResponse:
+    status_code: int
+    _body: dict[str, Any] = field(default_factory=dict)
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+@dataclass
+class _RecordingHTTP:
+    """Records calls; health 200, submit 202. Tracks aclose() for leak checks."""
+
+    submitted: list[dict[str, Any]] = field(default_factory=list)
+    closed: bool = False
+
+    async def get(self, url: str, *, headers: dict[str, str]) -> _FakeHTTPResponse:
+        return _FakeHTTPResponse(status_code=200)
+
+    async def post(
+        self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+    ) -> _FakeHTTPResponse:
+        self.submitted.append({"url": url, "payload": json})
+        return _FakeHTTPResponse(status_code=202)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _make_coordinator(
+    *,
+    tasks: dict[str, Task],
+    machines: list[Any],
+    task_store: Any = None,
+) -> FleetCoordinator:
+    config = SimpleNamespace(
+        fleet_machines=machines,
+        fleet_coordinator_poll_seconds=5,
+        fleet_heartbeat_seconds=30,
+        api_auth_token=None,
+    )
+    return FleetCoordinator(
+        config=config,
+        tasks=tasks,
+        tasks_lock=threading.Lock(),
+        task_store=task_store or MagicMock(),
+        worker_last_seen={},
+        enqueue_task_entry=MagicMock(),
+        running_flag=lambda: False,
+    )
+
+
+class TestCoordinatorClientLifecycle:
+    def test_tls_verify_false_reaches_httpx(self) -> None:
+        """tls_verify on the machine config must reach the default httpx client (#978b)."""
+        from maxwell_daemon.fleet.client import RemoteDaemonClient
+
+        client = RemoteDaemonClient(tls_verify=False)
+        # The default adapter stores the verify flag on its httpx client.
+        assert client._tls_verify is False
+        assert client._owns_http is True
+
+    def test_injected_client_is_not_closed(self) -> None:
+        """aclose() only releases transports the client created itself (#978b)."""
+        from maxwell_daemon.fleet.client import RemoteDaemonClient
+
+        http = _RecordingHTTP()
+        client = RemoteDaemonClient(http_client=http)
+        _run(client.aclose())
+        assert http.closed is False  # caller owns an injected transport
+
+    def test_one_persistent_client_per_machine_reused(self) -> None:
+        """Two ticks must reuse one client per machine, not build a new pool each tick."""
+        task = Task(id="t1", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.QUEUED)
+        machine = SimpleNamespace(
+            name="w1", host="h", port=8080, capacity=1, tags=[], tls=False, tls_verify=False
+        )
+        coordinator = _make_coordinator(tasks={"t1": task}, machines=[machine])
+
+        created: list[Any] = []
+        import maxwell_daemon.fleet.client as fleet_client_mod
+
+        original_cls = fleet_client_mod.RemoteDaemonClient
+
+        class _PatchedClient(original_cls):  # type: ignore[misc,valid-type]
+            def __init__(self, **kw: Any) -> None:
+                super().__init__(http_client=_RecordingHTTP(), **kw)
+                self.aclose_calls = 0
+                created.append(self)
+
+            async def aclose(self) -> None:
+                self.aclose_calls += 1
+                await super().aclose()
+
+        fleet_client_mod.RemoteDaemonClient = _PatchedClient  # type: ignore[misc]
+        try:
+            _run(coordinator._dispatch_tick())
+            # Reset task to QUEUED for a second tick and dispatch again.
+            task.status = TaskStatus.QUEUED
+            task.dispatched_to = None
+            _run(coordinator._dispatch_tick())
+        finally:
+            fleet_client_mod.RemoteDaemonClient = original_cls  # type: ignore[misc]
+
+        # One client built for the single machine, reused across both ticks
+        # rather than a fresh pool per tick (#978b).
+        assert len(created) == 1
+        assert created[0]._tls_verify is False
+        # coordinator.aclose() propagates to every cached per-machine client.
+        _run(coordinator.aclose())
+        assert created[0].aclose_calls == 1
+        assert coordinator._clients == {}
+
+    def test_cancel_during_dispatch_await_is_not_overwritten(self) -> None:
+        """A task cancelled while submit_task awaits stays CANCELLED, not DISPATCHED (#978d)."""
+        task = Task(id="t1", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.QUEUED)
+        machine = SimpleNamespace(
+            name="w1", host="h", port=8080, capacity=1, tags=[], tls=False, tls_verify=True
+        )
+        tasks = {"t1": task}
+        coordinator = _make_coordinator(tasks=tasks, machines=[machine])
+
+        import maxwell_daemon.fleet.client as fleet_client_mod
+
+        original_cls = fleet_client_mod.RemoteDaemonClient
+
+        class _RacingHTTP(_RecordingHTTP):
+            async def post(
+                self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+            ) -> _FakeHTTPResponse:
+                # Simulate a cancel landing during the dispatch await window.
+                task.status = TaskStatus.CANCELLED
+                return await super().post(url, json=json, headers=headers)
+
+        class _PatchedClient(original_cls):  # type: ignore[misc,valid-type]
+            def __init__(self, **kw: Any) -> None:
+                super().__init__(http_client=_RacingHTTP(), **kw)
+
+        fleet_client_mod.RemoteDaemonClient = _PatchedClient  # type: ignore[misc]
+        try:
+            _run(coordinator._dispatch_tick())
+        finally:
+            fleet_client_mod.RemoteDaemonClient = original_cls  # type: ignore[misc]
+
+        assert task.status is TaskStatus.CANCELLED
+        assert task.dispatched_to is None
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)

--- a/tests/unit/test_gh_client.py
+++ b/tests/unit/test_gh_client.py
@@ -313,6 +313,76 @@ class TestRateLimitHandling:
         assert GitHubClient._is_rate_limit_error(0, b"rate limit") is False  # rc=0 means success
         assert GitHubClient._is_rate_limit_error(1, b"Repository not found") is False
 
+    def test_bare_403_is_not_a_rate_limit(self) -> None:
+        """A 403 without rate-limit text is an auth error, not a rate limit (#980).
+
+        GitHub returns 403 for both secondary rate limits and auth/SSO failures;
+        only a co-occurring rate-limit marker should classify it as rate-limited.
+        """
+        assert GitHubClient._is_rate_limit_error(1, b"HTTP 403: Bad credentials") is False
+        assert (
+            GitHubClient._is_rate_limit_error(1, b"403 Forbidden: SSO authorization required")
+            is False
+        )
+        # A 403 that *is* a secondary rate limit still classifies correctly.
+        assert (
+            GitHubClient._is_rate_limit_error(1, b"403 You have exceeded a secondary rate limit")
+            is True
+        )
+
+    def test_bare_403_raises_without_sleeping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bare 403 surfaces as GhCliError immediately, with no backoff sleep (#980)."""
+        slept: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+        runner = self._make_runner([(4, b"", b"HTTP 403: Bad credentials")])
+        client = GitHubClient(runner=runner)  # type: ignore[arg-type]
+        with pytest.raises(GhCliError) as exc_info:
+            asyncio.run(client._gh("api", "user"))
+        assert "403" in str(exc_info.value)
+        assert not isinstance(exc_info.value, GitHubRateLimitError)
+        assert slept == []  # no rate-limit backoff for an auth failure
+
+    def test_subprocess_timeout_kills_and_reaps(self) -> None:
+        """_default_runner kills and reaps a hung gh and raises GhCliError (#980)."""
+        from maxwell_daemon.gh import client as gh_client_mod
+
+        killed = {"value": False}
+        waited = {"value": False}
+
+        class _HungProc:
+            returncode = None
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                await asyncio.sleep(10)  # longer than the test timeout
+                return b"", b""
+
+            def kill(self) -> None:
+                killed["value"] = True
+
+            async def wait(self) -> int:
+                waited["value"] = True
+                return -9
+
+        async def fake_create(*args: object, **kwargs: object) -> _HungProc:
+            return _HungProc()
+
+        async def _run() -> None:
+            orig = gh_client_mod.asyncio.create_subprocess_exec
+            gh_client_mod.asyncio.create_subprocess_exec = fake_create  # type: ignore[assignment]
+            try:
+                with pytest.raises(GhCliError, match="timed out"):
+                    await gh_client_mod._default_runner("gh", "api", "user", timeout=0.05)
+            finally:
+                gh_client_mod.asyncio.create_subprocess_exec = orig  # type: ignore[assignment]
+
+        asyncio.run(_run())
+        assert killed["value"] is True
+        assert waited["value"] is True
+
     def test_retries_once_on_rate_limit_with_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Client retries after a rate-limit error and succeeds on the second attempt."""
 

--- a/tests/unit/test_workspace_hooks_reap.py
+++ b/tests/unit/test_workspace_hooks_reap.py
@@ -1,0 +1,53 @@
+"""workspace_hooks._run_hook must reap timed-out children (no zombies) — #980."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from maxwell_daemon.daemon import workspace_hooks
+from maxwell_daemon.daemon.workspace_hooks import WorkspaceHookError, _run_hook
+
+
+class _HungProc:
+    """A subprocess that never finishes communicate() until killed."""
+
+    returncode = None
+
+    def __init__(self) -> None:
+        self.killed = False
+        self.waited = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        await asyncio.sleep(10)  # exceeds the test's tiny timeout
+        return b"", b""
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        self.waited = True
+        return -9
+
+
+def test_timed_out_hook_is_killed_and_reaped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proc = _HungProc()
+
+    async def fake_create(*args: object, **kwargs: object) -> _HungProc:
+        return proc
+
+    monkeypatch.setattr(workspace_hooks.asyncio, "create_subprocess_exec", fake_create)
+
+    async def _run() -> None:
+        with pytest.raises(WorkspaceHookError, match="timed out"):
+            await _run_hook("slow", "sleep 100", tmp_path, timeout_seconds=0.05)
+
+    asyncio.run(_run())
+
+    assert proc.killed is True
+    # The killed child must be reaped via proc.wait() so no zombie lingers.
+    assert proc.waited is True


### PR DESCRIPTION
Daemon robustness cluster (#978) plus gh-client / hook hardening (#980).

**Base note:** stacked on `daemon/correctness-stall-queue-singleton-971-972-975` (PR #1012); GitHub will retarget to `main` once that merges.

### #978 — daemon robustness (four defects)
- **(a)** `submit_issue` now enqueues *outside* `_tasks_lock` with saturation rollback, matching `submit()` and avoiding the documented cross-thread deadlock.
- **(b)** `FleetCoordinator` holds one long-lived `RemoteDaemonClient` per machine (reused across ticks, released on `stop()`), and per-machine `tls_verify` is forwarded into httpx so self-signed fleets are actually probed instead of failing every health check.
- **(c)** a dependent of a terminally FAILED/CANCELLED dependency transitions to `FAILED("dependency X failed")` instead of churning the re-enqueue loop forever.
- **(d)** the coordinator re-checks the task is still `QUEUED` under `_tasks_lock` before flipping it to `DISPATCHED`, so a cancel racing the `submit_task` await window is not overwritten into a remote run.

### #980 — gh subprocess + hooks
- `_default_runner` wraps `communicate()` in `asyncio.wait_for`; a hung `gh` is killed and reaped, raising `GhCliError` instead of pinning a worker.
- a bare `403` (no rate-limit text) is now an auth error surfaced immediately, no longer masked as a rate limit with a ~15s sleep.
- `workspace_hooks._run_hook` awaits `proc.wait()` after killing a timed-out hook so no zombie lingers.

Tests: `test_daemon_robustness.py`, additions to `test_gh_client.py`, `test_workspace_hooks_reap.py`. ruff + ruff format + mypy --strict clean locally.

Closes #978
Closes #980