### PR TITLE
docs: expand SPEC, de-overpromise executor naming, document .gaai provenance (#990 #991 #992)

### DIFF
--- a/.gaai/core/README.md
+++ b/.gaai/core/README.md
@@ -1,5 +1,27 @@
 # .gaai/ — GAAI Framework (v2.6.3)
 
+## Provenance
+
+> **Vendored from [`Fr-e-d/GAAI-framework`](https://github.com/Fr-e-d/GAAI-framework) @ v2.6.3.**
+> This tree is **not** first-party to Maxwell-Daemon. The files under
+> `.gaai/core/` (install scripts, git hooks such as
+> `pre-push.d/01-block-production.sh`, the skills library, and
+> `specialists.registry.yaml`) originate upstream and are kept in sync by the
+> post-commit hook described below.
+
+**Why it is committed rather than installed at setup time:** the post-commit sync
+hook treats this checkout as the *editing surface* for upstream `core/` — local
+edits are auto-contributed back to the OSS framework. Removing it from version
+control would break that bidirectional sync. Because the tree is executable
+framework code (including git hooks), treat upstream bumps as dependency
+updates: review the diff when `v2.6.x` changes, and pin the version recorded in
+this header.
+
+**Update path:** bump the upstream version, let the sync hook reconcile
+`core/`, then update the version in this README's title and the Provenance note.
+Maxwell-Daemon's own integration point is `maxwell_daemon/gaai/loader.py`
+(first-party), which only *reads* metadata from this tree.
+
 ## Directory Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cross-repo contract is in
 | --- | --- |
 | [`Repository_Management`](https://github.com/D-sorganization/Repository_Management) | Fleet orchestrator (CI workflows, skills, templates, agent coordination). |
 | [`runner-dashboard`](https://github.com/D-sorganization/runner-dashboard) | Operator console; its **Maxwell tab** consumes the daemon's HTTP API. |
-| `Maxwell-Daemon` (here) | Strategist / Implementer / Crucible pipeline + ExecutionSandbox + BYO-CLI runtime. |
+| `Maxwell-Daemon` (here) | Strategist / Implementer / Crucible pipeline + policy-gated executor (no isolation — see Execution) + BYO-CLI runtime. |
 
 The daemon's **`/ui/`** is the daemon's own console (for direct/local use).
 The fleet-wide operator console is `runner-dashboard`. The daemon never
@@ -27,7 +27,7 @@ traffic is into the daemon.
 - **Canonical Dashboard Launcher**: Use `Launch-Maxwell.bat`, `Launch-Maxwell.command`, or `Launch-Maxwell.sh` from a source checkout to bootstrap Maxwell-Daemon and open the shipped `/ui/` dashboard on Windows, macOS, or Linux.
 - **The Cognitive Pipeline**: A state-machine orchestrated team:
   - 🧠 **Strategist**: Formulates architectural plans using the compressed `RepoSchematic`.
-  - 💻 **Implementer**: Generates code and runs validation through a policy-gated `ExecutionSandbox`.
+  - 💻 **Implementer**: Generates code and runs validation through a policy-gated executor (argv allowlist + workspace/env/timeout policy; **not** an isolation sandbox — see [Execution](#execution-model) below).
   - ⚔️ **Maxwell Crucible**: Adversarial QA role that violently tests the Implementer's code against the Strategist's contract.
 - **BYO-CLI**: Don't pay double API taxes. Maxwell-Daemon can hook into your existing local CLI subscriptions (like `jules-cli`, `claude-code`, or `ollama`).
 
@@ -106,7 +106,7 @@ Operator-facing guides live under [`docs/operations/`](docs/operations/):
 ## 🧠 Architectural Highlights
 - **RepoSchematic**: Generates highly compressed file-and-symbol trees, saving massive token budgets compared to dumping raw files.
 - **Memory Annealer**: Automatically compresses verbose agent logs into dense `architectural_state.md` files, responsibly purging raw logs to save disk space.
-- **Execution Sandbox**: Validation commands run through an argv allowlist, workspace-root check, environment filter, timeout, output redaction, and artifact capture. The current executor uses host subprocesses; it does not provide Docker, filesystem, network, process, or resource isolation. See [Security](docs/operations/security.md) before running untrusted generated code.
+- <a id="execution-model"></a>**Execution model — policy-gated executor, NOT an isolation sandbox**: Validation commands run through an argv allowlist, workspace-root check, environment filter, timeout, output redaction, and artifact capture. **The executor runs host subprocesses and provides no Docker, filesystem, network, process, or resource isolation** — these policy gates reduce blast radius but are not a security boundary. Do not rely on it to contain untrusted generated code; see [Security](docs/operations/security.md) first. Real isolation is tracked as a roadmap item ([#1015](https://github.com/D-sorganization/Maxwell_Daemon/issues/1015)).
 
 ---
 **License**: MIT © D-sorganization

--- a/SPEC.md
+++ b/SPEC.md
@@ -19,3 +19,116 @@
   lane; py3.10 and py3.11 run compatibility tests without coverage overhead. The test matrix
   targets the desktop Linux runner pool for predictable throughput.
 
+## HTTP API
+
+The daemon exposes a versioned HTTP surface under `/api/v1/*` (with a small set
+of stable legacy aliases such as `/api/status`, `/api/v2/status`, `/api/reload`,
+and `/api/webhooks/trigger`). The router families are:
+
+| Family | Prefix(es) | Purpose |
+| --- | --- | --- |
+| auth | `/api/v1/auth/*` | Token mint / refresh / revoke / introspect (`me`). |
+| tasks | `/api/v1/tasks`, `/api/tasks` (legacy) | Submit, list, fetch, cancel tasks. |
+| issues | `/api/v1/issues/*`, `/api/v1/templates/*`, `/api/v1/memory/*` | Issue dispatch (plan/implement, A/B, batch), prompt templates, memory assemble/record. |
+| backends | `/api/v1/backends/*`, `/api/v1/cost` | Backend inventory + cost ledger summary. |
+| actions | `/api/v1/actions/*`, `/api/v1/artifacts/*` | Proposed action approval/rejection + artifact retrieval. |
+| work-items | `/api/v1/work-items/*`, `/api/v1/task-graphs/*` | Work-item and task-graph inspection. |
+| control-plane | `/api/v1/control-plane/gauntlet*` | Gauntlet run inventory + retry/cancel/waive. |
+| fleet | `/api/v1/fleet/*`, `/api/v1/workers/*`, `/api/v1/heartbeat` | Fleet topology, worker registration, heartbeats. |
+| ssh | `/api/v1/ssh/*` | SSH key store + session pool management. |
+| audit | `/api/v1/audit/*`, `/api/reload`, `/api/v1/admin/prune` | Audit-log read/verify, config hot-reload, retention prune. |
+| webhooks | `/api/v1/webhooks/*`, `/api/webhooks/trigger`, `/api/v1/evals/*` | Webhook config/trigger + eval runs. |
+| events | `/api/v1/events` (WebSocket) | Live event stream (see Event Bus below). |
+
+The authoritative, drift-checked route inventory lives in
+[`docs/reference/openapi.md`](docs/reference/openapi.md) and is enforced against
+the live FastAPI schema by `tests/unit/test_openapi_docs_sync.py` (a route added
+or removed without updating that doc fails CI). This SPEC intentionally lists
+route *families* rather than every path, so the single source of truth for exact
+paths and shapes remains the generated OpenAPI schema + that sync test.
+
+**Stability rule:** the `/api/v1/*` and legacy status endpoints are append-only.
+New endpoints and new response fields may be added freely; existing request or
+response shapes must not change without bumping the major version advertised at
+`GET /api/version`.
+
+## Event Bus
+
+Subscribers consume a typed event stream over `/api/v1/events` (WebSocket) and an
+in-process `EventBus`. Each event is `{kind, ts, payload}`; `payload` may carry a
+normalized `observability` context (task/work-item/action/artifact ids plus
+cost/timing). The `kind` values are defined by `EventKind`
+(`maxwell_daemon/events.py`):
+
+- Task lifecycle: `task_queued`, `task_started`, `task_completed`, `task_failed`.
+- Action lifecycle: `action_proposed`, `action_approved`, `action_rejected`,
+  `action_running`, `action_applied`, `action_failed`, `action_skipped`.
+- Diagnostics: `test_output`, `budget_alert`, `backend_health`.
+
+Event kinds are append-only: add new kinds rather than repurposing existing ones.
+
+## Task State Machine
+
+Tasks are persisted in the SQLite `TaskStore` (`TaskKind` ∈ {`prompt`, `issue`})
+and move through `TaskStatus` (`maxwell_daemon/daemon/task_models.py`):
+
+```
+            ┌──────────── dispatched ──────────┐   (fleet coordinator only)
+            │                                   │
+queued ─────┼──────────────► running ──────────┼──► completed
+            │                   │               │
+            │                   ├──► failed ◄────┘   (stall / error / dep failure)
+            └──► cancelled ◄────┘                    (operator cancel)
+```
+
+- `queued` → `running`: a worker claims the task once dependencies are COMPLETED
+  and the per-kind concurrency cap (`agent.concurrency_by_kind`) allows it.
+- `queued`/`running` → `dispatched`: the coordinator role assigns the task to a
+  remote worker (re-checked under lock so a racing cancel is never overwritten).
+- `running` → `completed` | `failed`: normal terminal outcomes. A task that
+  exceeds `agent.stall_timeout_seconds` is failed and retried under the bounded
+  `RetryPolicy`; a task whose dependency terminally failed is failed with reason
+  `dependency_failed` rather than re-queued forever.
+- any non-terminal → `cancelled`: operator cancellation. Terminal states
+  (`completed`, `failed`, `cancelled`) are final.
+
+## Fleet Manifest (`fleet.yaml`)
+
+`fleet.yaml` is a separate file from `maxwell-daemon.yaml`; it lists the repos the
+fleet manages plus shared defaults. Resolution order: explicit path →
+`MAXWELL_FLEET_CONFIG` → `./fleet.yaml` → `~/.maxwell-daemon/fleet.yaml`. Schema
+(`maxwell_daemon/config/fleet.py`):
+
+```yaml
+version: 1                       # must be 1
+fleet:                           # FleetDefaults — applied to every repo unless overridden
+  name: My Fleet                 # required
+  auto_promote_staging: false
+  discovery_interval_seconds: 300 # >= 10
+  default_slots: 2                # 1..32
+  default_budget_per_story: 0.50  # >= 0
+  default_pr_target_branch: staging
+  default_pr_fallback_to_default: true
+  default_watch_labels: []
+repos:                           # FleetRepoEntry list; unset fields inherit defaults
+  - name: Repo1                  # required
+    org: my-org                  # required
+    slots: 4                     # optional, 1..32
+    budget_per_story: 0.25       # optional, >= 0
+    pr_target_branch: main       # optional
+    pr_fallback_to_default: false
+    watch_labels: [maxwell:ready]
+    enabled: true                # per-repo, not inheritable
+```
+
+Duplicate repo names and `version != 1` are rejected at load time. See
+[`docs/architecture/fleet-architecture.md`](docs/architecture/fleet-architecture.md)
+for the dispatch/coordinator design.
+
+## Related Documentation
+
+- [`docs/architecture/overview.md`](docs/architecture/overview.md) — system overview.
+- [`docs/reference/openapi.md`](docs/reference/openapi.md) — drift-checked route inventory.
+- [`docs/architecture/fleet-architecture.md`](docs/architecture/fleet-architecture.md) — fleet topology + remote dispatch.
+- [`docs/operations/observability.md`](docs/operations/observability.md) — metrics, logging, event consumption.
+- [`docs/operations/security.md`](docs/operations/security.md) — execution policy + isolation caveats.


### PR DESCRIPTION
Documentation tranche: SPEC expansion, executor naming honesty, and .gaai provenance.

### #990 — SPEC.md was a 21-line stub
Expanded SPEC.md to cover the parts CLAUDE.md promises:
- **HTTP API** — the `/api/v1/*` route *families*, cross-linked to the drift-checked `docs/reference/openapi.md` inventory (enforced by `tests/unit/test_openapi_docs_sync.py`) so the exact-path source of truth stays the generated OpenAPI schema rather than a hand-maintained list that rots.
- **Event Bus** — the `EventKind` values consumed over `/api/v1/events`.
- **Task State Machine** — `TaskStatus` transitions including `dispatched`, dependency-failure, and bounded stall-retry.
- **Fleet Manifest** — the `fleet.yaml` (`FleetManifest`) schema + resolution order.
- A **Related Documentation** cross-link section.

### #991 — "ExecutionSandbox" overpromised isolation
- Renamed user-facing copy to **policy-gated executor**.
- Promoted the **no-isolation caveat** into the Execution section header (no "sandbox" wording without an adjacent caveat).
- Linked a dedicated isolation roadmap issue **#1015** (split from #991).

### #992 — .gaai/ vendored framework had no provenance statement
- Added a **Provenance** section to `.gaai/core/README.md`: vendored-from `Fr-e-d/GAAI-framework@v2.6.3`, why it is committed (bidirectional sync surface), the update path, and that `maxwell_daemon/gaai/loader.py` is the first-party integration point.

Docs sync tests (`test_openapi_docs_sync.py`, `test_docs_site_contract.py`) pass.

Refs #990
Closes #991
Refs #992
