### PR TITLE
fix(daemon): repair three Windows-support breakages (#981)

### DIFF
--- a/maxwell_daemon/config/fleet.py
+++ b/maxwell_daemon/config/fleet.py
@@ -155,9 +155,15 @@ def _candidate_paths() -> list[Path]:
     if env:
         paths.append(Path(env))
     paths.append(Path.cwd() / _CWD_FILENAME)
-    home = os.environ.get("HOME")
-    if home:
-        paths.append(Path(home) / _DEFAULT_HOME_SUBPATH)
+    # ``Path.home()`` resolves the user home on every platform (USERPROFILE on
+    # Windows); ``os.environ["HOME"]`` is unset on Windows, which silently
+    # dropped the default ~/.maxwell-daemon/fleet.yaml candidate there (#981).
+    try:
+        home = Path.home()
+    except RuntimeError:
+        home = None
+    if home is not None:
+        paths.append(home / _DEFAULT_HOME_SUBPATH)
     return paths
 
 

--- a/maxwell_daemon/daemon/fleet_coordinator.py
+++ b/maxwell_daemon/daemon/fleet_coordinator.py
@@ -74,10 +74,40 @@ class FleetCoordinator:
         self._worker_last_seen = worker_last_seen
         self._enqueue_task_entry = enqueue_task_entry
         self._running_flag = running_flag
+        # One long-lived RemoteDaemonClient per machine, reused across ticks
+        # rather than a fresh httpx pool per poll (#978b). Keyed by machine name
+        # because each machine carries its own ``tls_verify``. Lazily created so
+        # importing this module never requires httpx.
+        self._clients: dict[str, Any] = {}
 
     def update_config(self, config: MaxwellDaemonConfig) -> None:
         """Swap the active config (used during hot-reload)."""
         self._config = config
+
+    async def aclose(self) -> None:
+        """Release every per-machine remote client's connection pool."""
+        clients = list(self._clients.values())
+        self._clients.clear()
+        for client in clients:
+            await client.aclose()
+
+    def _client_for(self, machine: Any) -> Any:
+        """Return the long-lived client for ``machine``, creating it on first use.
+
+        Each client forwards the machine's ``tls_verify`` to httpx so a
+        self-signed fleet member with ``tls_verify=False`` is actually probed
+        instead of failing every health check (#978b).
+        """
+        from maxwell_daemon.fleet.client import RemoteDaemonClient
+
+        client = self._clients.get(machine.name)
+        if client is None:
+            client = RemoteDaemonClient(
+                auth_token=self._config.api_auth_token,
+                tls_verify=getattr(machine, "tls_verify", True),
+            )
+            self._clients[machine.name] = client
+        return client
 
     async def run_loop(self) -> None:
         """Coordinator event loop — runs until the daemon stops."""
@@ -92,7 +122,7 @@ class FleetCoordinator:
     async def _dispatch_tick(self) -> None:  # noqa: C901
         """One coordinator dispatch tick: probe machines, plan, submit, requeue stale tasks."""
         from maxwell_daemon.daemon.task_models import TaskStatus
-        from maxwell_daemon.fleet.client import RemoteDaemonClient, RemoteDaemonError
+        from maxwell_daemon.fleet.client import RemoteDaemonError
         from maxwell_daemon.fleet.dispatcher import (
             FleetDispatcher,
             MachineState,
@@ -103,7 +133,9 @@ class FleetCoordinator:
         if not fleet_machines:
             return
 
-        # Build initial MachineState snapshots from config.
+        # Build initial MachineState snapshots from config. ``tls``/``tls_verify``
+        # must be carried through so the scheme and certificate-verification
+        # policy reach the per-machine client (#978b).
         initial_machines = tuple(
             MachineState(
                 name=m.name,
@@ -111,16 +143,34 @@ class FleetCoordinator:
                 port=m.port,
                 capacity=m.capacity,
                 tags=tuple(m.tags),
+                tls=getattr(m, "tls", True),
+                tls_verify=getattr(m, "tls_verify", True),
             )
             for m in fleet_machines
         )
 
-        client = RemoteDaemonClient(
-            auth_token=self._config.api_auth_token,
-        )
+        # Probe all machines in parallel to get live health, each via its own
+        # long-lived per-machine client so per-machine ``tls_verify`` is honored
+        # and no httpx pool is leaked per tick (#978b).
+        async def _probe(m: MachineState) -> bool:
+            healthy: bool = await self._client_for(m).health_check(m)
+            return healthy
 
-        # Probe all machines in parallel to get live health.
-        machines = await client.refresh_all(initial_machines)
+        health = await asyncio.gather(*(_probe(m) for m in initial_machines))
+        machines = tuple(
+            MachineState(
+                name=m.name,
+                host=m.host,
+                port=m.port,
+                capacity=m.capacity,
+                tags=m.tags,
+                active_tasks=m.active_tasks,
+                healthy=healthy,
+                tls=m.tls,
+                tls_verify=m.tls_verify,
+            )
+            for m, healthy in zip(initial_machines, health, strict=True)
+        )
 
         # Requeue tasks dispatched to machines that have gone offline.
         now = datetime.now(timezone.utc)
@@ -198,7 +248,9 @@ class FleetCoordinator:
             }
 
             try:
-                result = await client.submit_task(machine, task_payload=task_payload)
+                result = await self._client_for(machine).submit_task(
+                    machine, task_payload=task_payload
+                )
             except RemoteDaemonError:
                 log.exception(
                     "failed to dispatch task %s to machine %s",
@@ -208,8 +260,24 @@ class FleetCoordinator:
                 continue
 
             if result.status == "submitted":
-                assigned_task.status = TaskStatus.DISPATCHED
-                assigned_task.dispatched_to = machine.name
+                # Re-check the task is still QUEUED under the lock before flipping
+                # to DISPATCHED: a cancel racing the submit_task await window must
+                # not be overwritten, which would run a cancelled task remotely
+                # (#978d). The snapshot above is stale across the await.
+                with self._tasks_lock:
+                    live = self._tasks.get(assigned_task.id)
+                    if live is None or live.status is not TaskStatus.QUEUED:
+                        log.info(
+                            "task %s no longer QUEUED (status=%s) after remote submit to %s; "
+                            "not marking DISPATCHED",
+                            assigned_task.id,
+                            None if live is None else live.status.value,
+                            machine.name,
+                        )
+                        continue
+                    live.status = TaskStatus.DISPATCHED
+                    live.dispatched_to = machine.name
+                    assigned_task = live
                 log.info("dispatched task %s to machine %s", assigned_task.id, machine.name)
                 try:
                     self._task_store.save(assigned_task)

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import functools
 import signal
 import threading
@@ -2146,8 +2147,20 @@ def main() -> None:
         await daemon.start()
         stop = asyncio.Event()
         loop = asyncio.get_event_loop()
+
+        # ``loop.add_signal_handler`` raises NotImplementedError on Windows'
+        # ProactorEventLoop. Guard every install so the daemon starts there too,
+        # matching the SIGUSR1 path in start() (#981). Fall back to
+        # ``signal.signal`` for SIGINT/SIGTERM so Ctrl-C still stops the daemon.
+        def _request_stop() -> None:
+            loop.call_soon_threadsafe(stop.set)
+
         for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, stop.set)
+            try:
+                loop.add_signal_handler(sig, stop.set)
+            except (NotImplementedError, OSError):
+                with contextlib.suppress(ValueError, OSError):
+                    signal.signal(sig, lambda _signum, _frame: _request_stop())
 
         def _sighup_handler() -> None:
             """Reload config in-place on SIGHUP without stopping workers."""
@@ -2158,7 +2171,9 @@ def main() -> None:
 
         sighup = getattr(signal, "SIGHUP", None)
         if sighup is not None:
-            loop.add_signal_handler(sighup, _sighup_handler)
+            # No SIGHUP on Windows — hot-reload-on-signal is simply unavailable.
+            with contextlib.suppress(NotImplementedError, OSError):
+                loop.add_signal_handler(sighup, _sighup_handler)
         await stop.wait()
         await daemon.stop()
 

--- a/maxwell_daemon/daemon/runner.py
+++ b/maxwell_daemon/daemon/runner.py
@@ -378,6 +378,32 @@ class Daemon:
             except asyncio.QueueFull:
                 await self._queue.put(deferred_item)
 
+    def _classify_dependencies_locked(self, task: Task) -> tuple[str | None, bool]:
+        """Classify a task's dependencies. Caller must hold ``_tasks_lock``.
+
+        Returns ``(failed_dependency, deps_pending)``:
+
+        * ``failed_dependency`` is the id of the first dependency that terminally
+          failed/cancelled — such a dependency will never reach COMPLETED, so
+          deferring on it would strand the dependent in a tight re-enqueue loop
+          forever (#978c). When set, the dependent should be failed.
+        * ``deps_pending`` is True when at least one dependency is still
+          unfinished (missing or not yet COMPLETED) and none has failed — the
+          dependent should be deferred.
+        """
+        for dep in task.depends_on:
+            dep_task = self._tasks.get(dep)
+            if dep_task is not None and dep_task.status in (
+                TaskStatus.FAILED,
+                TaskStatus.CANCELLED,
+            ):
+                return dep, False
+        deps_pending = any(
+            self._tasks.get(dep) is None or self._tasks[dep].status is not TaskStatus.COMPLETED
+            for dep in task.depends_on
+        )
+        return None, deps_pending
+
     async def _claim_next_queued_task(self) -> tuple[bool, Task | None]:
         deferred: list[tuple[int, Task]] = []
         claimed: Task | None = None
@@ -396,27 +422,55 @@ class Daemon:
             task = payload
 
             kind_cap = self._kind_cap_for(task)
+            failed_dependency: str | None = None
             with self._tasks_lock:
                 if task.status is not TaskStatus.QUEUED:
                     continue
                 if task.depends_on:
-                    unfinished = [
-                        dep
-                        for dep in task.depends_on
-                        if self._tasks.get(dep) is None
-                        or self._tasks[dep].status is not TaskStatus.COMPLETED
-                    ]
-                    if unfinished:
+                    failed_dependency, deps_pending = self._classify_dependencies_locked(task)
+                    if failed_dependency is None and deps_pending:
                         deferred.append((priority, task))
                         continue
-                if kind_cap is not None:
-                    kind_key = self._task_kind_key(task)
-                    if self._count_running_tasks_locked(kind_key=kind_key) >= kind_cap:
-                        deferred.append((priority, task))
-                        continue
-                task.status = TaskStatus.RUNNING
-                task.started_at = datetime.now(timezone.utc)
-                claimed = task
+                if failed_dependency is not None:
+                    dep_message = f"dependency {failed_dependency} failed"
+                    task.status = TaskStatus.FAILED
+                    task.error = dep_message
+                    task.finished_at = datetime.now(timezone.utc)
+                else:
+                    if kind_cap is not None:
+                        kind_key = self._task_kind_key(task)
+                        if self._count_running_tasks_locked(kind_key=kind_key) >= kind_cap:
+                            deferred.append((priority, task))
+                            continue
+                    task.status = TaskStatus.RUNNING
+                    task.started_at = datetime.now(timezone.utc)
+                    claimed = task
+            # Persist + publish the dependency-failure outside the lock (no store
+            # I/O or awaiting while holding the threading lock), then keep draining
+            # the queue rather than claiming the failed task for execution.
+            if failed_dependency is not None:
+                try:
+                    self._task_store.save(task)
+                except Exception:
+                    log.exception(
+                        "task store write failed while failing dependent task=%s", task.id
+                    )
+                await self._events.publish(
+                    Event(
+                        kind=EventKind.TASK_FAILED,
+                        payload=attach_observability(
+                            {
+                                "id": task.id,
+                                "error": task.error,
+                                "reason": "dependency_failed",
+                            },
+                            task_id=task.id,
+                            backend=task.backend,
+                            model=task.model,
+                        ),
+                    )
+                )
+                continue
             # ``put_nowait``/await of deferred entries must happen OUTSIDE the
             # threading lock (no awaiting while holding it).
             if claimed is not None:
@@ -581,6 +635,11 @@ class Daemon:
                 await close_method()
 
         await self._mcp_manager.stop()
+
+        # Release the long-lived per-machine fleet clients' connection pools
+        # (#978b) so a coordinator shutdown leaves no leaked httpx sockets.
+        if self._fleet_coordinator is not None:
+            await self._fleet_coordinator.aclose()
 
         # Release the single-instance lock so a clean restart can re-acquire it.
         self._instance_lock.release()
@@ -1151,19 +1210,23 @@ class Daemon:
             priority=priority,
             dry_run=dry_run,
         )
-        # See note in submit(): queue mutation must stay loop-affine once the
-        # daemon has started.
+        # See note in submit(): the queue mutation waits for the daemon loop to
+        # run a callback, so it must happen *outside* _tasks_lock — holding the
+        # lock across the cross-thread enqueue can deadlock the loop. Persist and
+        # track under the lock, enqueue after release, and roll back on
+        # saturation so a rejected task leaves no orphaned store/registry row.
         with self._tasks_lock:
             if task_id is not None:
                 self._reject_duplicate_task_id(task.id)
             self._task_store.save(task)
             self._tasks[task.id] = task
-            try:
-                self._enqueue_task_entry(task.priority, task)
-            except QueueSaturationError:
+        try:
+            self._enqueue_task_entry(task.priority, task)
+        except QueueSaturationError:
+            with self._tasks_lock:
                 del self._tasks[task.id]
-                self._task_store.delete(task.id)
-                raise
+            self._task_store.delete(task.id)
+            raise
         try:
             loop = asyncio.get_running_loop()
             bg = loop.create_task(

--- a/maxwell_daemon/daemon/workspace_hooks.py
+++ b/maxwell_daemon/daemon/workspace_hooks.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -47,9 +48,12 @@ async def _run_hook(
     name: str, command: str, cwd: Path, timeout_seconds: float
 ) -> tuple[int, bytes, bytes]:
     """Run a single hook command safely without shell=True."""
-    # We split using shlex to avoid shell=True while still allowing basic args
+    # We split using shlex to avoid shell=True while still allowing basic args.
+    # POSIX-mode shlex treats backslash as an escape, which mangles Windows
+    # paths (``C:\tools\x.exe`` -> ``C:toolsx.exe``); split in non-POSIX mode on
+    # Windows so native paths survive intact (#981).
     try:
-        args = shlex.split(command)
+        args = shlex.split(command, posix=(os.name != "nt"))
     except ValueError as e:
         raise WorkspaceHookError(f"Failed to parse hook command {command!r}: {e}") from e
 

--- a/maxwell_daemon/daemon/workspace_hooks.py
+++ b/maxwell_daemon/daemon/workspace_hooks.py
@@ -72,6 +72,9 @@ async def _run_hook(
 
             with contextlib.suppress(OSError):
                 proc.kill()
+            # Reap the killed child so it does not linger as a zombie (#980).
+            with contextlib.suppress(Exception):
+                await proc.wait()
             raise WorkspaceHookError(f"Hook {name!r} timed out after {timeout_seconds}s") from None
     except Exception as e:
         if isinstance(e, WorkspaceHookError):

--- a/maxwell_daemon/fleet/client.py
+++ b/maxwell_daemon/fleet/client.py
@@ -90,10 +90,30 @@ class RemoteDaemonClient:
         timeout_seconds: float = 30.0,
         tls_verify: bool = True,
     ) -> None:
-        self._http = http_client if http_client is not None else _make_default_http(timeout_seconds)
+        # Forward tls_verify into the default httpx adapter so ``tls_verify=False``
+        # actually reaches httpx; otherwise self-signed fleets fail every probe
+        # and surface only as "machine unhealthy" (#978b). We own the transport
+        # only when we created it — an injected client is the caller's to close.
+        self._owns_http = http_client is None
+        self._http = (
+            http_client
+            if http_client is not None
+            else _make_default_http(timeout_seconds, tls_verify=tls_verify)
+        )
         self._auth_token = auth_token
         self._timeout_seconds = timeout_seconds
         self._tls_verify = tls_verify
+
+    async def aclose(self) -> None:
+        """Release the underlying connection pool if we created it.
+
+        Injected transports are owned by the caller and left untouched so the
+        coordinator can hold one long-lived client per remote (#978b).
+        """
+        if self._owns_http:
+            aclose = getattr(self._http, "aclose", None)
+            if aclose is not None:
+                await aclose()
 
     # ------------------------------------------------------------------ headers
     def _headers(self) -> dict[str, str]:

--- a/maxwell_daemon/gh/client.py
+++ b/maxwell_daemon/gh/client.py
@@ -12,6 +12,7 @@ and other bounded inputs get regex-validated before they reach the subprocess.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import re
 import time
@@ -66,12 +67,15 @@ RateLimitError = GitHubRateLimitError
 
 # Exit codes emitted by `gh` when GitHub returns 403 or 429 (rate-limited).
 _RATE_LIMIT_EXIT_CODES: frozenset[int] = frozenset({4})  # gh uses rc=4 for HTTP 4xx
-# Error substrings that indicate a rate-limit response rather than an auth error.
+# Error substrings that indicate a genuine rate-limit response rather than an
+# auth error. A bare "403" is deliberately NOT here: GitHub returns 403 for both
+# secondary rate limits AND auth/SSO failures, so treating every 403 as a rate
+# limit masks bad-token errors as ~15s+ sleeps (#980). A 403 only counts as a
+# rate limit when one of these co-occurring markers is present.
 _RATE_LIMIT_MARKERS: tuple[str, ...] = (
     "rate limit",
     "rate_limit",
     "429",
-    "403",
     "secondary rate",
     "abuse detection",
 )
@@ -120,14 +124,34 @@ class PullRequest:
         return cls(number=int(match.group(1)), url=url, draft=draft)
 
 
-async def _default_runner(*argv: str, cwd: str | None = None) -> tuple[int, bytes, bytes]:
+# Wall-clock ceiling for a single `gh` invocation. A hung `gh` (e.g. a stuck
+# network call or auth prompt) must not pin a worker until the stall reconciler
+# fires and feeds the retry loop (#980).
+_GH_SUBPROCESS_TIMEOUT_SECONDS = 120.0
+
+
+async def _default_runner(
+    *argv: str,
+    cwd: str | None = None,
+    timeout: float = _GH_SUBPROCESS_TIMEOUT_SECONDS,
+) -> tuple[int, bytes, bytes]:
     proc = await asyncio.create_subprocess_exec(
         *argv,
         cwd=cwd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, stderr = await proc.communicate()
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        # Kill and reap so the hung child does not linger as a zombie, then
+        # surface a clear error instead of blocking the worker indefinitely.
+        proc.kill()
+        with contextlib.suppress(Exception):
+            await proc.wait()
+        raise GhCliError(
+            f"gh {' '.join(argv)} timed out after {timeout:.0f}s and was killed"
+        ) from None
     return proc.returncode or 0, stdout, stderr
 
 

--- a/tests/unit/test_daemon_robustness.py
+++ b/tests/unit/test_daemon_robustness.py
@@ -1,0 +1,309 @@
+"""Daemon robustness cluster regressions (#978).
+
+Four related defects on the runner / fleet-coordinator paths:
+
+* (a) ``submit_issue`` must not enqueue while holding ``_tasks_lock``.
+* (b) the coordinator must reuse one client per remote and forward ``tls_verify``.
+* (c) a dependent of a terminally-failed dependency must FAIL, not churn forever.
+* (d) a cancel racing the dispatch await window must not be overwritten with
+  DISPATCHED.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Awaitable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, TypeVar
+from unittest.mock import MagicMock
+
+from maxwell_daemon.config import MaxwellDaemonConfig
+from maxwell_daemon.daemon import Daemon
+from maxwell_daemon.daemon.fleet_coordinator import FleetCoordinator
+from maxwell_daemon.daemon.task_models import Task, TaskKind, TaskStatus
+from maxwell_daemon.events import EventKind
+
+T = TypeVar("T")
+
+
+def _run(coro: Awaitable[T]) -> T:
+    return asyncio.new_event_loop().run_until_complete(coro)  # type: ignore[arg-type]
+
+
+def _make_daemon(tmp_path: Path, cfg: MaxwellDaemonConfig, suffix: str = "a") -> Daemon:
+    return Daemon(
+        cfg,
+        ledger_path=tmp_path / f"ledger-{suffix}.db",
+        task_store_path=tmp_path / f"tasks-{suffix}.db",
+    )
+
+
+# ── (a) submit_issue enqueues outside _tasks_lock ────────────────────────────
+
+
+class TestSubmitIssueLockDiscipline:
+    def test_enqueue_runs_without_holding_tasks_lock(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        """The enqueue must observe an *unlocked* _tasks_lock (#978a).
+
+        We assert the lock is acquirable from inside the enqueue callback — if
+        submit_issue still held it, ``acquire(blocking=False)`` would fail.
+        """
+        d = _make_daemon(tmp_path, minimal_config)
+        observed: dict[str, bool] = {}
+        original = d._enqueue_task_entry
+
+        def _spy(priority: int, task: Task) -> None:
+            got = d._tasks_lock.acquire(blocking=False)
+            observed["lock_free"] = got
+            if got:
+                d._tasks_lock.release()
+            original(priority, task)
+
+        d._enqueue_task_entry = _spy  # type: ignore[method-assign]
+        task = d.submit_issue(repo="owner/repo", issue_number=1)
+        assert observed["lock_free"] is True
+        assert d._tasks[task.id].status is TaskStatus.QUEUED
+
+    def test_saturation_rolls_back_store_and_registry(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        """A saturated enqueue leaves no orphaned task in the store or registry."""
+        from maxwell_daemon.daemon.runner import QueueSaturationError
+
+        d = _make_daemon(tmp_path, minimal_config)
+
+        def _boom(priority: int, task: Task) -> None:
+            raise QueueSaturationError("queue full")
+
+        d._enqueue_task_entry = _boom  # type: ignore[method-assign]
+        try:
+            d.submit_issue(repo="owner/repo", issue_number=2)
+        except QueueSaturationError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected QueueSaturationError")
+        assert d._tasks == {}
+        assert d._task_store.get("__none__") is None
+
+
+# ── (c) failed dependency fails the dependent ────────────────────────────────
+
+
+class TestFailedDependencyFailsDependent:
+    def test_dependent_of_failed_dep_transitions_to_failed(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        d = _make_daemon(tmp_path, minimal_config)
+
+        dep = Task(id="dep", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.FAILED)
+        dependent = Task(
+            id="child",
+            prompt="p",
+            kind=TaskKind.PROMPT,
+            status=TaskStatus.QUEUED,
+            depends_on=["dep"],
+        )
+        d._tasks[dep.id] = dep
+        d._tasks[dependent.id] = dependent
+        d._task_store.save(dep)
+        d._task_store.save(dependent)
+        d._queue.put_nowait((dependent.priority, dependent))
+
+        events: list[Any] = []
+
+        async def _capture(event: Any) -> None:
+            events.append(event)
+
+        d._events.publish = _capture  # type: ignore[method-assign]
+
+        _stopped, claimed = _run(d._claim_next_queued_task())
+
+        assert claimed is None
+        assert dependent.status is TaskStatus.FAILED
+        assert "dep" in (dependent.error or "")
+        # Persisted failure + a TASK_FAILED event with the dependency reason.
+        assert d._task_store.get("child").status is TaskStatus.FAILED
+        assert any(e.kind is EventKind.TASK_FAILED for e in events)
+
+    def test_completed_dependency_still_allows_claim(
+        self, tmp_path: Path, minimal_config: MaxwellDaemonConfig
+    ) -> None:
+        """A COMPLETED dependency must not be mistaken for a failed one."""
+        d = _make_daemon(tmp_path, minimal_config)
+        dep = Task(id="dep", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.COMPLETED)
+        dependent = Task(
+            id="child",
+            prompt="p",
+            kind=TaskKind.PROMPT,
+            status=TaskStatus.QUEUED,
+            depends_on=["dep"],
+        )
+        d._tasks[dep.id] = dep
+        d._tasks[dependent.id] = dependent
+        d._queue.put_nowait((dependent.priority, dependent))
+
+        _stopped, claimed = _run(d._claim_next_queued_task())
+
+        assert claimed is dependent
+        assert dependent.status is TaskStatus.RUNNING
+
+
+# ── (b)/(d) fleet coordinator: client reuse, tls_verify, cancel race ──────────
+
+
+@dataclass
+class _FakeHTTPResponse:
+    status_code: int
+    _body: dict[str, Any] = field(default_factory=dict)
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+@dataclass
+class _RecordingHTTP:
+    """Records calls; health 200, submit 202. Tracks aclose() for leak checks."""
+
+    submitted: list[dict[str, Any]] = field(default_factory=list)
+    closed: bool = False
+
+    async def get(self, url: str, *, headers: dict[str, str]) -> _FakeHTTPResponse:
+        return _FakeHTTPResponse(status_code=200)
+
+    async def post(
+        self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+    ) -> _FakeHTTPResponse:
+        self.submitted.append({"url": url, "payload": json})
+        return _FakeHTTPResponse(status_code=202)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _make_coordinator(
+    *,
+    tasks: dict[str, Task],
+    machines: list[Any],
+    task_store: Any = None,
+) -> FleetCoordinator:
+    config = SimpleNamespace(
+        fleet_machines=machines,
+        fleet_coordinator_poll_seconds=5,
+        fleet_heartbeat_seconds=30,
+        api_auth_token=None,
+    )
+    return FleetCoordinator(
+        config=config,
+        tasks=tasks,
+        tasks_lock=threading.Lock(),
+        task_store=task_store or MagicMock(),
+        worker_last_seen={},
+        enqueue_task_entry=MagicMock(),
+        running_flag=lambda: False,
+    )
+
+
+class TestCoordinatorClientLifecycle:
+    def test_tls_verify_false_reaches_httpx(self) -> None:
+        """tls_verify on the machine config must reach the default httpx client (#978b)."""
+        from maxwell_daemon.fleet.client import RemoteDaemonClient
+
+        client = RemoteDaemonClient(tls_verify=False)
+        # The default adapter stores the verify flag on its httpx client.
+        assert client._tls_verify is False
+        assert client._owns_http is True
+
+    def test_injected_client_is_not_closed(self) -> None:
+        """aclose() only releases transports the client created itself (#978b)."""
+        from maxwell_daemon.fleet.client import RemoteDaemonClient
+
+        http = _RecordingHTTP()
+        client = RemoteDaemonClient(http_client=http)
+        _run(client.aclose())
+        assert http.closed is False  # caller owns an injected transport
+
+    def test_one_persistent_client_per_machine_reused(self) -> None:
+        """Two ticks must reuse one client per machine, not build a new pool each tick."""
+        task = Task(id="t1", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.QUEUED)
+        machine = SimpleNamespace(
+            name="w1", host="h", port=8080, capacity=1, tags=[], tls=False, tls_verify=False
+        )
+        coordinator = _make_coordinator(tasks={"t1": task}, machines=[machine])
+
+        created: list[Any] = []
+        import maxwell_daemon.fleet.client as fleet_client_mod
+
+        original_cls = fleet_client_mod.RemoteDaemonClient
+
+        class _PatchedClient(original_cls):  # type: ignore[misc,valid-type]
+            def __init__(self, **kw: Any) -> None:
+                super().__init__(http_client=_RecordingHTTP(), **kw)
+                self.aclose_calls = 0
+                created.append(self)
+
+            async def aclose(self) -> None:
+                self.aclose_calls += 1
+                await super().aclose()
+
+        fleet_client_mod.RemoteDaemonClient = _PatchedClient  # type: ignore[misc]
+        try:
+            _run(coordinator._dispatch_tick())
+            # Reset task to QUEUED for a second tick and dispatch again.
+            task.status = TaskStatus.QUEUED
+            task.dispatched_to = None
+            _run(coordinator._dispatch_tick())
+        finally:
+            fleet_client_mod.RemoteDaemonClient = original_cls  # type: ignore[misc]
+
+        # One client built for the single machine, reused across both ticks
+        # rather than a fresh pool per tick (#978b).
+        assert len(created) == 1
+        assert created[0]._tls_verify is False
+        # coordinator.aclose() propagates to every cached per-machine client.
+        _run(coordinator.aclose())
+        assert created[0].aclose_calls == 1
+        assert coordinator._clients == {}
+
+    def test_cancel_during_dispatch_await_is_not_overwritten(self) -> None:
+        """A task cancelled while submit_task awaits stays CANCELLED, not DISPATCHED (#978d)."""
+        task = Task(id="t1", prompt="p", kind=TaskKind.PROMPT, status=TaskStatus.QUEUED)
+        machine = SimpleNamespace(
+            name="w1", host="h", port=8080, capacity=1, tags=[], tls=False, tls_verify=True
+        )
+        tasks = {"t1": task}
+        coordinator = _make_coordinator(tasks=tasks, machines=[machine])
+
+        import maxwell_daemon.fleet.client as fleet_client_mod
+
+        original_cls = fleet_client_mod.RemoteDaemonClient
+
+        class _RacingHTTP(_RecordingHTTP):
+            async def post(
+                self, url: str, *, json: dict[str, Any], headers: dict[str, str]
+            ) -> _FakeHTTPResponse:
+                # Simulate a cancel landing during the dispatch await window.
+                task.status = TaskStatus.CANCELLED
+                return await super().post(url, json=json, headers=headers)
+
+        class _PatchedClient(original_cls):  # type: ignore[misc,valid-type]
+            def __init__(self, **kw: Any) -> None:
+                super().__init__(http_client=_RacingHTTP(), **kw)
+
+        fleet_client_mod.RemoteDaemonClient = _PatchedClient  # type: ignore[misc]
+        try:
+            _run(coordinator._dispatch_tick())
+        finally:
+            fleet_client_mod.RemoteDaemonClient = original_cls  # type: ignore[misc]
+
+        assert task.status is TaskStatus.CANCELLED
+        assert task.dispatched_to is None
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)

--- a/tests/unit/test_fleet_config.py
+++ b/tests/unit/test_fleet_config.py
@@ -219,7 +219,13 @@ class TestLoadFleetManifest:
             """,
         )
         monkeypatch.chdir(empty_cwd)
-        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        # Patch Path.home() rather than $HOME so the home fallback resolves the
+        # same way on every platform (Windows uses USERPROFILE, not HOME) — #981.
+        home_dir = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home_dir))
+        from maxwell_daemon.config import fleet as _fleet_mod
+
+        monkeypatch.setattr(_fleet_mod.Path, "home", classmethod(lambda cls: home_dir))
         monkeypatch.delenv("MAXWELL_FLEET_CONFIG", raising=False)
         manifest = load_fleet_manifest()
         assert manifest.fleet.name == "HOME"

--- a/tests/unit/test_gh_client.py
+++ b/tests/unit/test_gh_client.py
@@ -313,6 +313,76 @@ class TestRateLimitHandling:
         assert GitHubClient._is_rate_limit_error(0, b"rate limit") is False  # rc=0 means success
         assert GitHubClient._is_rate_limit_error(1, b"Repository not found") is False
 
+    def test_bare_403_is_not_a_rate_limit(self) -> None:
+        """A 403 without rate-limit text is an auth error, not a rate limit (#980).
+
+        GitHub returns 403 for both secondary rate limits and auth/SSO failures;
+        only a co-occurring rate-limit marker should classify it as rate-limited.
+        """
+        assert GitHubClient._is_rate_limit_error(1, b"HTTP 403: Bad credentials") is False
+        assert (
+            GitHubClient._is_rate_limit_error(1, b"403 Forbidden: SSO authorization required")
+            is False
+        )
+        # A 403 that *is* a secondary rate limit still classifies correctly.
+        assert (
+            GitHubClient._is_rate_limit_error(1, b"403 You have exceeded a secondary rate limit")
+            is True
+        )
+
+    def test_bare_403_raises_without_sleeping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bare 403 surfaces as GhCliError immediately, with no backoff sleep (#980)."""
+        slept: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+        runner = self._make_runner([(4, b"", b"HTTP 403: Bad credentials")])
+        client = GitHubClient(runner=runner)  # type: ignore[arg-type]
+        with pytest.raises(GhCliError) as exc_info:
+            asyncio.run(client._gh("api", "user"))
+        assert "403" in str(exc_info.value)
+        assert not isinstance(exc_info.value, GitHubRateLimitError)
+        assert slept == []  # no rate-limit backoff for an auth failure
+
+    def test_subprocess_timeout_kills_and_reaps(self) -> None:
+        """_default_runner kills and reaps a hung gh and raises GhCliError (#980)."""
+        from maxwell_daemon.gh import client as gh_client_mod
+
+        killed = {"value": False}
+        waited = {"value": False}
+
+        class _HungProc:
+            returncode = None
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                await asyncio.sleep(10)  # longer than the test timeout
+                return b"", b""
+
+            def kill(self) -> None:
+                killed["value"] = True
+
+            async def wait(self) -> int:
+                waited["value"] = True
+                return -9
+
+        async def fake_create(*args: object, **kwargs: object) -> _HungProc:
+            return _HungProc()
+
+        async def _run() -> None:
+            orig = gh_client_mod.asyncio.create_subprocess_exec
+            gh_client_mod.asyncio.create_subprocess_exec = fake_create  # type: ignore[assignment]
+            try:
+                with pytest.raises(GhCliError, match="timed out"):
+                    await gh_client_mod._default_runner("gh", "api", "user", timeout=0.05)
+            finally:
+                gh_client_mod.asyncio.create_subprocess_exec = orig  # type: ignore[assignment]
+
+        asyncio.run(_run())
+        assert killed["value"] is True
+        assert waited["value"] is True
+
     def test_retries_once_on_rate_limit_with_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Client retries after a rate-limit error and succeeds on the second attempt."""
 

--- a/tests/unit/test_windows_support.py
+++ b/tests/unit/test_windows_support.py
@@ -1,0 +1,160 @@
+"""Cross-platform (Windows) support regressions — #981.
+
+Three breakages that prevented the daemon from running on Windows:
+
+1. ``main()`` installed SIGINT/SIGTERM handlers via ``loop.add_signal_handler``
+   without a ``NotImplementedError`` guard (crashes on Windows' ProactorEventLoop).
+2. ``config/fleet.py`` resolved the home dir via ``os.environ["HOME"]`` (unset on
+   Windows) so ``~/.maxwell-daemon/fleet.yaml`` was silently never found.
+3. ``workspace_hooks._run_hook`` split commands with POSIX-mode shlex, mangling
+   Windows paths like ``C:\\tools\\x.exe``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+from pathlib import Path
+
+import pytest
+
+from maxwell_daemon.config import fleet as fleet_mod
+from maxwell_daemon.daemon import workspace_hooks
+
+# ── (1) main() signal-handler guard ──────────────────────────────────────────
+
+
+class TestSignalHandlerGuard:
+    def test_main_starts_when_add_signal_handler_unsupported(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A loop that raises NotImplementedError (Windows) must not crash main()."""
+        from maxwell_daemon.daemon import runner as runner_mod
+
+        signals_set: list[int] = []
+
+        class _FakeLoop:
+            def add_signal_handler(self, sig: int, cb: object) -> None:
+                raise NotImplementedError("Windows ProactorEventLoop")
+
+            def call_soon_threadsafe(self, cb: object, *a: object) -> None:
+                cb()
+
+        # Drive the daemon lifecycle with stubs so we exercise only the signal
+        # wiring in main()'s _run(), not a real daemon.
+        class _FakeDaemon:
+            _config = type("C", (), {"log_file": None})()
+
+            @classmethod
+            def from_config_path(cls) -> _FakeDaemon:
+                return cls()
+
+            async def start(self) -> None:
+                return None
+
+            async def stop(self) -> None:
+                return None
+
+            def reload_config(self) -> None:
+                return None
+
+        def _fake_signal(sig: int, handler: object) -> None:
+            signals_set.append(sig)
+
+        import maxwell_daemon.logging as logging_mod
+
+        monkeypatch.setattr(runner_mod.Daemon, "from_config_path", _FakeDaemon.from_config_path)
+        monkeypatch.setattr(runner_mod.asyncio, "get_event_loop", lambda: _FakeLoop())
+        monkeypatch.setattr(runner_mod.signal, "signal", _fake_signal)
+        monkeypatch.setattr(logging_mod, "configure_logging", lambda **kw: None)
+
+        # Make stop.wait() return immediately so _run() completes.
+        real_event = asyncio.Event
+
+        class _ImmediateEvent(real_event):  # type: ignore[misc,valid-type]
+            async def wait(self) -> bool:
+                return True
+
+        monkeypatch.setattr(runner_mod.asyncio, "Event", _ImmediateEvent)
+
+        # Should not raise despite add_signal_handler being unsupported.
+        runner_mod.main()
+        # Fallback path registered SIGINT/SIGTERM via signal.signal.
+        assert runner_mod.signal.SIGINT in signals_set
+        assert runner_mod.signal.SIGTERM in signals_set
+
+
+# ── (2) fleet.py home resolution ─────────────────────────────────────────────
+
+
+class TestFleetHomeResolution:
+    def test_home_candidate_uses_path_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The ~/.maxwell-daemon/fleet.yaml candidate is derived from Path.home()."""
+        # HOME unset (as on Windows) must not drop the home candidate.
+        monkeypatch.delenv("HOME", raising=False)
+        monkeypatch.setattr(fleet_mod.Path, "home", classmethod(lambda cls: tmp_path))
+
+        candidates = fleet_mod._candidate_paths()
+
+        expected = tmp_path / fleet_mod._DEFAULT_HOME_SUBPATH
+        assert expected in candidates
+
+    def test_unresolvable_home_is_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A RuntimeError from Path.home() degrades gracefully (no crash)."""
+
+        def _boom(cls: object) -> Path:
+            raise RuntimeError("no home")
+
+        monkeypatch.setattr(fleet_mod.Path, "home", classmethod(_boom))
+        # cwd candidate still present; the ~/.maxwell-daemon/fleet.yaml home
+        # candidate is simply omitted rather than raising.
+        candidates = fleet_mod._candidate_paths()
+        home_subpath = str(fleet_mod._DEFAULT_HOME_SUBPATH)
+        assert all(home_subpath not in str(p) for p in candidates)
+
+
+# ── (3) workspace_hooks Windows path splitting ───────────────────────────────
+
+
+class TestHookCommandSplitting:
+    def test_windows_path_survives_split(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On Windows (os.name == 'nt') a backslash path is not mangled."""
+        monkeypatch.setattr(workspace_hooks.os, "name", "nt")
+        # Mirror the production split to assert the policy directly.
+        args = shlex.split(r"C:\tools\x.exe --flag", posix=(workspace_hooks.os.name != "nt"))
+        assert args[0] == r"C:\tools\x.exe"
+
+    def test_posix_split_still_used_off_windows(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On POSIX, normal quoting semantics are preserved."""
+        monkeypatch.setattr(workspace_hooks.os, "name", "posix")
+        args = shlex.split("echo 'a b'", posix=(workspace_hooks.os.name != "nt"))
+        assert args == ["echo", "a b"]
+
+    def test_run_hook_parses_windows_path_without_error(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """_run_hook on Windows splits a native path into a single argv[0]."""
+        monkeypatch.setattr(workspace_hooks.os, "name", "nt")
+        captured: dict[str, object] = {}
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                return b"", b""
+
+        async def fake_create(*args: object, **kwargs: object) -> _Proc:
+            captured["args"] = args
+            return _Proc()
+
+        monkeypatch.setattr(workspace_hooks.asyncio, "create_subprocess_exec", fake_create)
+
+        async def _run() -> None:
+            await workspace_hooks._run_hook(
+                "win", r"C:\tools\x.exe --flag", tmp_path, timeout_seconds=5
+            )
+
+        asyncio.run(_run())
+        assert captured["args"][0] == r"C:\tools\x.exe"  # type: ignore[index]

--- a/tests/unit/test_workspace_hooks_reap.py
+++ b/tests/unit/test_workspace_hooks_reap.py
@@ -1,0 +1,53 @@
+"""workspace_hooks._run_hook must reap timed-out children (no zombies) — #980."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from maxwell_daemon.daemon import workspace_hooks
+from maxwell_daemon.daemon.workspace_hooks import WorkspaceHookError, _run_hook
+
+
+class _HungProc:
+    """A subprocess that never finishes communicate() until killed."""
+
+    returncode = None
+
+    def __init__(self) -> None:
+        self.killed = False
+        self.waited = False
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        await asyncio.sleep(10)  # exceeds the test's tiny timeout
+        return b"", b""
+
+    def kill(self) -> None:
+        self.killed = True
+
+    async def wait(self) -> int:
+        self.waited = True
+        return -9
+
+
+def test_timed_out_hook_is_killed_and_reaped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proc = _HungProc()
+
+    async def fake_create(*args: object, **kwargs: object) -> _HungProc:
+        return proc
+
+    monkeypatch.setattr(workspace_hooks.asyncio, "create_subprocess_exec", fake_create)
+
+    async def _run() -> None:
+        with pytest.raises(WorkspaceHookError, match="timed out"):
+            await _run_hook("slow", "sleep 100", tmp_path, timeout_seconds=0.05)
+
+    asyncio.run(_run())
+
+    assert proc.killed is True
+    # The killed child must be reaped via proc.wait() so no zombie lingers.
+    assert proc.waited is True


### PR DESCRIPTION
Repairs three Windows-support breakages (#981). The launcher explicitly targets Windows, yet the daemon crashed at startup, silently ignored fleet config, and corrupted hook command paths there.

**Base note:** stacked on `daemon/correctness-stall-queue-singleton-971-972-975` (PR #1012, which now also carries the merged #978/#980 work); GitHub will retarget to `main` once that merges.

1. **Signal handlers** — `runner.py` `main()` installed SIGINT/SIGTERM via `loop.add_signal_handler` with no `NotImplementedError` guard, crashing on Windows' ProactorEventLoop. Each install is now guarded (matching the SIGUSR1 path in `start()`), with a `signal.signal` fallback for SIGINT/SIGTERM so Ctrl-C still stops the daemon; SIGHUP is skipped where unavailable.
2. **Fleet home resolution** — `config/fleet.py` used `os.environ["HOME"]` (unset on Windows), so `~/.maxwell-daemon/fleet.yaml` was never found. Now uses `Path.home()` (USERPROFILE-aware), degrading gracefully if home is unresolvable.
3. **Hook path splitting** — `workspace_hooks._run_hook` used POSIX-mode shlex, mangling `C:\tools\x.exe` into `C:toolsx.exe`. Now splits with `posix=(os.name != "nt")`.

Tests: `test_windows_support.py` covers all three via mocked loop / `os.name` / `Path.home()`. The `test_fleet_config.py` home-fallback test now patches `Path.home()` so it is platform-independent. ruff + ruff format + mypy --strict clean.

Closes #981